### PR TITLE
PR: Added add_document and parsing code for bills

### DIFF
--- a/openstates/pr/bills.py
+++ b/openstates/pr/bills.py
@@ -72,7 +72,15 @@ class PRBillScraper(BillScraper):
 
                 date = datetime.datetime.strptime(tds[0].text_content(),
                                                   "%m/%d/%Y")
+                
                 action = tds[1].text_content().strip()
+                #get url of action
+                action_document =  tds[1].xpath('a[text()=\''+ action+'\']/@href')
+                #check it has a url and is not just text
+                if len(action_document) != 0:
+                    bill.add_document(action,action_document[0]);
+                
+                
                 for pattern, atype in _classifiers:
                     if re.match(pattern, action):
                         break


### PR DESCRIPTION
Added the code to check the action history of bills if it's a link it's gonna add that as a document possible we would check for extension. but so far they only appear to be using .doc and pdf for all links.
