### PR TITLE
sometimes rows contain <br> elements

### DIFF
--- a/openstates/az/legislators.py
+++ b/openstates/az/legislators.py
@@ -49,7 +49,7 @@ class AZLegislatorScraper(LegislatorScraper):
             for row in roster:
                 position = ''
                 vacated = ''
-                name, district, party, email, room, phone, fax = row.getchildren()
+                name, district, party, email, room, phone, fax = row.xpath('td')
 
                 link = name.xpath('string(a/@href)')
                 link = "http://www.azleg.gov" + link


### PR DESCRIPTION
there seems to be a couple of stray <br> elements in the legislator roster rows, now explicitly getting <td> children only
