### PR TITLE
Fix issue #171: Al missing sponsors

### DIFF
--- a/openstates/al/bills.py
+++ b/openstates/al/bills.py
@@ -126,8 +126,6 @@ class ALBillScraper(BillScraper):
                 bill = Bill(session, chamber, bill_id, title, type=bill_type)
                 if subject:
                     bill['subjects'] = [subject]
-                if sponsor:
-                    bill.add_sponsor('primary', sponsor)
 
                 if fnotes == 'ON':
                     bill.add_document('fiscal notes', 'http://alisondb.legislature.state.al.us/acas/ACTIONFiscalNotesFrameMac.asp?OID=%s&LABEL=%s' %
@@ -204,6 +202,10 @@ class ALBillScraper(BillScraper):
 
         with self.urlopen(url) as html:
             doc = lxml.html.fromstring(html)
+            # primary sponsors
+            for cs in doc.xpath('//table[2]/tr/td[1]/table/tr/td/text()'):
+                if cs:
+                    bill.add_sponsor('primary', cs)
             # cosponsors in really weird table layout (likely to break)
             for cs in doc.xpath('//table[2]/tr/td[2]/table/tr/td/text()'):
                 if cs:


### PR DESCRIPTION
Previously it was scraping the primary sponsor from the main bill summary page & the cosponsors from the sponsors page ( ex: http://alisondb.legislature.state.al.us/acas/ACTIONSponsorsResultsMac.asp?OID=75964&LABEL=HR98 )

However bug #171 occurs because on the main bill summary page, the sponsor is blank even though a sponsor exists on the sponsors page.

This commit changes it so that it will get both the primary sponsor and cosponsors from the same sponsors page.
