### PR TITLE
AZ - fix blank urls in bill documents

### DIFF
--- a/openstates/az/bills.py
+++ b/openstates/az/bills.py
@@ -52,7 +52,8 @@ class AZBillScraper(BillScraper):
             for row in rows:
                 tds = row.cssselect('td')
                 fact_sheet = tds[1].text_content().strip()
-                fact_sheet_url = tds[1].xpath('string(font/a/@href)')
+                fact_sheet_url = tds[1].xpath('string(font/a/@href)') or \
+                                 tds[2].xpath('string(font/a/@href)')
                 bill.add_document(fact_sheet, fact_sheet_url, type="summary")
                     
             #agendas


### PR DESCRIPTION
It looks like azleg has changed a couple of things: the "summary/fact sheet" section used to have the url for the document in the same td as the document title. be take a look at the source for http://www.azleg.gov/DocumentsForBill.asp?Bill_Number=SB1001&Session_ID=104
around line 482 and you'll see what I mean.
