### PR TITLE
Remove merge conflict tokens from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,5 @@ testdata/html_data
 billy_local.py
 site/collected_static
 site/openstates
-<<<<<<< HEAD
 +*.sublime*
-=======
 openstates.sqlite3
->>>>>>> 2de8c0acd852e871931029ee08c34fd133d06d87


### PR DESCRIPTION
I just noticed the remnants of a git merge conflict in this file, so I removed them. 

I assume that both "+_.sublime_" and "openstates.sqlite3" are patterns we'd like to leave in.
