### PR TITLE
Remove mailto: from legislator's email address for DATA-97

### DIFF
--- a/openstates/or/legislators.py
+++ b/openstates/or/legislators.py
@@ -96,6 +96,6 @@ class ORLegislatorScraper(LegislatorScraper):
                            name='Capitol Office',
                            address=info['Capitol Address'],
                            phone=phone,
-                           email=info['Email'].attrib['href'])
+                           email=info['Email'].attrib['href'].replace("mailto:",""))
 
             self.save_legislator(leg)


### PR DESCRIPTION
The website for Oregon Legislators has a mailto: prefix on each email address.  This change strips out that prefix when parsing the data to produce the JSON files.  This seems to be related to bug DATA-97; at least why one of the email addresses presented on openstates has two mailto: prefixes.
