### PR TITLE
fix dup email listing for legislators

### DIFF
--- a/site/templates/billy/web/public/legislator.html
+++ b/site/templates/billy/web/public/legislator.html
@@ -137,7 +137,7 @@
                         </li>
                         {% endif %}
                         {% endfor %}
-                        {% if legislator.email not in legislator.office_emails %}
+                        {% if legislator.email and legislator.email not in legislator.office_emails %}
                         <li class="clear">
                             <span class="email smTitle">{% trans "Email" %}: </span>
                             <a href="mailto:{{legislator.email}}">{{legislator.email}}</a>


### PR DESCRIPTION
When the legislator.email field is empty but legislator.office_emails is not empty, this if statement is true and the Email: label is displayed with no email address.

This commit prevents the Email: tag on the Legislator page from being displayed if the legislator.email field is empty.
