### PR TITLE
Various MN bill fixes

### DIFF
--- a/openstates/mn/bills.py
+++ b/openstates/mn/bills.py
@@ -31,7 +31,7 @@ class MNBillScraper(BillScraper):
         ('Third reading Passed', 'bill:passed'),
         ('Bill was passed', 'bill:passed'),
         ('Third reading', 'bill:reading:3'),
-        ("Governor('s action )?Approval", 'governor:signed'),
+        ("Governor('s action)? (A|a)pproval", 'governor:signed'),
         (".+? (V|v)eto", 'governor:vetoed'),
         ("Presented to Governor", 'governor:received'),
         ("Amended", 'amendment:passed'),


### PR DESCRIPTION
This pull request brings in a few fixes to the Minnesota bill scraper:
- Fixes issue where actions like "Referred to Committee X", where "Committee X" was a link was dropping that text.
- Adds reference to companion bills
- Fixes subject mapping (because of inconsistent bill id's)
- Minor fix to categorize governor approvals appropriately
