### PR TITLE
OR: Use HTTP instead of FTP for bill lists

### DIFF
--- a/openstates/or/bills.py
+++ b/openstates/or/bills.py
@@ -97,7 +97,12 @@ class ORBillScraper(BillScraper):
                 bill.add_sponsor(type='cosponsor', name=sponsor.text_content())
 
 
-            bill['title'] = _clean_ws(measure_info['Bill Title'].text_content())
+            title = _clean_ws(measure_info['Bill Title'].text_content())
+            # some bill titles need to be added manually
+            if self.slug == "2013R1" and bid == "HB2010":
+                title = ("Relating to Water Resources Department contested"
+                         "case proceedings.")
+            bill['title'] = title
 
             for version in versions:
                 name = version.text


### PR DESCRIPTION
Current scraper uses FTP to get a list of bills.  This branch switches the scraper to HTTP.  I did this because I'm  behind a restrictive firewall that blocks the FTP connection.  This might not be worth accepting to `sunlightlabs:master`, but here are some potential benefits of merging this and switching to HTTP:
1. I will try to add historical sessions to Oregon; that code will be based on this code.
2. Code is now fewer lines.
3. Current scraper appears to miss HB 2010 from 2013 Regular Session.
