### PR TITLE
MD: Added a bill type that was raising issues in historical sessions

### DIFF
--- a/openstates/md/bills.py
+++ b/openstates/md/bills.py
@@ -389,6 +389,8 @@ class MDBillScraper(Scraper):
             _type = ["bill"]
         elif "J" in bill_id:
             _type = ["joint resolution"]
+        elif "HS" in bill_id:
+            _type = ["resolution"]
         else:
             raise ValueError("unknown bill type " + bill_id)
 


### PR DESCRIPTION
Maryland: I wasn't able to find sponsor name issues, but I did find a bill type that was missing due to raised errors in 2017 session.

Semi-related to issue #3253 