### PR TITLE
NV: Added code to remove leg position from sponsor name.

### DIFF
--- a/openstates/nv/bills.py
+++ b/openstates/nv/bills.py
@@ -161,6 +161,10 @@ class NVBillScraper(Scraper, LXMLMixin):
         person_sponsors = page.xpath('.//a[@class="bio"]/text()')
         for leg in person_sponsors:
             name = leg.strip()
+            # Removes leg position from name
+            # Example: Assemblywoman Alexis Hansen
+            if name.split()[0] in ["Assemblywoman", "Assemblyman", "Senator"]:
+                name = " ".join(name.split()[1:]).strip()
             if name not in seen:
                 seen.append(name)
                 bill.add_sponsorship(


### PR DESCRIPTION
Nevada:

Removed "Assemblyman", "Assemblywoman", "Senator" from sponsor names.

Resolves issue #3262 

I recommend running session 79 after code is merged.