### PR TITLE
or: encode whitespace in urls

### DIFF
--- a/openstates/or/utils.py
+++ b/openstates/or/utils.py
@@ -1,4 +1,5 @@
 import pytz
+import urllib.parse
 
 
 def index_legislators(scraper, session_key):
@@ -19,6 +20,26 @@ def index_legislators(scraper, session_key):
 
 def get_timezone():
     return pytz.timezone("US/Pacific")
+
+
+def url_fix(s):
+    # Adapted from werkzeug.utils (https://bit.ly/3aPRHjv)
+    """Sometimes you get an URL by a user that just isn't a real URL because
+    it contains unsafe characters like ' ' and so on. This function can fix
+    some of the problems in a similar way browsers handle data entered by the
+    user:
+
+    :param s: the string with the URL to fix.
+    """
+    url = urllib.parse.urlparse(s)
+    path = urllib.parse.quote(url.path, safe="/%+$!*'(),")
+    return urllib.parse.urlunsplit((
+        url.scheme,
+        url.netloc,
+        path,
+        url.query,
+        url.fragment
+    ))
 
 
 SESSION_KEYS = {


### PR DESCRIPTION
the Oregon site has URL's with whitespace in them that were not being encoded, causing issues for people following the link outside of a browser.

i included a utility function to fix the URL for this specific issue, based off of a [werkzeug util](https://github.com/pallets/werkzeug/blob/51860032cc780fa4a120b4a3c0457a36bbe91715/src/werkzeug/urls.py#L608). don't know if it makes sense to integrate this more generally.. it seems like this is fairly isolated.

i also made a [PR](https://github.com/opencivicdata/pupa/pull/333) to tighten up validation in pupa to catch this.