### PR TITLE
OH: Fields in add_action are now specifically set to each field

### DIFF
--- a/openstates/oh/bills.py
+++ b/openstates/oh/bills.py
@@ -250,9 +250,11 @@ class OHBillScraper(Scraper):
                             )
                         )
                         date = "{:%Y-%m-%d}".format(date)
-
                         bill.add_action(
-                            action_desc, date, chamber=actor, classification=action_type
+                            description=action_desc,
+                            date=date,
+                            chamber=actor,
+                            classification=action_type,
                         )
 
                 # attach documents gathered earlier


### PR DESCRIPTION
Ohio:

Fields in add_action are now specifically set to each specific field (eg. description, date, chamber, classification).

It looks like it takes care of issue #3291 locally.