### PR TITLE
NC: Voter and Sponsor Name Issues

### DIFF
--- a/openstates/nc/bills.py
+++ b/openstates/nc/bills.py
@@ -281,8 +281,13 @@ class NCBillScraper(Scraper):
                 if votes_names:
                     for name in votes_names:
                         name = name.replace("\r", "")
+                        # Resolves names that have '(Chair)' in them
                         if "(" in name:
                             name = name[: name.find("(")]
+                        # Adds a space to names inbetween initial and last name
+                        # eg: L.Johnson -> L. Johnson
+                        if name[1] == "." and name[2] != " ":
+                            name = name[:2] + " " + name[2:]
                         ve.vote(vote_type, name)
 
             yield ve

--- a/openstates/nc/bills.py
+++ b/openstates/nc/bills.py
@@ -280,6 +280,7 @@ class NCBillScraper(Scraper):
                     vote_type = "Not a vote"
                 if votes_names:
                     for name in votes_names:
+                        name = name.replace("\r", "")
                         ve.vote(vote_type, name)
 
             yield ve

--- a/openstates/nc/bills.py
+++ b/openstates/nc/bills.py
@@ -281,6 +281,8 @@ class NCBillScraper(Scraper):
                 if votes_names:
                     for name in votes_names:
                         name = name.replace("\r", "")
+                        if "(" in name:
+                            name = name[: name.find("(")]
                         ve.vote(vote_type, name)
 
             yield ve


### PR DESCRIPTION
North Carolina:

Voter names had extra "\r" appended to the end of each name.

Rerun sessions: 2017, 2019.