### PR TITLE
VT Duplicate Error

### DIFF
--- a/openstates/vt/bills.py
+++ b/openstates/vt/bills.py
@@ -170,13 +170,15 @@ class VTBillScraper(Scraper, LXMLMixin):
             actions_url = "http://legislature.vermont.gov/bill/loadBillDetailedStatus/{0}/{1}".format(
                 year_slug, internal_bill_id
             )
-            actions_json = self.get(actions_url).text
-            try:
-                actions = json.loads(actions_json)["data"]
+            actions_json = self.get(actions_url)
+
+            # Checks if page actually has json posted
+            if "json" in actions_json.headers.get("Content-Type"):
+                actions = json.loads(actions_json.text)["data"]
+                # Checks to see if any data is actually there
                 if actions == "":
                     continue
-            except Exception as inst:
-                self.warning(inst)
+            else:
                 continue
             bill.add_source(actions_url)
 


### PR DESCRIPTION
Vermont was having duplication issues with votes. An identifier field was added to the vote. It is made up of the status date, the motion text, and the vote url.

An additional check was also added to actions to make sure that a json file was actually loaded and that it has data within it.

Should resolve issue #3298 