### PR TITLE
Patch Docker Compose CA download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ site/openstates
 *.jar
 +*.sublime*
 venv
+.venv/
 .vscode/
 
 # Binary data files and dumps, from Open States and state websites

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.california
-    entrypoint: /opt/openstates/openstates/openstates/ca/download.sh
+    entrypoint: /opt/openstates/openstates/scrapers/ca/download.sh
     environment:
     - MYSQL_HOST=mysql
     volumes:


### PR DESCRIPTION
This PR makes the following small changes:
- Update the California download script path in Docker compose.
- Ignore the `.venv/` directory, allowing a virtualenv to be placed within the project root for local testing.

Let me know if there are any issues. Thanks!