### PR TITLE
AR: Added First Extraordinary Session, 1999 to list of ignored sessions

### DIFF
--- a/scrapers/ar/__init__.py
+++ b/scrapers/ar/__init__.py
@@ -178,6 +178,7 @@ class Arkansas(State):
         "Regular Session, 2001",
         "First Extraordinary Session, 2002",
         "Regular Session, 1999",
+        "First Extraordinary Session, 1999",
         "First Extraordinary Session, 2000",
         "Second Extraordinary Session, 2000",
         "Regular Session, 1997",


### PR DESCRIPTION
AR: Added First Extraordinary Session, 1999 to list of ignored sessions. It was previously not found at https://www.arkleg.state.ar.us/Bills/Search