### PR TITLE
Enable LA events

### DIFF
--- a/scrapers/la/__init__.py
+++ b/scrapers/la/__init__.py
@@ -2,7 +2,7 @@ from utils import url_xpath, State
 from .people import LAPersonScraper
 
 # from .committees import LACommitteeScraper
-# from .events import LAEventScraper
+from .events import LAEventScraper
 from .bills import LABillScraper
 
 
@@ -10,7 +10,7 @@ class Louisiana(State):
     scrapers = {
         "people": LAPersonScraper,
         # "committees": LACommitteeScraper,
-        # 'events': LAEventScraper,
+        'events': LAEventScraper,
         "bills": LABillScraper,
     }
     legislative_sessions = [

--- a/scrapers/la/events.py
+++ b/scrapers/la/events.py
@@ -57,7 +57,7 @@ class LAEventScraper(Scraper, LXMLMixin):
         else:
             all_day = False
             when = datetime.datetime.strptime(
-                "%s %s" % (date, time), "%B %d, %Y %I:%M %p"
+                f"{date} {time}".strip(), "%B %d, %Y %I:%M %p"
             )
 
         # when = self._tz.localize(when)


### PR DESCRIPTION
This PR enables the LA events scraper. It also adds a small patch to trim leading and trailing whitespace characters surrounding the `date` and `time` combined string as it was previously failing on certain events (e.g., times such as `"10 a.m.  "`). Thanks!