### PR TITLE
TX: add some missing info for resolutions, add PDF version links for all bill types

### DIFF
--- a/scrapers/tx/bills.py
+++ b/scrapers/tx/bills.py
@@ -78,13 +78,21 @@ class TXBillScraper(Scraper, LXMLMixin):
 
         session_code = self._format_session(session)
 
-        self.versions = []
-        version_files = self._get_ftp_files(
+        self.html_versions = []
+        html_version_files = self._get_ftp_files(
             self._FTP_ROOT, "bills/{}/billtext/html".format(session_code)
         )
-        for item in version_files:
+        for item in html_version_files:
             bill_id = self._get_bill_id_from_file_path(item)
-            self.versions.append((bill_id, item))
+            self.html_versions.append((bill_id, item))
+
+        self.pdf_versions = []
+        pdf_version_files = self._get_ftp_files(
+            self._FTP_ROOT, "bills/{}/billtext/pdf".format(session_code)
+        )
+        for item in pdf_version_files:
+            bill_id = self._get_bill_id_from_file_path(item)
+            self.pdf_versions.append((bill_id, item))
 
         self.analyses = []
         analysis_files = self._get_ftp_files(
@@ -157,12 +165,20 @@ class TXBillScraper(Scraper, LXMLMixin):
         for subject in root.iterfind("subjects/subject"):
             bill.add_subject(subject.text.strip())
 
-        versions = [x for x in self.versions if x[0] == bill_id]
-        for version in versions:
+        html_versions = [x for x in self.html_versions if x[0] == bill_id]
+        for version in html_versions:
             bill.add_version_link(
                 note=self.NAME_SLUGS[version[1][-5]],
                 url=version[1],
                 media_type="text/html",
+            )
+
+        pdf_versions = [x for x in self.pdf_versions if x[0] == bill_id]
+        for version in pdf_versions:
+            bill.add_version_link(
+                note=self.NAME_SLUGS[version[1][-5]],
+                url=version[1],
+                media_type="application/pdf",
             )
 
         analyses = [x for x in self.analyses if x[0] == bill_id]


### PR DESCRIPTION
i found that TX resolutions did not contain versions, and looks like were also missing fiscal notes, witnesses and analyses.

the issue is that the file paths for resolutions omit the 'R' in the identifier, causing issues when we look up associated files by bill ID. i modified the function used to extract bill id to fix this when we create the lookup mapping.

i also added PDF version links for all documents. let me know if you concerns about that or want me to separate that out to a different PR.