### PR TITLE
OH: Added Concur_622 to Vote Motion Dict

### DIFF
--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -39,6 +39,7 @@ class OHBillScraper(Scraper):
         "pass_301": "Adopted",
         "third_407": "Passed - Amended",
         "concur_602": "Concurred in Senate amendments",
+        "concur_622": "Concurred in Senate amendments",
     }
 
     def scrape(self, session=None, chambers=None):


### PR DESCRIPTION
OH: Added Concur_622 to Vote Motion Dict.

The issue popped up on [HB-168](http://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_133/bills/hb168/votes). Bill info [here](https://www.legislature.ohio.gov/legislation/legislation-status?id=GA133-HB-168).