### PR TITLE
HI: Restore bill versions after site markup change

### DIFF
--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -173,16 +173,15 @@ class HIBillScraper(Scraper):
 
     def parse_bill_versions_table(self, bill, versions):
         versions = versions.xpath("./*")
-
         if versions == []:
             raise Exception("Missing bill versions.")
 
         for version in versions:
-            tds = version.xpath("./*")
+            tds = version.xpath("./td")
             if "No other versions" in tds[0].text_content():
                 return
 
-            if version.xpath("./a"):
+            if version.xpath("./td/a"):
                 http_href = tds[0].xpath("./a")
                 name = http_href[0].text_content().strip()
                 pdf_href = tds[1].xpath("./a")


### PR DESCRIPTION
The scraper has been missing HI versions recently due to a site markup change. This will put them back.