### PR TITLE
OH: Fix error when API data is empty

### DIFF
--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -176,6 +176,13 @@ class OHBillScraper(Scraper):
                     )
                 )
                 data = self.get(bill_api_url).json()
+                if len(data["items"]) is 0:
+                    self.logger.warning(
+                        "Data for bill {bill_id} has empty 'items' array,"
+                        " cannot process related information".format(bill_id=bill_id.lower().replace(" ", ""))
+                    )
+                    yield bill
+                    continue
 
                 # add title if no short title
                 if not bill.title:

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -176,7 +176,7 @@ class OHBillScraper(Scraper):
                     )
                 )
                 data = self.get(bill_api_url).json()
-                if len(data["items"]) is 0:
+                if len(data["items"]) == 0:
                     self.logger.warning(
                         "Data for bill {bill_id} has empty 'items' array,"
                         " cannot process related information".format(bill_id=bill_id.lower().replace(" ", ""))


### PR DESCRIPTION
Trying to fix the most [recent OH error](https://bobsled.openstates.org/run/32301a3420bd4845a5e5696be94c7cc9). Maybe someday this scraper will run to completion lol

[This is the error bill, btw](http://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_133/bills/hb656/)

Attempts to fix #3347