### PR TITLE
OH: Do not error when an unrecognized vote code is encountered

### DIFF
--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -501,6 +501,12 @@ class OHBillScraper(Scraper):
             except KeyError:
                 motion = v["motiontype"]
 
+            if motion in self._vote_motion_dict:
+                motion_text = self._vote_motion_dict[motion]
+            else:
+                self.warning('Unknown vote code {}, please add to _vote_motion_dict'.format(motion))
+                motion_text = v["results"]
+
             # Sometimes Ohio's SOLAR will only return part of the JSON, so in that case skip
             if not motion and isinstance(v["yeas"], str) and isinstance(v["nays"], str):
                 waringText = 'Malformed JSON found for vote ("revno" of {}); skipping'
@@ -519,7 +525,7 @@ class OHBillScraper(Scraper):
                 vote = VoteEvent(
                     chamber=chamber,
                     start_date=date,
-                    motion_text=self._vote_motion_dict[motion],
+                    motion_text=motion_text,
                     result="pass" if passed else "fail",
                     # organization=v["committee"],
                     bill=bill,
@@ -529,7 +535,7 @@ class OHBillScraper(Scraper):
                 vote = VoteEvent(
                     chamber=chamber,
                     start_date=date,
-                    motion_text=self._vote_motion_dict[motion],
+                    motion_text=motion_text,
                     result="pass" if passed else "fail",
                     classification="passed",
                     bill=bill,


### PR DESCRIPTION
instead fallback to 'results' field and warn

Attempted to solve #3363 This is similar to the behavior now implemented for the `action_dict`. As mentioned in the issue, sounds like these codes are not documented anywhere. In the case of the error encountered, it's not clear what relationship the code has to any text that the end user would see when [viewing the vote in the legislature.](https://www.legislature.ohio.gov/legislation/legislation-votes?id=GA133-HB-425). Decided to fall back to the "passed" value on the vote data because that matches the string found on the leg page ("Passed")