### PR TITLE
MN: Add 2020S1 votes URL

### DIFF
--- a/scrapers/mn/vote_events.py
+++ b/scrapers/mn/vote_events.py
@@ -18,6 +18,7 @@ VOTES_URLS = {
     "2017-2018": "http://www.house.leg.state.mn.us/votes/getVotesls90.asp",
     "2017s1": "http://www.house.leg.state.mn.us/votes/getVotesls9020171.asp",
     "2019-2020": "https://www.house.leg.state.mn.us/votes/getVotesls91.asp",
+    "2020s1": "https://www.house.leg.state.mn.us/votes/getVotesls9120201.asp",
 }
 
 


### PR DESCRIPTION
Adds the URL for 2020S1 special session.

However looks like this doesn't fix the current error that is interrupting the scraper run in bobsled: ["openstates.exceptions.ScrapeError: no objects returned from MNVoteScraper scrape"](https://bobsled.openstates.org/run/a49b7fee21124280b48db8a86dcc6f2e)

As a result currently bills in the special session are not being scraped
