### PR TITLE
MN: Fix 404 error with some bills when leading zeros in bill version url

### DIFF
--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -192,10 +192,11 @@ class MNBillScraper(Scraper, LXMLMixin):
             )
 
             # Version link sometimes goes to wrong place, forge it
+            # strip leading zeroes from bill number, because that can cause 404s
             bill["version_url"] = VERSION_URL % (
                 search_session[-4:],
                 search_session[0],
-                bill_details_link.text_content(),
+                re.sub(r"([a-zA-Z]+)(0+)([1-9]+)", r"\1\3", bill_details_link.text_content()),  # SF0120 => SF120
             )
 
             bills.append(bill)


### PR DESCRIPTION
Found 7 bills in the new special session where the URL for fetching versions was returning 404 errors, thus no versions were saved for those bills.

SC1
SR 1 through SR 6

Example 404 URL yielded by scraper vs. correct URL: 
https://www.revisor.mn.gov/bin/getbill.php?session_year=2020&session_number=1&number=SC0001&version=list
https://www.revisor.mn.gov/bin/getbill.php?session_year=2020&session_number=1&number=SC1&version=list

Just strips leading zeroes from the numeric part of the bill identifier