### PR TITLE
NV: Add 81st 2021 session to list to fix scraper runtime error

### DIFF
--- a/scrapers/nv/__init__.py
+++ b/scrapers/nv/__init__.py
@@ -95,6 +95,14 @@ class Nevada(State):
             "end_date": "2017-06-06",
         },
         {
+            "_scraped_name": "81st (2021) Session",
+            "classification": "primary",
+            "identifier": "81",
+            "name": "2021 Regular Session",
+            "start_date": "2021-02-01",
+            "end_date": "2021-06-01",
+        },
+        {
             "_scraped_name": "80th (2019) Session",
             "classification": "primary",
             "identifier": "80",
@@ -146,4 +154,5 @@ class Nevada(State):
         "78": "78th2015",
         "79": "79th2017",
         "80": "80th2019",
+        "81": "81st2021",
     }


### PR DESCRIPTION
This fixes the "missing session" error currently causing the NV scraper to fail.

However, the session is not listed as the ultimate in the array of sessions, because doing so causes a different error. The new session [appears on the NV website](https://www.leg.state.nv.us/Session/81st2021/) but there is a [related URL that scraping depends on](https://www.leg.state.nv.us/Session/81st2021/Reports/TablesAndIndex/2021_81-index.html) that does not work (404). I'm guessing the new session is only partially implemented at this point.

What's the protocol here? On one hand, the scraper is unable to run if the new session isn't added. On the other hand, adding the session as the penultimate may make it harder to remember to change this once again, closer to the actual session (so the new session is ingested).