### PR TITLE
VT: Fix invalid date string for bill action

### DIFF
--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -232,13 +232,19 @@ class VTBillScraper(Scraper, LXMLMixin):
                 # Manual fix for data error in
                 # https://legislature.vermont.gov/bill/status/2020/H.511
                 action["StatusDate"] = action["StatusDate"].replace("/0209", "/2019")
+                action_date = datetime.datetime.strftime(
+                    datetime.datetime.strptime(action["StatusDate"], "%m/%d/%Y"),
+                    "%Y-%m-%d"
+                )
+                # strftime doesn't always pad year value (%Y)  (https://bugs.python.org/issue32195)
+                # and sometimes this state has typos in year part of the StatusDate value
+                # which can cause validation errors, so fix leading zeroes if they are missing
+                if action_date.find("-") < 4:
+                    action_date = ("0" * (4 - action_date.find("-"))) + action_date
 
                 bill.add_action(
                     description=re.sub(HTML_TAGS_RE, "", action["FullStatus"]),
-                    date=datetime.datetime.strftime(
-                        datetime.datetime.strptime(action["StatusDate"], "%m/%d/%Y"),
-                        "%Y-%m-%d",
-                    ),
+                    date=action_date,
                     chamber=actor,
                     classification=action_type,
                 )

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -235,7 +235,7 @@ class VTBillScraper(Scraper, LXMLMixin):
                 # https://legislature.vermont.gov/bill/status/2020/H.942
                 if bill_id == 'H 942' and session == "2019-2020":
                     action["StatusDate"] = action["StatusDate"].replace("/0200", "/2020")
-                    
+
                 action_date = datetime.datetime.strftime(
                     datetime.datetime.strptime(action["StatusDate"], "%m/%d/%Y"),
                     "%Y-%m-%d"


### PR DESCRIPTION
VT scraper failed the last two days on a date string that failed validation. Looks like VT has typos in the dates of actions once in a while. Tried to fix here a little more generally than the previous fix (finding/replacing a specific typo string). Seems better to have a small number of stupid dates on bill actions (the year 200) rather than a scraper that totally stops if one action on one bill doesn't validate.

Interestingly `strftime` formats dates differently on different platforms! so `%Y` doesn't necessarily give you 4 digits back. This might point to a need for a more general error-correction method across scrapers.