### PR TITLE
CT: widen bill version regex

### DIFF
--- a/scrapers/ct/bills.py
+++ b/scrapers/ct/bills.py
@@ -132,7 +132,7 @@ class CTBillScraper(Scraper):
             bill.add_document_link(link.text.strip(), link.attrib["href"])
 
         for link in page.xpath(
-            "//a[contains(@href, '/pdf/') and contains(@href, '/TOB/')]"
+            "//a[(contains(@href, '/pdf/') or contains(@href, '/PDF/')) and contains(@href, '/TOB/')]"
         ):
             bill.add_version_link(
                 link.text.strip(), link.attrib["href"], media_type="application/pdf"


### PR DESCRIPTION
We were missing some bill versions due to the regex casing, such as on https://www.cga.ct.gov/asp/cgabillstatus/cgabillstatus.asp?selBillType=Bill&bill_num=HB-6001