### PR TITLE
NY: return properly on bills without titles

### DIFF
--- a/scrapers/ny/bills.py
+++ b/scrapers/ny/bills.py
@@ -234,6 +234,9 @@ class NYBillScraper(Scraper):
     def _scrape_bill(self, session, bill_data):
         details = self._parse_bill_details(bill_data)
 
+        if details is None:
+            return
+
         (
             senate_url,
             assembly_url,


### PR DESCRIPTION
Resolves current NY scraper issue.