### PR TITLE
Issue 100: bounce out of versions if node is empty

### DIFF
--- a/scrapers/tx/bills.py
+++ b/scrapers/tx/bills.py
@@ -134,6 +134,9 @@ class TXBillScraper(Scraper, LXMLMixin):
             bill.add_subject(subject.text.strip())
 
         for version in root.iterfind("billtext/docTypes/bill/versions"):
+            if not version:
+                continue
+            
             note = version.find("version/versionDescription").text
             html_url = version.find("version/WebHTMLURL").text
             bill.add_version_link(


### PR DESCRIPTION
Fix for https://github.com/openstates/issues/issues/100. The versions node was empty in the xml causing the scraper to fail when trying to parse the non-existant versionDescription child node. Updated to bounce out if the versions node is empty.