### PR TITLE
Fix `bill_list_url` query string in NV bill scrape

### DIFF
--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -89,8 +89,11 @@ class NVBillScraper(Scraper, LXMLMixin):
         }
 
         for doc_type in doc_types[chamber]:
-            bill_list_url = f"https://www.leg.state.nv.us/App/NELIS/REL/{session_slug}/HomeBill/BillsTab?Filters."
-            "SearchText=&Filters.SelectedBillTypes={doc_type}&Filters.DisplayTitles=false&Filters.PageSize=2147483647"
+            bill_list_url = (
+                f"https://www.leg.state.nv.us/App/NELIS/REL/{session_slug}/HomeBill/BillsTab?"
+                f"Filters.SearchText=&Filters.SelectedBillTypes={doc_type}&Filters.DisplayTitles=false&"
+                f"Filters.PageSize=2147483647"
+            )
             try:
                 listing_page = lxml.html.fromstring(self.get(bill_list_url).text)
                 listing_page.make_links_absolute("https://www.leg.state.nv.us")


### PR DESCRIPTION
Fixes openstates/issues#103 

## Issue & Investigation

Recent NV bill are duplicated.

I think the `bill_list_url` is intended to be a multi-line string, but it's effectively truncated due to missing multi-line string syntax.
This likely led to multiple passes of querying the same bill and resulted in certain NV bills being duplicated.

## Fix

Use parenthesis to ensure multiple lines of the url's query string
are accounted for.  Use f-string for the entirety of the multi-line string for consistency.
Note: as mentioned in https://github.com/openstates/issues/issues/103#issuecomment-672020483, some manual bill removal may be needed to fix preexisting data.