### PR TITLE
MA: add optional page_limit to allow a limited-latest bill scrape

### DIFF
--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -54,9 +54,13 @@ class MABillScraper(Scraper):
     # os-update ma bills --scrape sort=latest
     # bill_no can be set to a specific bill (no spaces) to scrape only one
     # os-update ma bills --scrape bill_no=H2
-    def scrape(self, chamber=None, session=None, bill_no=None, sort=None):
+    # page_limit can be set to stop scraping after a certain number of pages (for each chamber)
+    def scrape(self, chamber=None, session=None, bill_no=None, sort=None, page_limit=None):
         if not session:
             session = self.latest_session()
+
+        if page_limit:
+            page_limit = int(page_limit)
 
         if bill_no:
             single_bill_chamber = False
@@ -69,12 +73,12 @@ class MABillScraper(Scraper):
             return
 
         if not chamber:
-            yield from self.scrape_chamber("lower", session, sort)
-            yield from self.scrape_chamber("upper", session, sort)
+            yield from self.scrape_chamber("lower", session, sort, page_limit)
+            yield from self.scrape_chamber("upper", session, sort, page_limit)
         else:
-            yield from self.scrape_chamber(chamber, session)
+            yield from self.scrape_chamber(chamber, session, sort, page_limit)
 
-    def scrape_chamber(self, chamber, session, sort=None):
+    def scrape_chamber(self, chamber, session, sort=None, page_limit=None):
         # for the chamber of the action
 
         # Pull the search page to get the filters
@@ -83,8 +87,12 @@ class MABillScraper(Scraper):
         self.session_filters = self.get_refiners(page, "lawsgeneralcourt")
         self.chamber_filters = self.get_refiners(page, "lawsbranchname")
 
-        lastPage = self.get_max_pages(session, chamber)
-        for pageNumber in range(1, lastPage + 1):
+        if page_limit:
+            last_page = page_limit
+        else:
+            last_page = self.get_max_pages(session, chamber)
+
+        for pageNumber in range(1, last_page + 1):
             bills = self.list_bills(session, chamber, pageNumber, sort)
             for bill in bills:
                 bill = self.format_bill_number(bill).replace(" ", "")

--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -55,7 +55,9 @@ class MABillScraper(Scraper):
     # bill_no can be set to a specific bill (no spaces) to scrape only one
     # os-update ma bills --scrape bill_no=H2
     # page_limit can be set to stop scraping after a certain number of pages (for each chamber)
-    def scrape(self, chamber=None, session=None, bill_no=None, sort=None, page_limit=None):
+    def scrape(
+        self, chamber=None, session=None, bill_no=None, sort=None, page_limit=None
+    ):
         if not session:
             session = self.latest_session()
 
@@ -345,8 +347,10 @@ class MABillScraper(Scraper):
                 cached_vote.set_count("yes", y)
                 cached_vote.set_count("no", n)
 
-                housevote_pdf = "https://malegislature.gov/Journal/House/{}/{}/RollCalls".format(
-                    bill.legislative_session, action_year
+                housevote_pdf = (
+                    "https://malegislature.gov/Journal/House/{}/{}/RollCalls".format(
+                        bill.legislative_session, action_year
+                    )
                 )
                 self.scrape_house_vote(cached_vote, housevote_pdf, n_supplement)
                 cached_vote.add_source(housevote_pdf)


### PR DESCRIPTION
Hoping to provide a workaround/mitigation for https://github.com/openstates/issues/issues/107

My goals are:

- have a smaller daily task that would be *very likely* to complete and yield *most* bill data updates (ensure some data is updated frequently)
- could keep the existing full run (maybe less frequently) to *hopefully* yield *all* bill data updates

So in addition to merging this code, y'all would need to add an MA-scrape-lite job that did something like:

```
docker-compose run --rm scrape ma bills sort=latest page_limit=20 --scrape
```

## other options I considered

- I can imagine a structure wherein bill scrape yields bills and jobs. In MA, there are several related entities that need to be scraped in association with each bill. Instead of making these additional scrape requests as part of the bill-scrape procedure, the MA bill scraper would instead yield jobs. Each job would represent the context necessary to perform the additional, bill-related scrape/transform. Another worker task slowly picks up these jobs from a queue or database table and processes them atomically, yielding updates to the existing bills that cause add the related entities (actions, sponsors, votes). This would introduce some significant infrastructure changes, I imagine. 
-  Apply bill-related scrapes only if it looks like a Bill has been updated since (last update). Use some proxy available on the bill page (perhaps actions text) to decide whether it's worth performing the related scrapes or not. Looking at the MA pages, I'm guessing this method would not be reliable enough.