### PR TITLE
Fix DE scraper error - openstates/issues#135

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -97,6 +97,9 @@ class DEBillScraper(Scraper, LXMLMixin):
             if " w/ " in bill_id:
                 self.info("Found amended bill `{}`".format(bill_id))
                 bill_id, amendment = bill_id.split(" w/ ")
+            if " -" in bill_id:
+                self.info("Found amended bill `{}`".format(bill_id))
+                bill_id, amendment = bill_id.split(" -")
             # A bill can _both_ be amended and be substituted
             if " for " in bill_id:
                 self.info("Found substitute to use instead: `{}`".format(bill_id))


### PR DESCRIPTION
openstates/issues#135

Fixes the new style used by DE legislative site for indicating amendments as (H/S)B### -(H/S)A, saw this id style in a number of new bills for both the house and senate