### PR TITLE
Catch FTP error in VA load_members

### DIFF
--- a/scrapers/va/csv_bills.py
+++ b/scrapers/va/csv_bills.py
@@ -3,6 +3,7 @@ import csv
 import re
 import pytz
 import datetime
+import scrapelib
 from openstates.scrape import Scraper, Bill, VoteEvent
 from collections import defaultdict
 
@@ -57,8 +58,11 @@ class VaCSVBillScraper(Scraper):
 
     # Load members of legislative
     def load_members(self):
-        resp = self.get(self._url_base + "Members.csv").text
-
+        try:
+            resp = self.get(self._url_base + "Members.csv").text
+        except scrapelib.FTPError:
+            self.warning(self._url_base + "Members.csv connection failed.")
+            return False
         reader = csv.reader(resp.splitlines(), delimiter=",")
         # ['MBR_HOU', 'MBR_MBRNO', 'MBR_NAME']
         for row in reader:


### PR DESCRIPTION
FTP flakiness was causing the error below and leading to semi-frequent failed [VA scraper runs](https://bobsled.openstates.org/task/VA-scrape). This PR just catches that error so the scraper can continue.

`scrapelib.FTPError: error while retrieving ftp://**SCRAPERS/VIRGINIA_FTP_USER**:**SCRAPERS/VIRGINIA_FTP_PASSWORD**@legis.virginia.gov/fromdlas/csv202/Members.csv
`