### PR TITLE
DE: added 2020-2022 session to ignored session list for now

### DIFF
--- a/scrapers/de/__init__.py
+++ b/scrapers/de/__init__.py
@@ -91,8 +91,17 @@ class Delaware(State):
             "start_date": "2019-01-08",
             "end_date": "2020-05-06",
         },
+        # {
+        #     "_scraped_name": "2020 - 2022 (GA 151)",
+        #     "identifier": "151",
+        #     "name": "151st General Assembly (2020-2022)",
+        #     "start_date": "2021-01-12",
+        #     "end_date": "2022-05-06",
+        # },
     ]
-    ignored_scraped_sessions = []
+    ignored_scraped_sessions = [
+        "2020 - 2022 (GA 151)"
+    ]
 
     def get_session_list(self):
         url = "https://legis.delaware.gov/"


### PR DESCRIPTION
DE website now shows the 2020-2022 session. I can't tell if DE is still in special session or if it ended a week ago. If it's totally closed, then the scraper probably doesn't need to be fixed by merging this.