### PR TITLE
TX: Fix session id for 2021 related bills

### DIFF
--- a/scrapers/tx/bills.py
+++ b/scrapers/tx/bills.py
@@ -301,7 +301,7 @@ class TXBillScraper(Scraper, LXMLMixin):
             query = urlparse.parse_qs(parsed.query)
             bill.add_related_bill(
                 identifier=query["Bill"][0],
-                legislative_session=query["LegSess"][0],
+                legislative_session=query["LegSess"][0].replace("R",''),
                 relation_type="companion",
             )
 

--- a/scrapers/tx/bills.py
+++ b/scrapers/tx/bills.py
@@ -301,7 +301,7 @@ class TXBillScraper(Scraper, LXMLMixin):
             query = urlparse.parse_qs(parsed.query)
             bill.add_related_bill(
                 identifier=query["Bill"][0],
-                legislative_session=query["LegSess"][0].replace("R",''),
+                legislative_session=query["LegSess"][0].replace("R", ""),
                 relation_type="companion",
             )
 


### PR DESCRIPTION
Scraper was returning 87R on related bills instead of 87.