### PR TITLE
ME: Add 130th session which starts Dec 2

### DIFF
--- a/scrapers/me/__init__.py
+++ b/scrapers/me/__init__.py
@@ -80,7 +80,7 @@ class Maine(State):
         {
             "_scraped_name": "130th Legislature",
             "identifier": "130",
-            "name": "130th Legislature (2020-2021)",
+            "name": "130th Legislature (2021-2022)",
             "start_date": "2020-12-02",
             "end_date": "2021-06-16",
         },

--- a/scrapers/me/__init__.py
+++ b/scrapers/me/__init__.py
@@ -77,6 +77,13 @@ class Maine(State):
             "start_date": "2018-12-05",
             "end_date": "2019-06-09",
         },
+        {
+            "_scraped_name": "130th Legislature",
+            "identifier": "130",
+            "name": "130th Legislature (2020-2021)",
+            "start_date": "2020-12-02",
+            "end_date": "2021-06-16",
+        },
     ]
     ignored_scraped_sessions = ["2001-2002"]
 

--- a/scrapers/me/bills.py
+++ b/scrapers/me/bills.py
@@ -11,7 +11,7 @@ from openstates.scrape import Scraper, Bill, VoteEvent
 
 from .actions import Categorizer
 
-BLACKLISTED_BILL_IDS = {"128": ("SP 601", "SP 602"), "129": ()}
+BLACKLISTED_BILL_IDS = {"128": ("SP 601", "SP 602"), "129": (), "130": ()}
 
 
 class MEBillScraper(Scraper):

--- a/scrapers/me/bills.py
+++ b/scrapers/me/bills.py
@@ -77,7 +77,7 @@ class MEBillScraper(Scraper):
                 )
                 bill_id = bill.text[:2] + " " + bill.text[2:]
 
-                if bill_id in BLACKLISTED_BILL_IDS[session]:
+                if session in BLACKLISTED_BILL_IDS and bill_id in BLACKLISTED_BILL_IDS[session]:
                     continue
 
                 # avoid duplicates


### PR DESCRIPTION
Appears that no bills are available yet in session 130, so impossible to verify this is working. However, the bill advanced search interface does not seem to have changed. It does now list session 130:

http://www.mainelegislature.org/LawMakerWeb/advancedsearch.asp