### PR TITLE
TX: Disable vote scraping so we can ingest prefiled bills

### DIFF
--- a/scrapers/tx/__init__.py
+++ b/scrapers/tx/__init__.py
@@ -2,7 +2,7 @@ from utils import url_xpath, State
 from .bills import TXBillScraper
 from .events import TXEventScraper
 from .people import TXPersonScraper
-from .votes import TXVoteScraper
+# from .votes import TXVoteScraper
 
 # from .committees import TXCommitteeScraper
 

--- a/scrapers/tx/__init__.py
+++ b/scrapers/tx/__init__.py
@@ -13,7 +13,7 @@ class Texas(State):
         # 'committees': TXCommitteeScraper,
         "bills": TXBillScraper,
         # Re-enable vote scraper when adding next regular session
-        "votes": TXVoteScraper,
+        # "votes": TXVoteScraper,
         "events": TXEventScraper,
     }
     legislative_sessions = [


### PR DESCRIPTION
will need to re-enable in Jan, when (presumably) votes will begin to be available.

Fixes https://github.com/openstates/issues/issues/164