### PR TITLE
NM: Fix special session 2 bill version URLs

### DIFF
--- a/scrapers/nm/bills.py
+++ b/scrapers/nm/bills.py
@@ -12,8 +12,11 @@ from openstates.scrape import Scraper, Bill
 
 
 def session_slug(session):
-    session_type = "Special" if session.endswith("S") else "Regular"
-    return "{}%20{}".format(session[2:4], session_type)
+    session_type = "Special" if 's' in session.lower() else "Regular"
+    check_for_special_session_number = re.search(r'\d{2}S(\d)', session)
+    if check_for_special_session_number is None:
+        return "{}%20{}".format(session[2:4], session_type)
+    return "{}%20{}{}".format(session[2:4], session_type, check_for_special_session_number.group(1))
 
 
 class NMBillScraper(Scraper):


### PR DESCRIPTION
session_slug method did not expect there to be a second special session

Currently, all NM 2020S2 bill version URLs are wrong - they link to 2020 regular session bills.