### PR TITLE
WV: Skip 2021 and 2029 sessions for now

### DIFF
--- a/scrapers/wv/__init__.py
+++ b/scrapers/wv/__init__.py
@@ -140,9 +140,19 @@ class WestVirginia(State):
             "start_date": "2020-01-08",
             "end_date": "2020-03-07",
         },
+        # TODO: Re-enable when site starts posting
+        # {
+        #     "_scraped_name": "2021",
+        #     "classification": "primary",
+        #     "identifier": "2021",
+        #     "name": "2020 Regular Session",
+        #     "start_date": "2020-01-13",
+        #     "end_date": "2020-04-10",
+        # },
     ]
     ignored_scraped_sessions = [
-        "2020",
+        "2029",
+        "2021",
         "2010",
         "2009",
         "2008",


### PR DESCRIPTION
... and add 2021 metadata for when they start posting.