### PR TITLE
OK: skip author not found

### DIFF
--- a/scrapers/ok/bills.py
+++ b/scrapers/ok/bills.py
@@ -120,6 +120,8 @@ class OKBillScraper(Scraper):
 
         for link in page.xpath("//a[contains(@id, 'Auth')]"):
             name = link.xpath("string()").strip()
+            if 'author not found' in name.lower():
+                continue
 
             if ":" in name:
                 raise Exception(name)


### PR DESCRIPTION
OK was adding 'author not found' as a sponsor if we happened to catch a bill before they finished updating a bill.