### PR TITLE
MN: enable 2021-2022 session scraping

### DIFF
--- a/scrapers/mn/__init__.py
+++ b/scrapers/mn/__init__.py
@@ -199,18 +199,17 @@ class Minnesota(State):
             # Just a guess. TODO: set after end of special
             "end_date": "2020-12-13",
         },
-        #         {
-        #             "_scraped_name": "92nd Legislature, 2021-2022",
-        #             "classification": "primary",
-        #             "identifier": "2021-2022",
-        #             "name": "2021-2022 Regular Session",
-        #             "start_date": "2021-01-16",
-        #             # Just a guess. TODO: set after schedule is posted
-        #             "end_date": "2021-06-01",
-        #         },
+        {
+            "_scraped_name": "92nd Legislature, 2021-2022",
+            "classification": "primary",
+            "identifier": "2021-2022",
+            "name": "2021-2022 Regular Session",
+            "start_date": "2021-01-05",
+            # Just a guess. TODO: set after schedule is posted
+            "end_date": "2021-06-01",
+        },
     ]
     ignored_scraped_sessions = [
-        "92nd Legislature, 2021-2022",
         "85th Legislature, 2007-2008",
         "85th Legislature, 2007 1st Special Session",
         "84th Legislature, 2005-2006",


### PR DESCRIPTION
MN 2021 bills are now appearing at https://www.revisor.mn.gov/bills/reference.php

running `docker-compose run --rm scrape mn bills --fastmode --scrape` worked locally for me with this change