### PR TITLE
SD: Fix action parsing bugs

### DIFF
--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -133,7 +133,7 @@ class SDBillScraper(Scraper, LXMLMixin):
         actor = chamber
 
         for action in actions:
-            if action["StatusText"] is None and action["Description"]:  # properties can be null
+            if action["StatusText"] is None and action["Description"] is None:  # properties can be null
                 action_text = ""
             elif action["StatusText"] is None:  # fallback to Description if available, and no StatusText
                 action_text = action["Description"]

--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -133,8 +133,10 @@ class SDBillScraper(Scraper, LXMLMixin):
         actor = chamber
 
         for action in actions:
-            if action["StatusText"] is None:  # StatusText can be null
+            if action["StatusText"] is None and action["Description"]:  # properties can be null
                 action_text = ""
+            elif action["StatusText"] is None:  # fallback to Description if available, and no StatusText
+                action_text = action["Description"]
             else:
                 action_text = action["StatusText"]
             # This value is for synthesize full action text like site, will be added to

--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -133,7 +133,10 @@ class SDBillScraper(Scraper, LXMLMixin):
         actor = chamber
 
         for action in actions:
-            action_text = action["StatusText"]
+            if action["StatusText"] is None:  # StatusText can be null
+                action_text = ""
+            else:
+                action_text = action["StatusText"]
             # This value is for synthesize full action text like site, will be added to
             # tried to replicate site logic found in Bill.html on source site
             full_action = [action_text]
@@ -153,7 +156,7 @@ class SDBillScraper(Scraper, LXMLMixin):
                 if action["Result"] == "P":
                     second = "passage"
                 # D is "deferred"
-                elif action["Result"] == "F" or action["Result"] == "D":
+                elif action["Result"] == "F" or action["Result"] == "D" or action["Result"] == "N":
                     second = "failure"
                 else:
                     self.error("Unknown vote code: {}".format(action["Result"]))


### PR DESCRIPTION
Treating action.Result value of 'N' as failure, previously [was not accounted for](https://bobsled.openstates.org/run/eaf8412a90a049cb92473b9a21323456). In that case, the SD website is [ambiguous](https://sdlegislature.gov/Session/Bill/22026) however the [linked committee log pdf seems to indicate failure with the text "died for lack of second"](https://mylrc.sdlegislature.gov/api/Documents/212399.pdf#page=1). 

Also turning Null into an empty string which popped up [here](https://sdlegislature.gov/api/Bills/ActionLog/22168)