### PR TITLE
GA: Skip member whose profile crashes the api

### DIFF
--- a/scrapers/ga/bills.py
+++ b/scrapers/ga/bills.py
@@ -253,7 +253,9 @@ class GABillScraper(Scraper):
                 if "Sponsors" in instrument and instrument["Sponsors"]:
                     sponsors += instrument["Sponsors"]["Sponsorship"]
 
-            sponsors = [(x["Type"], self.get_member(x["MemberId"])) for x in sponsors]
+            # 4976 is Sheila McNeill
+            # whose profile is currently causing 500 errors 
+            sponsors = [(x["Type"], self.get_member(x["MemberId"])) for x in sponsors if x["MemberId"] != 4976]
 
             for typ, sponsor in sponsors:
                 name = "{First} {Last}".format(**dict(sponsor["Name"]))


### PR DESCRIPTION
https://www.legis.ga.gov/members/senate

Sheila McNeill currently causes the API to blow up, and even her member profile page on the site is broken. 

Skip over her for now when she's a (co)sponsor, and hopefully we can fix it later.