### PR TITLE
MS: Skip bills with no titles

### DIFF
--- a/scrapers/ms/bills.py
+++ b/scrapers/ms/bills.py
@@ -99,6 +99,10 @@ class MSBillScraper(Scraper):
             title = details_root.xpath("string(//SHORTTITLE)")
             longtitle = details_root.xpath("string(//LONGTITLE)")
 
+            if title == '':
+                self.warning(f"No title yet for {bill_id}, skipping")
+                return
+
             bill = Bill(
                 bill_id,
                 legislative_session=session,


### PR DESCRIPTION
MS published http://billstatus.ls.state.ms.us/2021/pdf/history/SN/SN0049.xml which has no title (short or long) yet, so skip it for now so the scraper doesn't bomb out.