### PR TITLE
SD: Fix error on vote document properties

### DIFF
--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -277,10 +277,10 @@ class SDBillScraper(Scraper, LXMLMixin):
         motion = page["actionLog"]["StatusText"]
         if motion:
             # If we can't detect a motion, skip this vote
-            yes_count = page["x"]["Yeas"]
-            no_count = page["x"]["Nays"]
-            excused_count = page["x"]["Excused"]
-            absent_count = page["x"]["Absent"]
+            yes_count = page["Yeas"]
+            no_count = page["Nays"]
+            excused_count = page["Excused"]
+            absent_count = page["Absent"]
 
             passed = yes_count > no_count
 


### PR DESCRIPTION
Looks like SD changed the Votes document in the API to no longer place certain properties behind an 'x' property
