### PR TITLE
AZ: fix empty subject name bug

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -128,7 +128,8 @@ class AZBillScraper(Scraper):
         )
         page = json.loads(self.get(subjects_url).content.decode("utf-8"))
         for subject in page:
-            bill.add_subject(subject["Name"])
+            if "Name" in subject and len(subject["Name"]) > 0:
+                bill.add_subject(subject["Name"])
 
     def scrape_actions(self, bill, page, self_chamber):
         """


### PR DESCRIPTION
Caused failed run due to validation error on empty subject string: https://bobsled.openstates.org/run/c88602285b36493499b8a9f3bbaa0a41