### PR TITLE
GA: Fix source bill URL to match GA current website

### DIFF
--- a/scrapers/ga/bills.py
+++ b/scrapers/ga/bills.py
@@ -25,7 +25,7 @@ from .util import get_client, get_url, backoff, SESSION_SITE_IDS
 
 
 member_cache = {}
-SOURCE_URL = "http://www.legis.ga.gov/Legislation/en-US/display/{session}/{bid}"
+SOURCE_URL = "https://www.legis.ga.gov/legislation/{bid}"
 
 vote_name_pattern = re.compile(r"(.*), (\d+(?:ST|ND|RD|TH))", re.IGNORECASE)
 


### PR DESCRIPTION
Source URLs of the old format `http://www.legis.ga.gov/Legislation/en-US/display/{session}/{internalBillId}` are now going to 404 error pages. Fix to match the URL format used by the new GA site.