### PR TITLE
HI: Disable scraping HRs for now

### DIFF
--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -372,4 +372,11 @@ class HIBillScraper(Scraper):
             if chamber == "upper":
                 bill_types.append("gm")
             for typ in bill_types:
+                # TODO: Remove this - disable scraping HR's for now 
+                # due to broken list page. Restore when
+                # https://www.capitol.hawaii.gov/report.aspx?type=HR&year=2021
+                # is loading again
+                if chamber == "lower" and typ == "r":
+                    self.warning("Skipping HR due to a state website bug.")
+                    continue
                 yield from self.scrape_type(chamber, session, typ)


### PR DESCRIPTION
https://www.capitol.hawaii.gov/report.aspx?type=HR&year=2021

is failing on the state side due to an error, so skip HRs.

https://github.com/openstates/issues/issues/357