### PR TITLE
MI: fix some actor classification errors

### DIFF
--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -137,7 +137,15 @@ class MIBillScraper(Scraper):
                     )
                     continue
             # instead of trusting upper/lower case, use journal for actor
-            actor = "upper" if "SJ" in journal else "lower"
+            # Journal entries are often posted with 'Expected Soon' as the cite,
+            # then changed to the journal entry.
+            if "SJ" in journal.upper():
+                actor = "upper"
+            elif "HJ" in journal.upper():
+                actor = "lower"
+            else:
+                actor = "legislature"
+
             classification = categorize_action(action)
             bill.add_action(action, date, chamber=actor, classification=classification)
 

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -144,9 +144,9 @@ class MIBillScraper(Scraper):
                 actor = "upper"
             elif "HJ" in journal.upper():
                 actor = "lower"
-            elif journal.split()[0].islower():
+            elif action.split()[0].islower():
                 actor = "lower"
-            elif journal.split()[0].isupper():
+            elif action.split()[0].isupper():
                 actor = "upper"
             else:
                 actor = "legislature"

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -136,13 +136,18 @@ class MIBillScraper(Scraper):
                         "{} has action with invalid date. Skipping Action".format(bill_id)
                     )
                     continue
-            # instead of trusting upper/lower case, use journal for actor
+            # use journal for actor
+            # then fall back to upper/lower case
             # Journal entries are often posted with 'Expected Soon' as the cite,
             # then changed to the journal entry.
             if "SJ" in journal.upper():
                 actor = "upper"
             elif "HJ" in journal.upper():
                 actor = "lower"
+            elif journal.split()[0].islower():
+                actor = "lower"
+            elif journal.split()[0].isupper():
+                actor = "upper"
             else:
                 actor = "legislature"
 


### PR DESCRIPTION
In MI, we're classifying the action chambers (actors) via a reference to the chamber's journal page, which appears next to the action on the website. (HJ vs SJ).

Lately, they've been posting actions with 'Expected Soon' as the journal cite, then adding it later. This causes us to incorrectly classify the action due to an overly loose else clause.

**edit** looks like we can fall back to using the casing, because house lowercases and senate uppercases. Yuck.

@jamesturk until they post the reference, we may not know the chamber. Will it cause the OS ingestion any problems if we save those actors as 'legislature', then it gets updated on subsequent scrapes?

Here's a screenshot of what i'm talking about, to help clarify:

https://www.dropbox.com/s/itzv7ru8s3ku3kr/Screenshot_2021-03-24-17%3A06.png?dl=0