### PR TITLE
AR: fixed vote event scraper after website update removed screenreader class

### DIFF
--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -270,16 +270,14 @@ class ARBillScraper(Scraper):
             )
 
         for link in page.xpath(
-            "//table[@class=\"screenreader\"]//a[contains(@href, '/Bills/Votes?id=')]"
+            '//div[@role="grid"]/..//div[@class="col-md-2"]//a[contains(@href, \'/Bills/Votes?id=\')]'
         ):
-            date = link.xpath(
-                "normalize-space(substring-after(string(../../td[2]), 'Date:'))"
-            )
+            date = link.xpath("normalize-space(string(../../div[2]))")
             date = TIMEZONE.localize(
                 datetime.datetime.strptime(date, "%m/%d/%Y %I:%M:%S %p")
             )
 
-            motion = link.xpath("string(../../td[3])")
+            motion = link.xpath("string(../../div[3])")
             yield from self.scrape_vote(bill, date, motion, link.attrib["href"])
 
     def scrape_vote(self, bill, date, motion, url):

--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -270,7 +270,7 @@ class ARBillScraper(Scraper):
             )
 
         for link in page.xpath(
-            '//div[@role="grid"]/..//div[@class="col-md-2"]//a[contains(@href, \'/Bills/Votes?id=\')]'
+            "//div[@role=\"grid\"]/../..//a[contains(@href, '/Bills/Votes?id=')]"
         ):
             date = link.xpath("normalize-space(string(../../div[2]))")
             date = TIMEZONE.localize(


### PR DESCRIPTION
Seems a website update removed the screenreader class for most bill pages, which the page scraper relies on for searching for vote links. I changed the xpaths to point to the divs in the grid role instead.