### PR TITLE
AR: Scrape date and time of day for bill actions

### DIFF
--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -110,7 +110,7 @@ class ARBillScraper(Scraper):
             date = TIMEZONE.localize(
                 datetime.datetime.strptime(row[5], "%Y-%m-%d %H:%M:%S.%f")
             )
-            date = "{:%Y-%m-%d}".format(date)
+
             action = row[6]
 
             action_type = []


### PR DESCRIPTION
I noticed that bill actions were only scraping dates, making it difficult to chronologically sort actions that occurred the same day. This change allows time of day to be scraped as well. 