### PR TITLE
AR: fix address scraper

### DIFF
--- a/scrapers/ar/people.py
+++ b/scrapers/ar/people.py
@@ -116,8 +116,10 @@ class ARLegislatorScraper(Scraper):
         except AttributeError:
             email = None
         address = root.xpath('string(//div[@id="bodyContent"]/div[1]/div[1]/p/b)')
-        address_parts = address.split(", ")
-        address = '%s; %s, AR, %s' % (address_parts[0], address_parts[1], address_parts[2])
+        address_list = list(address)
+        address_list.insert(len(address_list) - 5, "AR ")
+        address_list = "".join(address_list)
+        address = address_list
 
         person.add_contact_detail(type="address", value=address, note="District Office")
         if phone is not None:


### PR DESCRIPTION
Previous address scraper change based on splitting the string on commas was causing some addresses with more than two commas to break. This change will allow "AR" to be inserted near the end of the string before the zipcode. 