### PR TITLE
FL: Properly replace jr/sr in bill sponsors

### DIFF
--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -57,6 +57,7 @@ class BillList(HtmlListPage):
     dependencies = {"subjects": SubjectPDF}
 
     def get_source_from_input(self):
+        # to test scrape an individual bill, add &billNumber=1351
         return (
             f"https://flsenate.gov/Session/Bills/{self.input['session']}?chamber=both"
         )
@@ -109,6 +110,7 @@ class BillList(HtmlListPage):
         bill.subject = list(self.subjects[subj_bill_id])
 
         sponsor = re.sub(r"^(?:Rep|Sen)\.\s", "", sponsor)
+        sponsor = re.sub(r",\s+(Jr|Sr)\.", r" \1.", sponsor)
         for sp in sponsor.split(", "):
             sp = sp.strip()
             bill.add_sponsorship(sp, "primary", "person", True)

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -113,7 +113,8 @@ class BillList(HtmlListPage):
         sponsor = re.sub(r",\s+(Jr|Sr)\.", r" \1.", sponsor)
         for sp in sponsor.split(", "):
             sp = sp.strip()
-            bill.add_sponsorship(sp, "primary", "person", True)
+            sp_type = "organization" if "committee" in sp.lower() else "person"
+            bill.add_sponsorship(sp, "primary", sp_type, True)
 
         return BillDetail(bill)
 


### PR DESCRIPTION
FL was improperly parsing suffixed names into multiple sponsors, ie "Aloupis, Jr." became two sponsors -- "Aloupis",  and "Jr." 

Catch "Sr." and "Jr." and add them to the name normally.

https://openstates.org/fl/bills/2021/HB1351/