### PR TITLE
IL: Switch URLs to HTTPS

### DIFF
--- a/scrapers/il/__init__.py
+++ b/scrapers/il/__init__.py
@@ -165,4 +165,4 @@ class Illinois(State):
     ]
 
     def get_session_list(self):
-        return url_xpath("http://ilga.gov/PreviousGA.asp", "//option/text()")
+        return url_xpath("https://ilga.gov/PreviousGA.asp", "//option/text()")

--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -227,7 +227,7 @@ COMMITTEE_CORRECTIONS = {
 }
 
 DUPE_VOTES = {
-    "http://ilga.gov/legislation/votehistory/100/house/committeevotes/"
+    "https://ilga.gov/legislation/votehistory/100/house/committeevotes/"
     "10000HB2457_16401.pdf"
 }
 
@@ -267,7 +267,7 @@ def chamber_slug(chamber):
 
 
 class IlBillScraper(Scraper):
-    LEGISLATION_URL = "http://ilga.gov/legislation/grplist.asp"
+    LEGISLATION_URL = "https://ilga.gov/legislation/grplist.asp"
     localize = pytz.timezone("America/Chicago").localize
 
     def get_bill_urls(self, chamber, session, doc_type):
@@ -322,7 +322,7 @@ class IlBillScraper(Scraper):
 
     def scrape_archive_bills(self, session):
         session_abr = session[0:2]
-        url = f"http://www.ilga.gov/legislation/legisnet{session_abr}/{session_abr}gatoc.html"
+        url = f"https://www.ilga.gov/legislation/legisnet{session_abr}/{session_abr}gatoc.html"
         html = self.get(url).text
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(url)
@@ -569,7 +569,7 @@ class IlBillScraper(Scraper):
         pdf_only = False
 
         # Some bills don't have html versions, even though they link to them
-        # http://ilga.gov/legislation/fulltext.asp?DocName=&
+        # https://ilga.gov/legislation/fulltext.asp?DocName=&
         # SessionId=108&GA=101&DocTypeId=HB&DocNum=66&GAID=15&LegID=113888&SpecSess=&Session=
         # These bills only show one PDF link at a time, so we're safe in the loop below
         if "HTML full text does not exist for this appropriations document" in html:

--- a/scrapers/il/events.py
+++ b/scrapers/il/events.py
@@ -7,8 +7,8 @@ from openstates.scrape import Scraper, Event
 import pytz
 
 urls = {
-    "upper": "http://www.ilga.gov/senate/schedules/weeklyhearings.asp",
-    "lower": "http://www.ilga.gov/house/schedules/weeklyhearings.asp",
+    "upper": "https://www.ilga.gov/senate/schedules/weeklyhearings.asp",
+    "lower": "https://www.ilga.gov/house/schedules/weeklyhearings.asp",
 }
 
 

--- a/scrapers/il/people.py
+++ b/scrapers/il/people.py
@@ -4,8 +4,8 @@ from utils import validate_phone_number
 
 
 CHAMBER_URLS = {
-    "upper": "http://ilga.gov/senate/default.asp?GA={term}",
-    "lower": "http://ilga.gov/house/default.asp?GA={term}",
+    "upper": "https://ilga.gov/senate/default.asp?GA={term}",
+    "lower": "https://ilga.gov/house/default.asp?GA={term}",
 }
 
 CHAMBER_ROLES = {"upper": "Senator", "lower": "Representative"}


### PR DESCRIPTION
Illinois is using HTTPS consistently now, so might as well update URLs.