### PR TITLE
OR: fix bad vote classification (failure)

### DIFF
--- a/scrapers/or/votes.py
+++ b/scrapers/or/votes.py
@@ -30,7 +30,7 @@ class ORVoteScraper(Scraper):
         (".*Recommendation: Do pass.*", ["committee-passage-favorable"]),
         (".*Governor signed.*", ["executive-signature"]),
         (".*Third reading.* Passed", ["passage", "reading-3"]),
-        (".*Third reading.* Failed", ["failure", "reading-3"]),
+        (".*Third reading.* Failed", ["reading-3"]),
         (".*President signed.*", ["passage"]),
         (".*Speaker signed.*", ["passage"]),
         (".*Final reading.* Adopted", ["passage"]),


### PR DESCRIPTION
Looks like there was one more classifier still using this no-longer-supported classification `failure`

re: https://github.com/openstates/issues/issues/409