### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/scrapers/al/people.py
+++ b/scrapers/al/people.py
@@ -22,7 +22,7 @@ class ALPersonScraper(Scraper, LXMLMixin):
         # the url for each rep is unfindable (by me)
         # and the parts needed to make it up do not appear in the html or js.
         # we can find basic information on the main rep page, and sponsor
-        # info on a version of their indivdual page called using only their
+        # info on a version of their individual page called using only their
         # sponsor ID (which we have to scrape from ALISON)
         # we can't get detailed information without another ID
         # which I have not been able to find.

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -150,7 +150,7 @@ class AZBillScraper(Scraper):
                 if page[action] is True:
                     continue
                 try:
-                    # Remove miliseconds from date if present
+                    # Remove milliseconds from date if present
                     cleaned_date = page[action].split(".")[0]
                     action_date = datetime.datetime.strptime(
                         cleaned_date, "%Y-%m-%dT%H:%M:%S"

--- a/scrapers/co/committees.py
+++ b/scrapers/co/committees.py
@@ -21,7 +21,7 @@ class COCommitteeScraper(Scraper, LXMLMixin):
         ):
             details = member.xpath('.//div[@class="member-details"]')[0]
             person = details.xpath("./h4")[0].text_content()
-            # This page does random weird things with whitepace to names
+            # This page does random weird things with whitespace to names
             person = " ".join(person.strip().split())
             if not person:
                 continue

--- a/scrapers/ga/events.py
+++ b/scrapers/ga/events.py
@@ -41,7 +41,7 @@ class GAEventScraper(Scraper):
             if "cancelled" in title.lower() or "canceled" in title.lower():
                 status = "cancelled"
                 # try to replace all variants of "[optional dash] cancel[l]ed [optional dash]"
-                # so we can match up events to thier pre-cancellation occurrence
+                # so we can match up events to their pre-cancellation occurrence
                 title = re.sub(r"-?\s*cancell?ed\s*-?\s*", " ", title, flags=re.I)
 
             where = row["location"]

--- a/scrapers/in/apiclient.py
+++ b/scrapers/in/apiclient.py
@@ -16,7 +16,7 @@ https://addons.mozilla.org/en-US/firefox/addon/modify-headers/
 
 class BadApiResponse(Exception):
     """Raised if the service returns a service code higher than 400,
-    other than 429. Makes the response object avaible as exc.resp
+    other than 429. Makes the response object available as exc.resp
     """
 
     def __init__(self, resp, *args):

--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -39,7 +39,7 @@ class MOBillScraper(Scraper, LXMLMixin):
         self._scrape_subjects(self.latest_session())
 
     def _get_action(self, actor, action):
-        # Alright. This covers both chambers and everyting else.
+        # Alright. This covers both chambers and everything else.
         flags = [
             ("Introduced", "introduction"),
             ("Offered", "introduction"),

--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -574,7 +574,7 @@ class MTBillScraper(Scraper, LXMLMixin):
             elif v == "A":
                 vote.vote("absent", name, note=note)
 
-        # code to deterimine value of `passed`
+        # code to determine value of `passed`
         passed = None
 
         # some actions take a super majority, so we aren't just

--- a/scrapers/nc/bills.py
+++ b/scrapers/nc/bills.py
@@ -381,7 +381,7 @@ class NCBillScraper(Scraper):
                 if line and re.match(r"[H, S]\d\d\d\d", line[0]):
                     bill_id = line[0]
 
-                    # Counting by 2 to find each line. 50 is an abitraty number that is
+                    # Counting by 2 to find each line. 50 is an arbitrary number that is
                     # high enough to find all votes for a bill
                     for y in range(1, 50, 2):
                         if not re.match(r"[H, S]\d\d\d\d", vote_text[x + y]) and (

--- a/scrapers/nd/votes.py
+++ b/scrapers/nd/votes.py
@@ -187,7 +187,7 @@ class NDVoteScraper(Scraper, LXMLMixin):
                         cur_vote = None
 
                         # Identify what is being voted on
-                        # Throw a warning if impropper informaiton found
+                        # Throw a warning if impropper information found
                         bills.extend(re.findall(r"(?i)(H|S|J)(C?)(B|R|M) (\d+)", line))
                         if bills == [] or cur_motion.strip() == "":
                             results = {}

--- a/scrapers/nm/bills.py
+++ b/scrapers/nm/bills.py
@@ -257,7 +257,7 @@ class NMBillScraper(Scraper):
         # if you need to find a missing action code,
         # look up the abbrs in http://www.nmlegis.gov/Legislation/Action_Abbreviations
         action_map = {
-            # these two are recomendations but not reported yet
+            # these two are recommendations but not reported yet
             "6601": ("Recommended DO PASS committee report adopted.", ""),
             "6602": ("Recommended DO PASS, as amended, committee report adopted.", ""),
             "6605": ("Recommended DO NOT PASS, Committee substitute DO PASS", ""),

--- a/scrapers/ny/apiclient.py
+++ b/scrapers/ny/apiclient.py
@@ -9,7 +9,7 @@ from OpenSSL.SSL import SysCallError
 class BadAPIResponse(Exception):
     """
     Raised if the service returns a service code higher than 400,
-    other than 429. Makes the response object avaible as exc.resp.
+    other than 429. Makes the response object available as exc.resp.
     """
 
     def __init__(self, resp, *args):

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -70,7 +70,7 @@ class OHBillScraper(Scraper):
                 "senate": "upper",
             }
 
-            # so presumanbly not everything passes, but we haven't
+            # so presumably not everything passes, but we haven't
             # seen anything not pass yet, so we'll need to wait
             # till it fails and get the right language in here
             vote_results = {

--- a/scrapers/pr/bills.py
+++ b/scrapers/pr/bills.py
@@ -23,7 +23,7 @@ _classifiers = (
     # comissions give a report but sometimes they dont do any amendments and
     # leave them as they are.
     # i am not checking if they did or not. but it be easy just read the end and
-    # if it dosnt have amendments it should say 'sin enmiendas'
+    # if it doesn't have amendments it should say 'sin enmiendas'
     ("1er Informe", "", "amendment-amendment"),
     ("2do Informe", "", "amendment-amendment"),
     ("Aprobado con enmiendas", "", "amendment-passage"),

--- a/scrapers/sd/events.py
+++ b/scrapers/sd/events.py
@@ -30,7 +30,7 @@ class SDEventScraper(Scraper):
         for com in coms:
 
             # temporary store for the events,
-            # because the state lists all the various bits seperately
+            # because the state lists all the various bits separately
             events_by_date = {}
 
             # Skip the floor sessions


### PR DESCRIPTION
There are small typos in:
- scrapers/al/people.py
- scrapers/az/bills.py
- scrapers/co/committees.py
- scrapers/ga/events.py
- scrapers/in/apiclient.py
- scrapers/mo/bills.py
- scrapers/mt/bills.py
- scrapers/nc/bills.py
- scrapers/nd/votes.py
- scrapers/nm/bills.py
- scrapers/ny/apiclient.py
- scrapers/oh/bills.py
- scrapers/pr/bills.py
- scrapers/sd/events.py

Fixes:
- Should read `available` rather than `avaible`.
- Should read `whitespace` rather than `whitepace`.
- Should read `their` rather than `thier`.
- Should read `separately` rather than `seperately`.
- Should read `recommendations` rather than `recomendations`.
- Should read `presumably` rather than `presumanbly`.
- Should read `milliseconds` rather than `miliseconds`.
- Should read `information` rather than `informaiton`.
- Should read `individual` rather than `indivdual`.
- Should read `everything` rather than `everyting`.
- Should read `doesn't` rather than `dosnt`.
- Should read `determine` rather than `deterimine`.
- Should read `arbitrary` rather than `abitraty`.

Closes #3679