### PR TITLE
NV: Classify actions by search instead of match

### DIFF
--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -203,7 +203,7 @@ class BillTabDetail(HtmlPage):
 
                 action_type = None
                 for pattern, atype in ACTION_CLASSIFIERS:
-                    if re.match(pattern, action):
+                    if re.search(pattern, action, re.IGNORECASE):
                         action_type = atype
                         break
 


### PR DESCRIPTION
NV was missing some action classifications, because we were only looking for matches at the start of the action string, instead of anywhere in it, and doing so case sensitively. 