### PR TITLE
KS: Fix import error caused by people scraper refactor

### DIFF
--- a/scrapers/ks/__init__.py
+++ b/scrapers/ks/__init__.py
@@ -1,7 +1,7 @@
 from utils import url_xpath, State
 from .bills import KSBillScraper
 from .events import KSEventScraper
-from .people import KSPersonScraper
+# from .people import KSPersonScraper
 
 # from .committees import KSCommitteeScraper
 
@@ -17,7 +17,7 @@ class Kansas(State):
     scrapers = {
         "bills": KSBillScraper,
         "events": KSEventScraper,
-        "people": KSPersonScraper,
+        # "people": KSPersonScraper,
         # 'committees': KSCommitteeScraper,
     }
     legislative_sessions = [


### PR DESCRIPTION
Commented out lines as a quick fix for [bobsled error](https://bobsled.openstates.org/run/60c767eda1ec4652ab1d343da3d4684c)