### PR TITLE
CT: Remove errant bill classification

### DIFF
--- a/scrapers/ct/bills.py
+++ b/scrapers/ct/bills.py
@@ -278,9 +278,6 @@ class CTBillScraper(Scraper):
                 if re.match(r"SIGNED BY GOVERNOR", action):
                     act_type.append("executive-signature")
 
-                if re.match(r"PUBLIC ACT", action):
-                    act_type.append("became-law")
-
                 if re.match(r"^LINE ITEM VETOED", action):
                     act_type.append("executive-veto-line-item")
 


### PR DESCRIPTION
The CT legislature publishes "public act" documents for bills that have passed both houses, even if they haven't become law (yet).

We were incorrectly categorizing all bills with public acts as having become law.

Quote from our researcher:
"here is the exact process from CT site: A bill becomes a public act when it passes both chambers of the General Assembly. The act is then assigned a public act number, with the first number indicating the year of enactment (e.g., PA 11-250 was enacted in 2011). Note that a public act does not actually become law until the governor has signed it, or it can become law if the governor takes no action (i.e., does not veto the public act)."

