### PR TITLE
CT: widen bill version xpath

### DIFF
--- a/scrapers/ct/bills.py
+++ b/scrapers/ct/bills.py
@@ -134,7 +134,7 @@ class CTBillScraper(Scraper):
             bill.add_document_link(link.text.strip(), link.attrib["href"])
 
         for link in page.xpath(
-            "//a[(contains(@href, '/pdf/') or contains(@href, '/PDF/')) and contains(@href, '/TOB/')]"
+            "//a[(contains(@href, '/pdf/') or contains(@href, '/PDF/')) and (contains(@href, '/TOB/') or contains(@href, '/FC/') or contains(@href, '/ACT/'))]"
         ):
             bill.add_version_link(
                 link.text.strip(), link.attrib["href"], media_type="application/pdf"


### PR DESCRIPTION
CT was missing final acts due to a too-specific selector. 