### PR TITLE
AZ: resume scraping regular session to catch missing HR 2017

### DIFF
--- a/scrapers/az/__init__.py
+++ b/scrapers/az/__init__.py
@@ -250,20 +250,20 @@ class Arizona(State):
             "end_date": "2020-05-27",
         },
         {
-            "_scraped_name": "2021 - Fifty-fifth Legislature - First Regular Session",
-            "classification": "primary",
-            "identifier": "55th-1st-regular",
-            "name": "55th Legislature - 1st Regular Session",
-            "start_date": "2020-01-11",
-            "end_date": "2020-04-23",
-        },
-        {
             "_scraped_name": "2021 - Fifty-fifth Legislature - First Special Session",
             "classification": "special",
             "identifier": "55th-1st-special",
             "name": "55th Legislature - 1st Special Session",
             "start_date": "2021-06-14",
             "end_date": "2021-06-18",
+        },
+        {
+            "_scraped_name": "2021 - Fifty-fifth Legislature - First Regular Session",
+            "classification": "primary",
+            "identifier": "55th-1st-regular",
+            "name": "55th Legislature - 1st Regular Session",
+            "start_date": "2020-01-11",
+            "end_date": "2020-04-23",
         },
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
Re-orders sessions so regular session will be scraped again. [HR 2017](https://apps.azleg.gov/BillStatus/BillOverview/76200?SessionId=123) is missing from [Open States data](https://openstates.org/search/?query=HR+2017&state=az).

(@jamesturk is this still the preferred way to handle this - vs. changing the task definition to specify the regular session?)