### PR TITLE
RI: Fix some senate action classes

### DIFF
--- a/scrapers/ri/bills.py
+++ b/scrapers/ri/bills.py
@@ -174,10 +174,11 @@ class RIBillScraper(Scraper):
                 actor = "lower"
 
             if "senate" in action.lower():
-                if actor == "joint":
-                    actor = "upper"
-                else:
-                    actor = "legislature"
+                actor = "upper"
+
+            if "joint" in action.lower():
+                actor = "legislature"
+
             if "governor" in action.lower():
                 actor = "executive"
             date = action.split(" ")[0]


### PR DESCRIPTION
We were getting the actor wrong on many RI senate actions, so mark them as "upper" instead of "legislature"