### PR TITLE
updated lines that used com.parent to com.chamber as per ScrapeCommittee update

### DIFF
--- a/scrapers_next/ga/committees.py
+++ b/scrapers_next/ga/committees.py
@@ -42,9 +42,9 @@ class CommitteeDetail(JsonPage):
             self.source.url, note="Detail page (requires authorization token)"
         )
 
-        if com.parent == "upper":
+        if com.chamber == "upper":
             link_chamber = "senate"
-        elif com.parent == "lower":
+        elif com.chamber == "lower":
             link_chamber = "house"
 
         source_url_list = self.source.url.split("/")
@@ -101,7 +101,7 @@ class CommitteeList(JsonListPage):
 
         com = ScrapeCommittee(
             name=item["name"],
-            parent=chamber,
+            chamber=chamber,
         )
 
         com.add_source(


### PR DESCRIPTION
Note that GA does not have any joint or sub committees listed. This scraper does not scrape the "House Special & Study Committees" page. @jamesturk 