### PR TITLE
NY: Temporary fix for missing OpenSSL library error

### DIFF
--- a/scrapers/ny/apiclient.py
+++ b/scrapers/ny/apiclient.py
@@ -3,6 +3,7 @@ import os
 import time
 import functools
 from collections import defaultdict
+
 # from OpenSSL.SSL import SysCallError
 
 

--- a/scrapers/ny/apiclient.py
+++ b/scrapers/ny/apiclient.py
@@ -3,7 +3,7 @@ import os
 import time
 import functools
 from collections import defaultdict
-from OpenSSL.SSL import SysCallError
+# from OpenSSL.SSL import SysCallError
 
 
 class BadAPIResponse(Exception):
@@ -109,16 +109,15 @@ class OpenLegislationAPIClient(object):
         response = None
         tries = 0
         while response is None and tries < num_bad_packets_allowed:
-            try:
-                response = self.scraper.get(url, *requests_args, **requests_kwargs)
-            except SysCallError as e:
-                err, string = e.args
-                if err != 104:
-                    raise
-                tries += 1
-                if tries >= num_bad_packets_allowed:
-                    print(err, string)
-                    raise RuntimeError("Received too many bad packets from API.")
+            response = self.scraper.get(url, *requests_args, **requests_kwargs)
+            # except SysCallError as e:
+            #     err, string = e.args
+            #     if err != 104:
+            #         raise
+            #     tries += 1
+            #     if tries >= num_bad_packets_allowed:
+            #         print(err, string)
+            #         raise RuntimeError("Received too many bad packets from API.")
 
         return response
 


### PR DESCRIPTION
Fixes https://github.com/openstates/issues/issues/455

NY scrape started failing yesterday due to `ModuleNotFoundError: No module named 'OpenSSL'` - seems like this must have been an implicit dependency imported by some other package. Poked around a bit to find a recent change that would explain it but didn't find it. 

This disables retry handling on NY API calls as a quick temporary fix. Hopefully when @jamesturk is back he will know about the root issue :)