### PR TITLE
ScrapeCommittee update: updated parent to chamber and added chamber to subcommittees

### DIFF
--- a/scrapers_next/mn/committees.py
+++ b/scrapers_next/mn/committees.py
@@ -90,10 +90,13 @@ class SenateCommitteeList(HtmlListPage):
         if re.search(" - ", name):
             parent, com_name = name.split(" - Subcommittee on ")
             com = ScrapeCommittee(
-                name=com_name, classification="subcommittee", parent=parent
+                name=com_name,
+                classification="subcommittee",
+                parent=parent,
+                chamber=self.chamber,
             )
         else:
-            com = ScrapeCommittee(name=name, parent=self.chamber)
+            com = ScrapeCommittee(name=name, chamber=self.chamber)
 
         com.add_source(self.source.url)
         return SenateCommitteeDetail(com, source=item.get("href"))


### PR DESCRIPTION
subcommittees have chambers and parents, while committees only have chambers

House committee list also includes 1 subcommittee, but it doesn't have a parent, so didn't make the change there ([Subcommittee on Legislative Process Reform](https://www.house.leg.state.mn.us/committees))
- This is also the case for [NY House subcommittees](https://assembly.state.ny.us/comm/)