### PR TITLE
In spatula scrape

### DIFF
--- a/scrapers_next/in/people.py
+++ b/scrapers_next/in/people.py
@@ -1,0 +1,19 @@
+from spatula import HtmlListPage  # , CSS, XPath, URL
+from openstates.models import ScrapePerson
+
+
+class LegList(HtmlListPage):
+    def process_item(self, item):
+        return ScrapePerson()
+
+
+class RepList(LegList):
+    source = ""
+    # selector = CSS("", num_items=)
+    chamber = "lower"
+
+
+class SenList(LegList):
+    source = ""
+    # selector = CSS("", num_items=)
+    chamber = "upper"

--- a/scrapers_next/in/people.py
+++ b/scrapers_next/in/people.py
@@ -1,17 +1,96 @@
-from spatula import HtmlListPage, XPath, CSS  # , CSS, , URL
+from spatula import (
+    HtmlListPage,
+    XPath,
+    CSS,
+    URL,
+    HtmlPage,
+    SelectorError,
+)  # , CSS, , URL
 from openstates.models import ScrapePerson
+import re
+
+
+class LegDetail(HtmlPage):
+    def process_page(self):
+        p = self.input
+
+        try:
+            title = (
+                CSS(
+                    "div .fusion-column-wrapper.fusion-flex-justify-content-flex-start.fusion-content-layout-column h2"
+                )
+                .match(self.root)[0]
+                .text_content()
+            )
+        except SelectorError:
+            pass
+
+        assistant = (
+            CSS("div .fusion-text.fusion-text-2 p").match(self.root)[0].text_content()
+        )
+        assistant = re.search(r"Legislative Assistant:\s(.+)", assistant).groups()[0]
+
+        phones = (
+            CSS("div .fusion-text.fusion-text-2 p").match(self.root)[1].text_content()
+        )
+        phone1, phone2 = re.search(
+            r"Phone:\s(\d{3}-\d{3}-\d{4})\s\|\s(.+)", phones
+        ).groups()
+
+        email = (
+            CSS("div .fusion-text.fusion-text-2 p a").match(self.root)[0].text_content()
+        )
+
+        media_contact = (
+            CSS("div .fusion-text.fusion-text-2 p").match(self.root)[3].text_content()
+        )
+        media_contact_name, media_contact_email = re.search(
+            r"Media Contact:\s(\w+\s\w+)\s\|\s(.+)", media_contact
+        ).groups()
+        addr = (
+            XPath("//div/div[3]/div/div[2]/div/div[1]/text()")
+            .match(self.root)[0]
+            .strip()
+        )
+
+        twitter = CSS("div .fusion-social-links a").match(self.root)[0].get("href")
+        fb = CSS("div .fusion-social-links a").match(self.root)[1].get("href")
+
+        # print(phone1)
+        # print(phone2)
+        # print(addr)
+        p.district_office.voice = phone1
+        p.capitol_office.address = addr
+        p.capitol_office.voice = phone2
+
+        p.email = email
+
+        p.extras["title"] = title
+        p.extras["assistant"] = assistant
+        p.extras["media contact name"] = media_contact_name
+        p.extras["media contact email"] = media_contact_email
+        p.extras["twitter"] = twitter
+        p.extras["facebook"] = fb
+
+        return p
 
 
 class LegList(HtmlListPage):
     def process_item(self, item):
-        # name = item.text_content()
         name = CSS("div a").match(item)[1].text_content()
+        # print(name)
         district = (
             CSS("div .esg-content.eg-senators-grid-element-1")
             .match_one(item)
             .text_content()
+            .split("|")[1]
+            .strip()
+            .lower()
         )
-        img = CSS("div img").match_one(item).get("src")
+        district = re.search(r"district\s(\d+)", district).groups()[0]
+        # print(district)
+        img = CSS("div img").match_one(item).get("data-lazysrc")
+        # print(img)
 
         p = ScrapePerson(
             name=name,
@@ -21,32 +100,40 @@ class LegList(HtmlListPage):
             party=self.party,
             image=img,
         )
-        return p
+
+        detail_link = CSS("div a").match(item)[1].get("href")
+        p.add_link(detail_link, note="homepage")
+        p.add_source(self.source.url)
+        return LegDetail(p, source=detail_link)
 
 
 class RedRepList(LegList):
     source = "https://www.indianahouserepublicans.com/members/"
     # selector = CSS("", num_items=)
     chamber = "lower"
-    party = "republican"
+    party = "Republican"
 
 
 class BlueRepList(LegList):
-    source = "https://indianahousedemocrats.org/members"
+    source = URL("https://indianahousedemocrats.org/members")
     # selector = CSS("", num_items=)
     chamber = "lower"
-    party = "democratic"
+    party = "Democratic"
 
 
 class BlueSenList(LegList):
     source = "https://www.indianasenatedemocrats.org/senators/"
-    selector = XPath(".//*[@id='esg-grid-10-1']/div/ul/li")
+    # selector = XPath(".//*[@id='esg-grid-10-1']/div/ul/li")
+    # selector = CSS("ul .mainul li")
+    selector = CSS(
+        "body main section div div div.fusion-fullwidth.fullwidth-box.fusion-builder-row-2.nonhundred-percent-fullwidth.non-hundred-percent-height-scrolling article ul li"
+    )
     chamber = "upper"
-    party = "democratic"
+    party = "Democratic"
 
 
 class RedSenList(LegList):
     source = "https://www.indianasenaterepublicans.com/senators"
     # selector = CSS("", num_items=)
     chamber = "upper"
-    party = "republican"
+    party = "Republican"

--- a/scrapers_next/in/people.py
+++ b/scrapers_next/in/people.py
@@ -4,8 +4,7 @@ from spatula import (
     CSS,
     URL,
     HtmlPage,
-    SelectorError,
-)  # , CSS, , URL
+)
 from openstates.models import ScrapePerson
 import re
 
@@ -14,16 +13,11 @@ class LegDetail(HtmlPage):
     def process_page(self):
         p = self.input
 
-        try:
-            title = (
-                CSS(
-                    "div .fusion-column-wrapper.fusion-flex-justify-content-flex-start.fusion-content-layout-column h2"
-                )
-                .match(self.root)[0]
-                .text_content()
-            )
-        except SelectorError:
-            pass
+        titles = CSS("h2").match(self.root)
+        if len(titles) > 9:
+            title = titles[0].text_content()
+            print(title)
+            p.extras["title"] = title
 
         assistant = (
             CSS("div .fusion-text.fusion-text-2 p").match(self.root)[0].text_content()
@@ -65,7 +59,6 @@ class LegDetail(HtmlPage):
 
         p.email = email
 
-        p.extras["title"] = title
         p.extras["assistant"] = assistant
         p.extras["media contact name"] = media_contact_name
         p.extras["media contact email"] = media_contact_email
@@ -104,6 +97,7 @@ class LegList(HtmlListPage):
         detail_link = CSS("div a").match(item)[1].get("href")
         p.add_link(detail_link, note="homepage")
         p.add_source(self.source.url)
+        p.add_source(detail_link)
         return LegDetail(p, source=detail_link)
 
 
@@ -126,7 +120,8 @@ class BlueSenList(LegList):
     # selector = XPath(".//*[@id='esg-grid-10-1']/div/ul/li")
     # selector = CSS("ul .mainul li")
     selector = CSS(
-        "body main section div div div.fusion-fullwidth.fullwidth-box.fusion-builder-row-2.nonhundred-percent-fullwidth.non-hundred-percent-height-scrolling article ul li"
+        "body main section div div div.fusion-fullwidth.fullwidth-box.fusion-builder-row-2.nonhundred-percent-fullwidth.non-hundred-percent-height-scrolling article ul li",
+        num_items=11,
     )
     chamber = "upper"
     party = "Democratic"
@@ -134,6 +129,6 @@ class BlueSenList(LegList):
 
 class RedSenList(LegList):
     source = "https://www.indianasenaterepublicans.com/senators"
-    # selector = CSS("", num_items=)
+    selector = CSS("div.senator-list div.senator-item", num_items=39)
     chamber = "upper"
     party = "Republican"

--- a/scrapers_next/in/people.py
+++ b/scrapers_next/in/people.py
@@ -1,19 +1,52 @@
-from spatula import HtmlListPage  # , CSS, XPath, URL
+from spatula import HtmlListPage, XPath, CSS  # , CSS, , URL
 from openstates.models import ScrapePerson
 
 
 class LegList(HtmlListPage):
     def process_item(self, item):
-        return ScrapePerson()
+        # name = item.text_content()
+        name = CSS("div a").match(item)[1].text_content()
+        district = (
+            CSS("div .esg-content.eg-senators-grid-element-1")
+            .match_one(item)
+            .text_content()
+        )
+        img = CSS("div img").match_one(item).get("src")
+
+        p = ScrapePerson(
+            name=name,
+            state="in",
+            chamber=self.chamber,
+            district=district,
+            party=self.party,
+            image=img,
+        )
+        return p
 
 
-class RepList(LegList):
-    source = ""
+class RedRepList(LegList):
+    source = "https://www.indianahouserepublicans.com/members/"
     # selector = CSS("", num_items=)
     chamber = "lower"
+    party = "republican"
 
 
-class SenList(LegList):
-    source = ""
+class BlueRepList(LegList):
+    source = "https://indianahousedemocrats.org/members"
+    # selector = CSS("", num_items=)
+    chamber = "lower"
+    party = "democratic"
+
+
+class BlueSenList(LegList):
+    source = "https://www.indianasenatedemocrats.org/senators/"
+    selector = XPath(".//*[@id='esg-grid-10-1']/div/ul/li")
+    chamber = "upper"
+    party = "democratic"
+
+
+class RedSenList(LegList):
+    source = "https://www.indianasenaterepublicans.com/senators"
     # selector = CSS("", num_items=)
     chamber = "upper"
+    party = "republican"

--- a/scrapers_next/in/people_api.py
+++ b/scrapers_next/in/people_api.py
@@ -1,0 +1,37 @@
+from spatula import (
+    JsonListPage,
+    # JsonPage,
+    URL,
+)  # HtmlListPage, XPath, CSS, HtmlPage  # , SelectorError
+from openstates.models import ScrapePerson
+
+"""
+class LegDetailPage(JsonPage):
+    def process_page(self):
+        return p
+"""
+
+
+class LegListPage(JsonListPage):
+    def process_item(self, item):
+        print(item)
+
+        p = ScrapePerson(
+            name="",
+            state="in",
+            chamber="",
+            district="",
+            party="",
+            image="",
+        )
+
+        return p
+
+
+class ApiGet(LegListPage):
+    base_url = "http://iga.in.gov/legislative"
+    api_base_url = "https://api.iga.in.gov"
+
+    source = URL(
+        "https://api.iga.in.gov/122/legislators", headers={"Authorization": "Token"}
+    )

--- a/scrapers_next/in/people_api.py
+++ b/scrapers_next/in/people_api.py
@@ -15,6 +15,11 @@ class LegDetailPage(JsonPage):
 class LegListPage(JsonListPage):
     def process_item(self, item):
         print(item)
+        firstname = item["firstName"]
+        # lastname = item["lastName"]
+        # party = item["party"]
+        # link = item["link"]
+        print(firstname)
 
         p = ScrapePerson(
             name="",
@@ -33,5 +38,9 @@ class ApiGet(LegListPage):
     api_base_url = "https://api.iga.in.gov"
 
     source = URL(
-        "https://api.iga.in.gov/122/legislators", headers={"Authorization": "Token"}
+        "https://api.iga.in.gov/122/chambers/senate/legislators",
+        headers={
+            "Authorization": "Token a62cb5ec0dcb321f9ac33802160911556c6cbb19",
+            "Accept": "application/json",
+        },
     )


### PR DESCRIPTION
Converting Indiana people scraper to spatula. There are a couple of hiccups/missing items:

1. Democratic Senators have emails, but they are 'protected.' Showing up as "[email\u00a0protected]" after scrape.
2. Democratic Senators have 2 phones listed. Can both be listed in capitol address?
3. Democratic Senators do not have a district address.
4. Democratic Senators have twitter and facebook links. I am currently adding these to extras. Should the full links go in 'ids' instead? 
example link: https://www.indianasenatedemocrats.org/senators/s33/

5. Republican Senators also have 2 phones listed (see 2 above).
6. Republican Senators also do not have a district address (see 3 above).
7. Republican Senators have Education listed, but the format is messy (some have multi-lines but no "\n"). Is it worth grabbing and trying to parse with regex? Or just ignore?
example link: https://www.indianasenaterepublicans.com/brown

8. Both Democratic and Republican Representatives do not have office address or emails listed. Instead, they have Assistant name, phone, address information (currently adding to extras)
example link: https://indianahousedemocrats.org/members/rita-fleming/full
example link: https://www.indianahouserepublicans.com/members/general/tony-cook/?back=members

@jamesturk 