### PR TITLE
Il spatula people

### DIFF
--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -9,23 +9,68 @@ class LegDetail(HtmlPage):
         img = CSS("body table tr td img").match(self.root)[2].get("src")
         p.image = img
 
-        captiol_addr = CSS("body table tr td").match(self.root)[31].text_content()
+        # print(len(CSS("body table tr td.member").match(self.root)))
+
+        if len(CSS("body table tr td").match(self.root)) == 10:
+            print("GOT A 10")
+            idx = 1
+            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 phone
+        else:
+            return None
+        """
+        elif len(CSS("body table tr td").match(self.root)) == 11:
+            idx = 1
+            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 phone, 9 email
+        elif len(CSS("body table tr td").match(self.root)) == 12:
+            idx = 1
+            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 email
+        elif len(CSS("body table tr td").match(self.root)) == 13:
+            idx = 1
+            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 fax, 11 email
+            # 2, 3, 4, 8, 9, 10, 11
+        elif len(CSS("body table tr td").match(self.root)) == 14:
+            idx = 2
+            # 2 addr, 3 addr, 4 phone, 8 addr, 9 addr, 10 addr, 11 phone, 12 fax
+        """
+
+        # idx = 1
+
+        captiol_addr = (
+            CSS("body table tr td.member").match(self.root)[idx].text_content()
+        )
         captiol_addr += " "
-        captiol_addr += CSS("body table tr td").match(self.root)[32].text_content()
-        captiol_phone = CSS("body table tr td").match(self.root)[33].text_content()
+        captiol_addr += (
+            CSS("body table tr td.member").match(self.root)[idx + 1].text_content()
+        )
+        captiol_phone = (
+            CSS("body table tr td.member").match(self.root)[idx + 2].text_content()
+        )
 
         p.capitol_office.address = captiol_addr
         p.capitol_office.voice = captiol_phone
 
-        district_addr = CSS("body table tr td").match(self.root)[37].text_content()
+        district_addr = (
+            CSS("body table tr td.member").match(self.root)[idx + 5].text_content()
+        )
         district_addr += " "
-        district_addr += CSS("body table tr td").match(self.root)[38].text_content()
-        district_addr += " "
-        district_addr += CSS("body table tr td").match(self.root)[39].text_content()
-        district_phone = CSS("body table tr td").match(self.root)[40].text_content()
+        district_addr += (
+            CSS("body table tr td.member").match(self.root)[idx + 6].text_content()
+        )
+        # district_addr += " "
+        # district_addr += CSS("body table tr td.member").match(self.root)[idx + 8].text_content()
+        district_phone = (
+            CSS("body table tr td.member").match(self.root)[idx + 7].text_content()
+        )
 
         p.district_office.address = district_addr
         p.district_office.voice = district_phone
+
+        # 12-14 for sen
+        # 10-14 for house
+        print(captiol_addr)
+        print(captiol_phone)
+        print(district_addr)
+        print(district_phone)
 
         return p
 

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -1,5 +1,6 @@
 from spatula import CSS, HtmlListPage, HtmlPage
 from openstates.models import ScrapePerson
+import re
 
 
 class LegDetail(HtmlPage):
@@ -11,24 +12,46 @@ class LegDetail(HtmlPage):
 
         # print(len(CSS("body table tr td.member").match(self.root)))
 
-        if len(CSS("body table tr td").match(self.root)) == 10:
-            print("GOT A 10")
+        if len(CSS("body table tr td.member").match(self.root)) == 10:
+            # 3 house links have a length of 10
+            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=3006
+            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=2994
+            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=2949
+            # 0 senate links have a length of 10
             idx = 1
             # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 phone
-        else:
             return None
-        """
-        elif len(CSS("body table tr td").match(self.root)) == 11:
+        elif len(CSS("body table tr td.member").match(self.root)) == 11:
+            # 34 house links have a length of 11
+            # 0 senate links have a length of 11
             idx = 1
             # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 phone, 9 email
-        elif len(CSS("body table tr td").match(self.root)) == 12:
+            email_or_fax = (
+                CSS("body table tr td.member").match(self.root)[9].text_content()
+            )
+            if re.search(r"FAX", email_or_fax):
+                fax = re.search(r"(.+)\sFAX", email_or_fax).groups()[0]
+                p.district_office.fax = fax
+                print(fax)
+            else:
+                email = re.search(r"Email:\s(.+)", email_or_fax).groups()[0]
+                p.email = email.strip()
+                print(email)
+            # return None
+            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=2945 special case
+            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=3003 additional office
+        else:
+            return None
+
+        """
+        elif len(CSS("body table tr td.member").match(self.root)) == 12:
             idx = 1
             # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 email
-        elif len(CSS("body table tr td").match(self.root)) == 13:
+        elif len(CSS("body table tr td.member").match(self.root)) == 13:
             idx = 1
             # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 fax, 11 email
             # 2, 3, 4, 8, 9, 10, 11
-        elif len(CSS("body table tr td").match(self.root)) == 14:
+        elif len(CSS("body table tr td.member").match(self.root)) == 14:
             idx = 2
             # 2 addr, 3 addr, 4 phone, 8 addr, 9 addr, 10 addr, 11 phone, 12 fax
         """
@@ -67,10 +90,10 @@ class LegDetail(HtmlPage):
 
         # 12-14 for sen
         # 10-14 for house
-        print(captiol_addr)
-        print(captiol_phone)
-        print(district_addr)
-        print(district_phone)
+        # print(captiol_addr)
+        # print(captiol_phone)
+        # print(district_addr)
+        # print(district_phone)
 
         return p
 

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -1,5 +1,33 @@
-from spatula import CSS, HtmlListPage
+from spatula import CSS, HtmlListPage, HtmlPage
 from openstates.models import ScrapePerson
+
+
+class LegDetail(HtmlPage):
+    def process_page(self):
+        p = self.input
+
+        img = CSS("body table tr td img").match(self.root)[2].get("src")
+        p.image = img
+
+        captiol_addr = CSS("body table tr td").match(self.root)[31].text_content()
+        captiol_addr += " "
+        captiol_addr += CSS("body table tr td").match(self.root)[32].text_content()
+        captiol_phone = CSS("body table tr td").match(self.root)[33].text_content()
+
+        p.capitol_office.address = captiol_addr
+        p.capitol_office.voice = captiol_phone
+
+        district_addr = CSS("body table tr td").match(self.root)[37].text_content()
+        district_addr += " "
+        district_addr += CSS("body table tr td").match(self.root)[38].text_content()
+        district_addr += " "
+        district_addr += CSS("body table tr td").match(self.root)[39].text_content()
+        district_phone = CSS("body table tr td").match(self.root)[40].text_content()
+
+        p.district_office.address = district_addr
+        p.district_office.voice = district_phone
+
+        return p
 
 
 class LegList(HtmlListPage):
@@ -18,7 +46,14 @@ class LegList(HtmlListPage):
         detail_link = first_link.get("href")
 
         # these are "Former Senate Members"
-        if name == "Andy Manar" or name == "Heather A. Steans":
+        former_members = [
+            "Andy Manar",
+            "Heather A. Steans",
+            "Edward Kodatt",
+            "Michael J. Madigan",
+            "André Thapedi",
+        ]
+        if name in former_members:
             self.skip()
 
         district = CSS("td").match(item)[3].text_content()
@@ -38,7 +73,7 @@ class LegList(HtmlListPage):
         p.add_source(detail_link)
         p.add_link(detail_link, note="homepage")
 
-        return p
+        return LegDetail(p, source=detail_link)
 
 
 class House(LegList):

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -19,19 +19,19 @@ class LegDetail(HtmlPage):
             district_fax,
             email,
         ) = self.process_addrs()
-        if not capitol_addr:
-            return None
 
         p.capitol_office.address = capitol_addr
         p.capitol_office.voice = capitol_phone
+        if capitol_fax:
+            p.capitol_office.fax = capitol_fax
         if district_addr:
             p.district_office.address = district_addr
         if district_phone:
             p.district_office.voice = district_phone
-        if email:
-            p.email = email
         if district_fax:
             p.district_office.fax = district_fax
+        if email:
+            p.email = email
 
         return p
 
@@ -171,8 +171,8 @@ class LegDetail(HtmlPage):
                 email,
             )
         elif len(addresses) == 13:
-            # 28 house links have a length of 12
-            # 32 senate links ahve a length of 12
+            # 28 house links have a length of 13
+            # 32 senate links ahve a length of 13
             if re.search(r"(Senator|Representative)", addresses[1].text_content()):
                 cap_addr_line1 = addresses[2].text_content()
                 cap_addr_line2 = addresses[3].text_content()
@@ -229,6 +229,10 @@ class LegDetail(HtmlPage):
                 email,
             )
         elif len(addresses) == 14:
+            # 10 house links have a length of 14
+            # 16 senate links ahve a length of 14
+            return (None, None, None, None, None, None, None)
+            """
             cap_addr_line1 = addresses[2].text_content()
             cap_addr_line2 = addresses[3].text_content()
             cap_phone = addresses[4].text_content()
@@ -237,14 +241,18 @@ class LegDetail(HtmlPage):
             if addresses[10].text_content().startswith("("):
                 dis_phone = addresses[10].text_content()
                 dis_fax = addresses[11].text_content()
-                dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
-                district_addr = dis_addr_line1 + " " + dis_addr_line2
+            """
+            # dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+            # district_addr = dis_addr_line1 + " " + dis_addr_line2
+            """
             else:
                 dis_addr_line3 = addresses[10].text_content()
                 dis_phone = addresses[11].text_content()
                 if addresses[12].text_content().startswith("("):
                     dis_fax = addresses[12].text_content()
-                    dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+            """
+            # dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+            """
                 else:
                     dis_fax = None
                 district_addr = (
@@ -260,14 +268,31 @@ class LegDetail(HtmlPage):
                 dis_fax,
                 None,
             )
+            """
         elif len(addresses) == 15:
-            return (None, None, None, None, None, None, None)
-
-        """
-        elif len(CSS("body table tr td.member").match(self.root)) == 14:
-            idx = 2
-            # 2 addr, 3 addr, 4 phone, 8 addr, 9 addr, 10 addr, 11 phone, 12 fax
-        """
+            # 0 house links have a length of 15
+            # 1 senate link has a length of 15
+            # https://ilga.gov/senate/Senator.asp?GA=102&MemberID=2899
+            cap_addr_line1 = addresses[2].text_content()
+            cap_addr_line2 = addresses[3].text_content()
+            cap_phone = addresses[4].text_content()
+            dis_addr_line1 = addresses[8].text_content()
+            dis_addr_line2 = addresses[9].text_content()
+            dis_addr_line3 = addresses[10].text_content()
+            dis_phone = addresses[11].text_content()
+            dis_fax = addresses[12].text_content()
+            dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
+            district_addr = dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
+            return (
+                capitol_addr,
+                cap_phone,
+                None,
+                district_addr,
+                dis_phone,
+                dis_fax,
+                None,
+            )
 
 
 class LegList(HtmlListPage):

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -55,9 +55,10 @@ class LegDetail(HtmlPage):
             if (
                 line == "Springfield Office:"
                 or line == "District Office:"
-                or line == "Additional Offices"
+                or line == "Additional District Addresses"
                 or line.startswith("Senator")
                 or line.startswith("Representative")
+                or line.startswith("Years served:")
                 or line == ""
             ):
                 line_number += 1
@@ -66,7 +67,7 @@ class LegDetail(HtmlPage):
             if not capitol_addr:
                 capitol_addr = line
                 line_number += 1
-            elif line.startswith("Springfield"):
+            elif line_number in [2, 3] and not line.startswith("("):
                 capitol_addr += " "
                 capitol_addr += line
                 line_number += 1
@@ -85,7 +86,11 @@ class LegDetail(HtmlPage):
                 district_addr += line
                 line_number += 1
                 district_addr_lines += 1
-            elif not line.startswith("("):
+            elif (
+                district_addr_lines == 2
+                and not line.strip().startswith("(")
+                and not re.search(r"Email:", line)
+            ):
                 district_addr += " "
                 district_addr += line
                 line_number += 1
@@ -96,14 +101,14 @@ class LegDetail(HtmlPage):
             elif re.search(r"FAX", line):
                 dis_fax = re.search(r"(.+)\sFAX", line).groups()[0]
                 line_number += 1
-            else:
-                email = re.search(r"Email:\s", line).groups()[0].strip()
+            elif re.search(r"Email:\s", line.strip()):
+                email = re.search(r"Email:\s(.+)", line).groups()[0].strip()
                 line_number += 1
 
         # print(capitol_addr)
         # print(cap_phone)
         # print(capitol_fax)
-        print(district_addr)
+        # print(district_addr)
         # print(dis_phone)
         # print(dis_fax)
         # print(email)

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -1,0 +1,51 @@
+from spatula import CSS, HtmlListPage
+from openstates.models import ScrapePerson
+
+
+class LegList(HtmlListPage):
+    selector = CSS("form table tr")
+
+    def process_item(self, item):
+        # skip header rows
+        if (
+            len(CSS("td").match(item)) == 1
+            or CSS("td").match(item)[0].get("class") == "header"
+        ):
+            self.skip()
+
+        first_link = CSS("td a").match(item)[0]
+        name = first_link.text_content()
+        detail_link = first_link.get("href")
+
+        # these are "Former Senate Members"
+        if name == "Andy Manar" or name == "Heather A. Steans":
+            self.skip()
+
+        district = CSS("td").match(item)[3].text_content()
+        party_letter = CSS("td").match(item)[4].text_content()
+        party_dict = {"D": "Democratic", "R": "Republican", "I": "Independent"}
+        party = party_dict[party_letter]
+
+        p = ScrapePerson(
+            name=name,
+            state="il",
+            party=party,
+            chamber=self.chamber,
+            district=district,
+        )
+
+        p.add_source(self.source.url)
+        p.add_source(detail_link)
+        p.add_link(detail_link, note="homepage")
+
+        return p
+
+
+class House(LegList):
+    source = "https://ilga.gov/house/default.asp?GA=102"
+    chamber = "lower"
+
+
+class Senate(LegList):
+    source = "https://ilga.gov/senate/default.asp?GA=102"
+    chamber = "upper"

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -171,20 +171,99 @@ class LegDetail(HtmlPage):
                 email,
             )
         elif len(addresses) == 13:
-            return (None, None, None, None, None, None, None)
+            # 28 house links have a length of 12
+            # 32 senate links ahve a length of 12
+            if re.search(r"(Senator|Representative)", addresses[1].text_content()):
+                cap_addr_line1 = addresses[2].text_content()
+                cap_addr_line2 = addresses[3].text_content()
+                cap_phone = addresses[4].text_content()
+                capitol_fax = None
+                dis_addr_line1 = addresses[8].text_content()
+                dis_addr_line2 = addresses[9].text_content()
+                dis_addr_line3 = addresses[10].text_content()
+                dis_phone = addresses[11].text_content()
+                dis_fax = None
+                email = None
+            else:
+                cap_addr_line1 = addresses[1].text_content()
+                cap_addr_line2 = addresses[2].text_content()
+                cap_phone = addresses[3].text_content()
+                if re.search(r"FAX", addresses[4].text_content()):
+                    capitol_fax = re.search(
+                        r"(.+)\sFAX", addresses[4].text_content()
+                    ).groups()[0]
+                    dis_addr_line1 = addresses[7].text_content()
+                    dis_addr_line2 = addresses[8].text_content()
+                    dis_addr_line3 = addresses[9].text_content()
+                    dis_phone = addresses[10].text_content()
+                else:
+                    capitol_fax = None
+                    dis_addr_line1 = addresses[6].text_content()
+                    dis_addr_line2 = addresses[7].text_content()
+                    if addresses[8].text_content().startswith("("):
+                        dis_addr_line3 = ""
+                        dis_phone = addresses[8].text_content()
+                        dis_fax = addresses[9].text_content()
+                    else:
+                        dis_addr_line3 = addresses[8].text_content()
+                        dis_phone = addresses[9].text_content()
+                        dis_fax = addresses[10].text_content()
+                email_or_fax = addresses[11].text_content()
+                if re.search(r"FAX", email_or_fax):
+                    dis_fax = re.search(r"(.+)\sFAX", email_or_fax).groups()[0]
+                    email = None
+                else:
+                    email = re.search(r"Email:\s(.+)", email_or_fax).groups()[0]
+                    dis_fax = None
+
+            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
+            district_addr = dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
+            district_addr = district_addr.strip()
+            return (
+                capitol_addr,
+                cap_phone,
+                capitol_fax,
+                district_addr,
+                dis_phone,
+                dis_fax,
+                email,
+            )
         elif len(addresses) == 14:
-            return (None, None, None, None, None, None, None)
+            cap_addr_line1 = addresses[2].text_content()
+            cap_addr_line2 = addresses[3].text_content()
+            cap_phone = addresses[4].text_content()
+            dis_addr_line1 = addresses[8].text_content()
+            dis_addr_line2 = addresses[9].text_content()
+            if addresses[10].text_content().startswith("("):
+                dis_phone = addresses[10].text_content()
+                dis_fax = addresses[11].text_content()
+                dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+                district_addr = dis_addr_line1 + " " + dis_addr_line2
+            else:
+                dis_addr_line3 = addresses[10].text_content()
+                dis_phone = addresses[11].text_content()
+                if addresses[12].text_content().startswith("("):
+                    dis_fax = addresses[12].text_content()
+                    dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
+                else:
+                    dis_fax = None
+                district_addr = (
+                    dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
+                )
+            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
+            return (
+                capitol_addr,
+                cap_phone,
+                None,
+                district_addr,
+                dis_phone,
+                dis_fax,
+                None,
+            )
         elif len(addresses) == 15:
             return (None, None, None, None, None, None, None)
 
         """
-        elif len(CSS("body table tr td.member").match(self.root)) == 12:
-            idx = 1
-            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 email
-        elif len(CSS("body table tr td.member").match(self.root)) == 13:
-            idx = 1
-            # 1 addr, 2 addr, 3 phone, 6 addr, 7 addr, 8 addr, 9 phone, 10 fax, 11 email
-            # 2, 3, 4, 8, 9, 10, 11
         elif len(CSS("body table tr td.member").match(self.root)) == 14:
             idx = 2
             # 2 addr, 3 addr, 4 phone, 8 addr, 9 addr, 10 addr, 11 phone, 12 fax

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -13,10 +13,11 @@ class LegDetail(HtmlPage):
         (
             capitol_addr,
             capitol_phone,
+            capitol_fax,
             district_addr,
             district_phone,
-            email,
             district_fax,
+            email,
         ) = self.process_addrs()
         if not capitol_addr:
             return None
@@ -45,7 +46,7 @@ class LegDetail(HtmlPage):
             cap_addr_line2 = addresses[2].text_content()
             cap_phone = addresses[3].text_content()
             capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            return (capitol_addr, cap_phone, None, None, None, None)
+            return (capitol_addr, cap_phone, None, None, None, None, None)
         elif len(addresses) == 10:
             # 3 house links have a length of 10
             # https://ilga.gov/house/Rep.asp?GA=102&MemberID=3006
@@ -60,7 +61,7 @@ class LegDetail(HtmlPage):
             dis_phone = addresses[8].text_content()
             capitol_addr = cap_addr_line1 + " " + cap_addr_line2
             district_addr = dis_addr_line1 + " " + dis_addr_line2
-            return (capitol_addr, cap_phone, district_addr, dis_phone, None, None)
+            return (capitol_addr, cap_phone, None, district_addr, dis_phone, None, None)
         elif len(addresses) == 11:
             # 34 house links have a length of 11
             # 0 senate links have a length of 11
@@ -78,13 +79,13 @@ class LegDetail(HtmlPage):
                     dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
                 )
                 email = None
-                fax = None
+                district_fax = None
             elif (
                 self.source.url == "https://ilga.gov/house/Rep.asp?GA=102&MemberID=3003"
             ):
                 # another special case, additional office link
                 email = None
-                fax = None
+                district_fax = None
                 dis_phone = addresses[8].text_content()
                 district_addr = dis_addr_line1 + " " + dis_addr_line2
             else:
@@ -93,26 +94,88 @@ class LegDetail(HtmlPage):
                 district_addr = dis_addr_line1 + " " + dis_addr_line2
 
                 if re.search(r"FAX", email_or_fax):
-                    fax = re.search(r"(.+)\sFAX", email_or_fax).groups()[0]
+                    district_fax = re.search(r"(.+)\sFAX", email_or_fax).groups()[0]
                     email = None
                     # p.district_office.fax = fax
                     # print(fax)
                 else:
                     email = re.search(r"Email:\s(.+)", email_or_fax).groups()[0]
-                    fax = None
+                    district_fax = None
                     # p.email = email.strip()
                     # print(email.strip())
 
             capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            return (capitol_addr, cap_phone, district_addr, dis_phone, email, fax)
+
+            return (
+                capitol_addr,
+                cap_phone,
+                None,
+                district_addr,
+                dis_phone,
+                district_fax,
+                email,
+            )
         elif len(addresses) == 12:
-            return (None, None, None, None, None, None)
+            # 42 house links have a length of 12
+            # 10 senate links ahve a length of 12
+            if re.search(r"(Senator|Representative)", addresses[1].text_content()):
+                cap_addr_line1 = addresses[2].text_content()
+                cap_addr_line2 = addresses[3].text_content()
+                cap_phone = addresses[4].text_content()
+                capitol_fax = None
+                dis_addr_line1 = addresses[8].text_content()
+                dis_addr_line2 = addresses[9].text_content()
+                dis_phone = addresses[10].text_content()
+                capitol_addr = cap_addr_line1 + " " + cap_addr_line2
+                district_addr = dis_addr_line1 + " " + dis_addr_line2
+                email = None
+                district_fax = None
+            else:
+                cap_addr_line1 = addresses[1].text_content()
+                cap_addr_line2 = addresses[2].text_content()
+                cap_phone = addresses[3].text_content()
+                if re.search(r"FAX", addresses[4].text_content()):
+                    capitol_fax = re.search(
+                        r"(.+)\sFAX", addresses[4].text_content()
+                    ).groups()[0]
+                    dis_addr_line1 = addresses[7].text_content()
+                    dis_addr_line2 = addresses[8].text_content()
+                    district_addr = dis_addr_line1 + " " + dis_addr_line2
+                else:
+                    capitol_fax = None
+                    dis_addr_line1 = addresses[6].text_content()
+                    dis_addr_line2 = addresses[7].text_content()
+                    dis_addr_line3 = addresses[8].text_content()
+                    district_addr = (
+                        dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
+                    )
+
+                dis_phone = addresses[9].text_content()
+                capitol_addr = cap_addr_line1 + " " + cap_addr_line2
+                email_or_fax = addresses[10].text_content()
+                if re.search(r"FAX", email_or_fax):
+                    district_fax = re.search(r"(.+)\sFAX", email_or_fax).groups()[0]
+                    email = None
+                    # p.district_office.fax = fax
+                    # print(fax)
+                else:
+                    email = re.search(r"Email:\s(.+)", email_or_fax).groups()[0]
+                    district_fax = None
+            return (
+                capitol_addr,
+                cap_phone,
+                capitol_fax,
+                district_addr,
+                dis_phone,
+                district_fax,
+                email,
+            )
         elif len(addresses) == 13:
-            return (None, None, None, None, None, None)
+            return (None, None, None, None, None, None, None)
         elif len(addresses) == 14:
-            return (None, None, None, None, None, None)
+            return (None, None, None, None, None, None, None)
         elif len(addresses) == 15:
-            return (None, None, None, None, None, None)
+            return (None, None, None, None, None, None, None)
 
         """
         elif len(CSS("body table tr td.member").match(self.root)) == 12:

--- a/scrapers_next/il/people.py
+++ b/scrapers_next/il/people.py
@@ -18,9 +18,7 @@ class LegDetail(HtmlPage):
             district_phone,
             district_fax,
             email,
-        ) = self.process_addrs_try_two()
-        # if not capitol_addr:
-        #     return None
+        ) = self.process_addrs()
 
         p.capitol_office.address = capitol_addr
         p.capitol_office.voice = capitol_phone
@@ -37,7 +35,12 @@ class LegDetail(HtmlPage):
 
         return p
 
-    def process_addrs_try_two(self):
+    def process_addrs(self):
+        """
+        For a given detail page, len(CSS("body table tr td.member").match(self.root))
+        can be either 7, 10, 11, 12, 13, 14, or 15. This function / for loop handles
+        pages with varies number of 'address' lines.
+        """
         (
             capitol_addr,
             cap_phone,
@@ -51,7 +54,7 @@ class LegDetail(HtmlPage):
         line_number = 0
         district_addr_lines = 0
         for line in addresses:
-            line = line.text_content()
+            line = line.text_content().strip()
             if (
                 line == "Springfield Office:"
                 or line == "District Office:"
@@ -105,13 +108,6 @@ class LegDetail(HtmlPage):
                 email = re.search(r"Email:\s(.+)", line).groups()[0].strip()
                 line_number += 1
 
-        # print(capitol_addr)
-        # print(cap_phone)
-        # print(capitol_fax)
-        # print(district_addr)
-        # print(dis_phone)
-        # print(dis_fax)
-        # print(email)
         return (
             capitol_addr,
             cap_phone,
@@ -121,351 +117,6 @@ class LegDetail(HtmlPage):
             dis_fax,
             email,
         )
-
-    def fax_or_email(self, email_or_fax):
-        if email_or_fax == "" or email_or_fax == "Additional District Addresses":
-            return (None, None)
-        elif re.search(r"FAX", email_or_fax):
-            return (re.search(r"(.+)\sFAX", email_or_fax).groups()[0], "fax")
-        else:
-            return (
-                re.search(r"Email:\s(.+)", email_or_fax).groups()[0].strip(),
-                "email",
-            )
-
-    def process_addrs(self):
-        addresses = CSS("body table tr td.member").match(self.root)
-        if len(addresses) == 7:
-            # no district information
-            # 1 house link has a length of 7
-            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=3012
-            # 0 senate links have a length of 7
-            cap_addr_line1 = addresses[1].text_content()
-            cap_addr_line2 = addresses[2].text_content()
-            cap_phone = addresses[3].text_content()
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            return (capitol_addr, cap_phone, None, None, None, None, None)
-        elif len(addresses) == 10:
-            # 3 house links have a length of 10
-            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=3006
-            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=2994
-            # https://ilga.gov/house/Rep.asp?GA=102&MemberID=2949
-            # 0 senate links have a length of 10
-            # no fax or email info
-            cap_addr_line1 = addresses[1].text_content()
-            cap_addr_line2 = addresses[2].text_content()
-            cap_phone = addresses[3].text_content()
-            dis_addr_line1 = addresses[6].text_content()
-            dis_addr_line2 = addresses[7].text_content()
-            dis_phone = addresses[8].text_content()
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            district_addr = dis_addr_line1 + " " + dis_addr_line2
-            return (capitol_addr, cap_phone, None, district_addr, dis_phone, None, None)
-        elif len(addresses) == 11:
-            # no capitol fax listed
-            # 34 house links have a length of 11
-            # 0 senate links have a length of 11
-            cap_addr_line1 = addresses[1].text_content()
-            cap_addr_line2 = addresses[2].text_content()
-            cap_phone = addresses[3].text_content()
-            dis_addr_line1 = addresses[6].text_content()
-            dis_addr_line2 = addresses[7].text_content()
-
-            # special case (extra line in district address)
-            if self.source.url == "https://ilga.gov/house/Rep.asp?GA=102&MemberID=2945":
-                dis_addr_line3 = addresses[8].text_content()
-                dis_phone = addresses[9].text_content()
-                district_addr = (
-                    dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
-                )
-                email = None
-                district_fax = None
-            elif (
-                self.source.url == "https://ilga.gov/house/Rep.asp?GA=102&MemberID=3003"
-            ):
-                # another special case, additional office link
-                email = None
-                district_fax = None
-                dis_phone = addresses[8].text_content()
-                district_addr = dis_addr_line1 + " " + dis_addr_line2
-            else:
-                dis_phone = addresses[8].text_content()
-                email_or_fax = addresses[9].text_content()
-                district_addr = dis_addr_line1 + " " + dis_addr_line2
-
-                (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                if e_or_f_sting == "fax":
-                    district_fax = email_or_fax
-                    email = None
-                else:
-                    email = email_or_fax.strip()
-                    district_fax = None
-
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            return (
-                capitol_addr,
-                cap_phone,
-                None,
-                district_addr,
-                dis_phone,
-                district_fax,
-                email,
-            )
-        elif len(addresses) == 12:
-            # 42 house links have a length of 12
-            # 10 senate links ahve a length of 12
-            if re.search(r"(Senator|Representative)", addresses[1].text_content()):
-                cap_addr_line1 = addresses[2].text_content()
-                cap_addr_line2 = addresses[3].text_content()
-                cap_phone = addresses[4].text_content()
-                capitol_fax = None
-                dis_addr_line1 = addresses[8].text_content()
-                dis_addr_line2 = addresses[9].text_content()
-                dis_phone = addresses[10].text_content()
-                capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-                district_addr = dis_addr_line1 + " " + dis_addr_line2
-                email = None
-                district_fax = None
-            else:
-                cap_addr_line1 = addresses[1].text_content()
-                cap_addr_line2 = addresses[2].text_content()
-                cap_phone = addresses[3].text_content()
-
-                email_or_fax = addresses[4].text_content()
-                (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                if e_or_f_sting == "fax":
-                    capitol_fax = email_or_fax
-                    dis_addr_line1 = addresses[7].text_content()
-                    dis_addr_line2 = addresses[8].text_content()
-                    district_addr = dis_addr_line1 + " " + dis_addr_line2
-                    dis_phone = addresses[9].text_content()
-                    email_or_fax = addresses[10].text_content()
-                    (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                    if e_or_f_sting == "fax":
-                        district_fax = email_or_fax
-                        email = None
-                    else:
-                        email = email_or_fax.strip()
-                        district_fax = None
-                else:
-                    capitol_fax = None
-                    dis_addr_line1 = addresses[6].text_content()
-                    if re.search(r"Mail\sOnly", addresses[7].text_content()):
-                        dis_addr_line2 = ""
-                    else:
-                        dis_addr_line2 = addresses[7].text_content()
-
-                    if addresses[8].text_content().startswith("("):
-                        district_addr = dis_addr_line1 + " " + dis_addr_line2
-                        dis_phone = addresses[8].text_content()
-                        district_fax = addresses[9].text_content()
-                        district_fax = re.search(r"(.+)\sFAX", district_fax).groups()[0]
-                        email = addresses[10].text_content()
-                        email = re.search(r"Email:\s(.+)", email).groups()[0].strip()
-                    else:
-                        dis_addr_line3 = addresses[8].text_content()
-                        district_addr = (
-                            dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
-                        )
-                        dis_phone = addresses[9].text_content()
-                        email_or_fax = addresses[10].text_content()
-                        (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                        if e_or_f_sting == "fax":
-                            district_fax = email_or_fax
-                            email = None
-                        else:
-                            email = email_or_fax.strip()
-                            district_fax = None
-
-                capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-
-            return (
-                capitol_addr,
-                cap_phone,
-                capitol_fax,
-                district_addr,
-                dis_phone,
-                district_fax,
-                email,
-            )
-        elif len(addresses) == 13:
-            # 28 house links have a length of 13
-            # 32 senate links ahve a length of 13
-            if re.search(r"(Senator|Representative)", addresses[1].text_content()):
-                cap_addr_line1 = addresses[2].text_content()
-                cap_addr_line2 = addresses[3].text_content()
-                cap_phone = addresses[4].text_content()
-                capitol_fax = None
-                dis_addr_line1 = addresses[8].text_content()
-                dis_addr_line2 = addresses[9].text_content()
-                if addresses[10].text_content().startswith("("):
-                    dis_addr_line3 = ""
-                    dis_phone = addresses[10].text_content()
-                    email_or_fax = addresses[11].text_content()
-                    (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                    dis_fax = email_or_fax
-                    email = None
-                else:
-                    dis_addr_line3 = addresses[10].text_content()
-                    dis_phone = addresses[11].text_content()
-                    dis_fax = None
-                    email = None
-            else:
-                cap_addr_line1 = addresses[1].text_content()
-                cap_addr_line2 = addresses[2].text_content()
-                cap_phone = addresses[3].text_content()
-                email_or_fax = addresses[4].text_content()
-                (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-
-                if e_or_f_sting == "fax":
-                    capitol_fax = email_or_fax
-                    dis_addr_line1 = addresses[7].text_content()
-                    dis_addr_line2 = addresses[8].text_content()
-                    if addresses[9].text_content().startswith("("):
-                        dis_addr_line3 = ""
-                        dis_phone = addresses[9].text_content()
-                        dis_fax = re.search(
-                            r"(.+)\sFAX", addresses[10].text_content()
-                        ).groups()[0]
-                        email = (
-                            re.search(r"Email:\s(.+)", addresses[11].text_content())
-                            .groups()[0]
-                            .strip()
-                        )
-                    else:
-                        dis_addr_line3 = addresses[9].text_content()
-                        dis_phone = addresses[10].text_content()
-                        email = (
-                            re.search(r"Email:\s(.+)", addresses[11].text_content())
-                            .groups()[0]
-                            .strip()
-                        )
-                else:
-                    capitol_fax = None
-                    dis_addr_line1 = addresses[6].text_content()
-                    dis_addr_line2 = addresses[7].text_content()
-                    if addresses[8].text_content().startswith("("):
-                        dis_addr_line3 = ""
-                        dis_phone = addresses[8].text_content()
-                        # dis_fax = addresses[9].text_content()
-                        dis_fax = re.search(
-                            r"(.+)\sFAX", addresses[9].text_content()
-                        ).groups()[0]
-                        email = (
-                            re.search(r"Email:\s(.+)", addresses[10].text_content())
-                            .groups()[0]
-                            .strip()
-                        )
-                    else:
-                        dis_addr_line3 = addresses[8].text_content()
-                        dis_phone = addresses[9].text_content()
-                        dis_fax = addresses[10].text_content()
-                        email = (
-                            re.search(r"Email:\s(.+)", addresses[11].text_content())
-                            .groups()[0]
-                            .strip()
-                        )
-
-                """
-                email_or_fax = addresses[11].text_content()
-                (email_or_fax, e_or_f_sting) = self.fax_or_email(email_or_fax)
-                if e_or_f_sting == 'fax':
-                    dis_fax = email_or_fax
-                    email = None
-                else:
-                    email = email_or_fax.strip()
-                    dis_fax = None
-                """
-
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            district_addr = dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
-            district_addr = district_addr.strip()
-
-            print(capitol_addr)
-            print(cap_phone)
-            if capitol_fax:
-                print(capitol_fax)
-            print(district_addr)
-            print(dis_phone)
-            if dis_fax:
-                print(dis_fax)
-            if email:
-                print(email)
-
-            return (
-                capitol_addr,
-                cap_phone,
-                capitol_fax,
-                district_addr,
-                dis_phone,
-                dis_fax,
-                email,
-            )
-        elif len(addresses) == 14:
-            # 10 house links have a length of 14
-            # 16 senate links ahve a length of 14
-            return (None, None, None, None, None, None, None)
-            """
-            cap_addr_line1 = addresses[2].text_content()
-            cap_addr_line2 = addresses[3].text_content()
-            cap_phone = addresses[4].text_content()
-            dis_addr_line1 = addresses[8].text_content()
-            dis_addr_line2 = addresses[9].text_content()
-            if addresses[10].text_content().startswith("("):
-                dis_phone = addresses[10].text_content()
-                dis_fax = addresses[11].text_content()
-            """
-            # dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
-            # district_addr = dis_addr_line1 + " " + dis_addr_line2
-            """
-            else:
-                dis_addr_line3 = addresses[10].text_content()
-                dis_phone = addresses[11].text_content()
-                if addresses[12].text_content().startswith("("):
-                    dis_fax = addresses[12].text_content()
-            """
-            # dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
-            """
-                else:
-                    dis_fax = None
-                district_addr = (
-                    dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
-                )
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            return (
-                capitol_addr,
-                cap_phone,
-                None,
-                district_addr,
-                dis_phone,
-                dis_fax,
-                None,
-            )
-            """
-        elif len(addresses) == 15:
-            # 0 house links have a length of 15
-            # 1 senate link has a length of 15
-            # https://ilga.gov/senate/Senator.asp?GA=102&MemberID=2899
-            cap_addr_line1 = addresses[2].text_content()
-            cap_addr_line2 = addresses[3].text_content()
-            cap_phone = addresses[4].text_content()
-            dis_addr_line1 = addresses[8].text_content()
-            dis_addr_line2 = addresses[9].text_content()
-            dis_addr_line3 = addresses[10].text_content()
-            dis_phone = addresses[11].text_content()
-            dis_fax = addresses[12].text_content()
-            dis_fax = re.search(r"(.+)\sFAX", dis_fax).groups()[0]
-            capitol_addr = cap_addr_line1 + " " + cap_addr_line2
-            district_addr = dis_addr_line1 + " " + dis_addr_line2 + " " + dis_addr_line3
-            return (
-                capitol_addr,
-                cap_phone,
-                None,
-                district_addr,
-                dis_phone,
-                dis_fax,
-                None,
-            )
 
 
 class LegList(HtmlListPage):


### PR DESCRIPTION
Re-writing the IL people scraper to use spatula framework. Currently scraping 59 Senators and 118 Representatives. Skipping over "Former Senate Members". process_addrs() handles pages with varying number of capitol/district address lines.

10 senators and 5 representatives have a link to a new page with "Additional District Addresses". I tried to write a class to capture these additional addresses, but could not get it to work. 
example: https://ilga.gov/house/Rep.asp?GA=102&MemberID=2879

@jamesturk 