### PR TITLE
Co people spatula clean

### DIFF
--- a/scrapers_next/co/people.py
+++ b/scrapers_next/co/people.py
@@ -1,0 +1,72 @@
+from spatula import CSS, HtmlListPage, HtmlPage, SelectorError
+from openstates.models import ScrapePerson
+
+
+class LegDetail(HtmlPage):
+    def process_page(self):
+        p = self.input
+
+        name = CSS("main header h1").match_one(self.root).text_content()
+        p.name = name
+
+        img = CSS("main img").match_one(self.root).get("src")
+        p.image = img
+
+        capitol_addr1 = CSS("div .thoroughfare").match_one(self.root).text_content()
+
+        try:
+            capitol_addr2 = CSS("div .premise").match_one(self.root).text_content()
+        except SelectorError:
+            capitol_addr2 = None
+
+        capitol_addr3 = (
+            CSS("div .addressfield-container-inline.locality-block.country-US")
+            .match_one(self.root)
+            .text_content()
+        )
+
+        if capitol_addr2:
+            capitol_addr = capitol_addr1 + " " + capitol_addr2 + " " + capitol_addr3
+        else:
+            capitol_addr = capitol_addr1 + " " + capitol_addr3
+        p.capitol_office.address = capitol_addr
+        # most of them have the same capitol_addr. just a mailing address?
+
+        return p
+
+
+class LegList(HtmlListPage):
+    source = "http://leg.colorado.gov/legislators"
+    selector = CSS("tbody tr", num_items=101)
+
+    def process_item(self, item):
+        title = CSS("td").match(item)[0].text_content().strip()
+        if title == "Representative":
+            chamber = "lower"
+        elif title == "Senator":
+            chamber = "upper"
+
+        district = CSS("td").match(item)[2].text_content()
+
+        party = CSS("td").match(item)[3].text_content()
+        if party == "Democrat":
+            party = "Democratic"
+
+        p = ScrapePerson(
+            name="",
+            state="co",
+            party=party,
+            chamber=chamber,
+            district=district,
+        )
+
+        p.capitol_office.voice = CSS("td").match(item)[4].text_content().strip()
+        p.email = CSS("td").match(item)[5].text_content().strip()
+
+        detail_link = CSS("td a").match_one(item).get("href")
+
+        p.add_source(self.source.url)
+        p.add_source(detail_link)
+        p.add_link(detail_link, note="homepage")
+
+        return LegDetail(p, source=detail_link)

--- a/scrapers_next/co/people.py
+++ b/scrapers_next/co/people.py
@@ -32,6 +32,20 @@ class LegDetail(HtmlPage):
         p.capitol_office.address = capitol_addr
         # most of them have the same capitol_addr. just a mailing address?
 
+        if len(CSS("div .legislator-content > div").match(self.root)) > 2:
+            title = (
+                CSS("div .legislator-content > div .field-items div")
+                .match(self.root)[2]
+                .text_content()
+            )
+            p.extras["title"] = title
+
+        counties = CSS("div .counties div .field-items div").match(self.root)
+        counties_rep = []
+        for county in counties:
+            counties_rep.append(county.text_content())
+        p.extras["counties represented"] = counties_rep
+
         return p
 
 


### PR DESCRIPTION
Writing Colorado people scraper using spatula framework. All Senators and Representatives have 200 E Colfax RM 307 Denver, CO 80203 or 200 E Colfax RM 346 Denver, CO 80203 or 200 E Colfax RM 272 Denver, CO 80203 as their 'mailing address'. I am currently assigning this to their capitol office address (see line 33). There are no district office addresses listed. 

This clean branch has the updated il directory from the main branch.

@jamesturk