### PR TITLE
CT people spatula scrape

### DIFF
--- a/scrapers_next/ct/people.py
+++ b/scrapers_next/ct/people.py
@@ -60,6 +60,8 @@ class LegList(CsvListPage):
         print("legislator url", legislator_url)
         p.add_link(legislator_url)
 
+        p.add_source(self.source.url)
+
         # the spacing of the address?
         office_address = "%s Room %s; %s" % (
             row["capitol street address"],
@@ -74,7 +76,7 @@ class LegList(CsvListPage):
 
         # spacing?
         if row["home street address"] and row["home city"]:
-            home_address = "{}\n{}, {} {}".format(
+            home_address = "{}; {}, {} {}".format(
                 row["home street address"],
                 row["home city"],
                 row["home state"],

--- a/scrapers_next/ct/people.py
+++ b/scrapers_next/ct/people.py
@@ -1,0 +1,54 @@
+# import attr
+from spatula import HtmlListPage, XPath, CSS
+
+# from openstates.models import ScrapePerson
+
+
+class LegList(HtmlListPage):
+    def process_item(self, item):
+        # print("hi", item.text_content())
+        # for td in CSS("td").match(item):
+        #     print("td.text ", td.text_content())
+        district, name, url, party, __ = CSS("td").match(item)
+
+        print("district", district.text_content())
+        print(name.text_content())
+
+        name = name.text_content().split(", ")
+        name = name[1] + " " + name[0]
+        name = name.replace("  ", " ")
+
+        print("NAME", name)
+        # TODO: nicer way to write this:
+        if district.text_content().startswith("S"):
+            district = district.text_content()[1:]
+            if district.startswith("0"):
+                district = district[1:]
+        print("district ", district)
+
+        party = party.text_content().strip()
+        if party == "D":
+            party = "Democrat"
+        elif party == "R":
+            party = "Republican"
+        print("PARTY ", party)
+
+        # p = ScrapePerson(
+        #     name = name,
+        #     state = "nj"
+        # )
+
+
+class SenList(LegList):
+    selector = CSS("#content tbody tr")
+    source = "https://www.cga.ct.gov/asp/menu/slist.asp"
+    chamber = "upper"
+
+
+class RepList(LegList):
+    selector = XPath(
+        "/html/body/table/tr[6]//p//a[contains(@href, 'BIO')][position()>40]",
+        num_items=80,
+    )
+    source = "https://www.cga.ct.gov/asp/menu/hlist.asp"
+    chamber = "lower"

--- a/scrapers_next/ct/people.py
+++ b/scrapers_next/ct/people.py
@@ -1,4 +1,3 @@
-# import attr
 from spatula import CsvListPage
 from openstates.models import ScrapePerson
 
@@ -7,7 +6,6 @@ class LegList(CsvListPage):
     source = "ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv"
 
     def process_item(self, row):
-        # name = "{} {} {}".format(row["first name"], row["middle initial"].strip(), row["last name"])
         name = row["first name"]
         mid = row["middle initial"].strip()
         if mid:
@@ -16,19 +14,11 @@ class LegList(CsvListPage):
         suffix = row["suffix"].strip()
         if suffix:
             name += " %s" % suffix
-        print("name", name)
 
-        if row["party"] == "Democrat" or "Republican":
-            party = row["party"]
-        else:
-            # TODO: party?
-            self.logger.warning("party warning")
-        print("party", party)
+        party = row["party"]
 
         district = row["dist"].lstrip("0")
         assert district.isdigit(), "Invalid district found: {}".format(district)
-
-        print("district", district)
 
         chamber = {"H": "lower", "S": "upper"}[row["office code"]]
 
@@ -37,11 +27,9 @@ class LegList(CsvListPage):
             if not email:
                 email = ""
             elif email.startswith("http://") or email.startswith("https://"):
-                # extra_office_fields['contact_form'] = email
                 email = ""
             else:
                 raise ValueError("Problematic email found: {}".format(email))
-        print("email", email)
 
         p = ScrapePerson(
             name=name,
@@ -50,14 +38,12 @@ class LegList(CsvListPage):
             district=district,
             party=party,
             email=email,
-            # image=image,
         )
 
         legislator_url = row["URL"].replace("\\", "//").strip()
         if legislator_url != "":
             if not legislator_url.startswith("http"):
                 legislator_url = "http://"
-        print("legislator url", legislator_url)
         p.add_link(legislator_url)
 
         p.add_source(self.source.url)
@@ -68,7 +54,6 @@ class LegList(CsvListPage):
             row["room number"],
             row["capitol city"].replace("  ", " "),
         )
-        print("office address", office_address)
         p.capitol_office.address = office_address
 
         if row["capitol phone"].strip():
@@ -82,7 +67,6 @@ class LegList(CsvListPage):
                 row["home state"],
                 row["home zip code"],
             )
-            print("home address", home_address)
 
             if "Legislative Office Building" not in home_address:
                 p.district_office.address = home_address

--- a/scrapers_next/ct/people.py
+++ b/scrapers_next/ct/people.py
@@ -1,54 +1,105 @@
 # import attr
-from spatula import HtmlListPage, XPath, CSS
-
-# from openstates.models import ScrapePerson
-
-
-class LegList(HtmlListPage):
-    def process_item(self, item):
-        # print("hi", item.text_content())
-        # for td in CSS("td").match(item):
-        #     print("td.text ", td.text_content())
-        district, name, url, party, __ = CSS("td").match(item)
-
-        print("district", district.text_content())
-        print(name.text_content())
-
-        name = name.text_content().split(", ")
-        name = name[1] + " " + name[0]
-        name = name.replace("  ", " ")
-
-        print("NAME", name)
-        # TODO: nicer way to write this:
-        if district.text_content().startswith("S"):
-            district = district.text_content()[1:]
-            if district.startswith("0"):
-                district = district[1:]
-        print("district ", district)
-
-        party = party.text_content().strip()
-        if party == "D":
-            party = "Democrat"
-        elif party == "R":
-            party = "Republican"
-        print("PARTY ", party)
-
-        # p = ScrapePerson(
-        #     name = name,
-        #     state = "nj"
-        # )
+from spatula import CsvListPage
+from openstates.models import ScrapePerson
 
 
-class SenList(LegList):
-    selector = CSS("#content tbody tr")
-    source = "https://www.cga.ct.gov/asp/menu/slist.asp"
-    chamber = "upper"
+class LegList(CsvListPage):
+    source = "ftp://ftp.cga.ct.gov/pub/data/LegislatorDatabase.csv"
 
+    def process_item(self, row):
+        # name = "{} {} {}".format(row["first name"], row["middle initial"].strip(), row["last name"])
+        name = row["first name"]
+        mid = row["middle initial"].strip()
+        if mid:
+            name += " %s" % mid
+        name += " %s" % row["last name"]
+        suffix = row["suffix"].strip()
+        if suffix:
+            name += " %s" % suffix
+        print("name", name)
 
-class RepList(LegList):
-    selector = XPath(
-        "/html/body/table/tr[6]//p//a[contains(@href, 'BIO')][position()>40]",
-        num_items=80,
-    )
-    source = "https://www.cga.ct.gov/asp/menu/hlist.asp"
-    chamber = "lower"
+        if row["party"] == "Democrat" or "Republican":
+            party = row["party"]
+        else:
+            # TODO: party?
+            self.logger.warning("party warning")
+        print("party", party)
+
+        district = row["dist"].lstrip("0")
+        assert district.isdigit(), "Invalid district found: {}".format(district)
+
+        print("district", district)
+
+        chamber = {"H": "lower", "S": "upper"}[row["office code"]]
+
+        email = row["email"].strip()
+        if "@" not in email:
+            if not email:
+                email = ""
+            elif email.startswith("http://") or email.startswith("https://"):
+                # extra_office_fields['contact_form'] = email
+                email = ""
+            else:
+                raise ValueError("Problematic email found: {}".format(email))
+        print("email", email)
+
+        p = ScrapePerson(
+            name=name,
+            state="ct",
+            chamber=chamber,
+            district=district,
+            party=party,
+            email=email,
+            # image=image,
+        )
+
+        legislator_url = row["URL"].replace("\\", "//").strip()
+        if legislator_url != "":
+            if not legislator_url.startswith("http"):
+                legislator_url = "http://"
+        print("legislator url", legislator_url)
+        p.add_link(legislator_url)
+
+        # the spacing of the address?
+        office_address = "%s Room %s; %s" % (
+            row["capitol street address"],
+            row["room number"],
+            row["capitol city"].replace("  ", " "),
+        )
+        print("office address", office_address)
+        p.capitol_office.address = office_address
+
+        if row["capitol phone"].strip():
+            p.capitol_office.voice = row["capitol phone"]
+
+        # spacing?
+        if row["home street address"] and row["home city"]:
+            home_address = "{}\n{}, {} {}".format(
+                row["home street address"],
+                row["home city"],
+                row["home state"],
+                row["home zip code"],
+            )
+            print("home address", home_address)
+
+            if "Legislative Office Building" not in home_address:
+                p.district_office.address = home_address
+
+        types = [
+            "gender",
+            "title",
+            "committee member1",
+            "committee codes",
+            "business phone",
+            "fax",
+            "prison",
+        ]
+
+        for type in types:
+            if row[type] != " ":
+                if type == "committee member1":
+                    type_changed = "committees"
+                    p.extras[type_changed] = row[type]
+                else:
+                    p.extras[type] = row[type]
+        return p

--- a/scrapers_next/ct/people.py
+++ b/scrapers_next/ct/people.py
@@ -9,11 +9,11 @@ class LegList(CsvListPage):
         name = row["first name"]
         mid = row["middle initial"].strip()
         if mid:
-            name += " %s" % mid
-        name += " %s" % row["last name"]
+            name += f" {mid}"
+        name += f" {row['last name']}"
         suffix = row["suffix"].strip()
         if suffix:
-            name += " %s" % suffix
+            name += f" {suffix}"
 
         party = row["party"]
 
@@ -48,8 +48,7 @@ class LegList(CsvListPage):
 
         p.add_source(self.source.url)
 
-        # the spacing of the address?
-        office_address = "%s Room %s; %s" % (
+        office_address = "{} Room {}; {}".format(
             row["capitol street address"],
             row["room number"],
             row["capitol city"].replace("  ", " "),
@@ -59,7 +58,6 @@ class LegList(CsvListPage):
         if row["capitol phone"].strip():
             p.capitol_office.voice = row["capitol phone"]
 
-        # spacing?
         if row["home street address"] and row["home city"]:
             home_address = "{}; {}, {} {}".format(
                 row["home street address"],
@@ -68,7 +66,10 @@ class LegList(CsvListPage):
                 row["home zip code"],
             )
 
-            if "Legislative Office Building" not in home_address:
+            if (
+                "Legislative Office Building"
+                and "Legislative Office Bldg" not in home_address
+            ):
                 p.district_office.address = home_address
 
         types = [


### PR DESCRIPTION
- the old scraper listed the reps' home address as their district office address so I did the same, but wanted to check if this was still okay
- listed the committees each rep is on only as extra information, not as an Organization object like the old scraper
- I've never used `assert` for the scrapers but just included the line because the old version had it
- I usually do some sort of party checking, but figured that this is already done during scraper, but wanted to make sure this is the case!
- apologies for the few commits, will commit more often next time!