### PR TITLE
MI committee spatula scrape

### DIFF
--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -10,49 +10,82 @@ class SenateCommitteeDetail(HtmlPage):
     def process_page(self):
         # com = self.input
         print("a new comm")
+        # print("item name", )
+        print("self source url", self.source.url)
 
 
 class SenateCommitteeList(HtmlListPage):
     source = "https://committees.senate.michigan.gov/"
-    selector = CSS("form .col-md-6")
+    selector = CSS("form .col-md-6 ul li")
+    # since im passing the selector off to another function, selector must be the actual link?
     chamber = "upper"
 
     def process_item(self, item):
         try:
-            title = CSS("h3").match(item)
+            # title = CSS("h3").match(item)
+            title = XPath("..//preceding-sibling::h3/text()").match(item)
+            # print("try title", title)
+
         except SelectorError:
-            title = XPath("..//preceding-sibling::h3").match(item)
+            title = XPath("../../..//preceding-sibling::h3/text()").match(item)
+            # print("try title", title)
 
         for comm_name in title:
-            # try:
-            print(comm_name.text_content())
-            comm_name = comm_name.text_content()
-            # except SelectorError:
-            if comm_name == "Standing Committees":
-                for committee in CSS("ul li").match(item):
+            # print("single title", comm_name)
 
-                    name = committee.text_content()
+            #    for comm_name in title:
+            # print("single title:", comm_name)
+            if (
+                comm_name == "Standing Committees"
+                or comm_name == "Appropriations Subcommittees"
+            ):
+                name_link = CSS("a").match_one(item)
+                name = name_link.text_content()
+                # print("NAME: ", name)
+                source = name_link.get("href")
+                # print("source: ", source)
+                if comm_name == "Standing Committees":
                     com = ScrapeCommittee(name=name, chamber=self.chamber)
-                    # print("com", com)
-                    # print("source OKAY", CSS("a").match_one(committee).get("href"))
-                    source = CSS("a").match_one(committee).get("href")
-                    # print("HERE")
-                    return SenateCommitteeDetail(com, source=source)
-            elif comm_name == "Appropriations Subcommittees":
-                for committee in CSS("ul li").match(item):
-
-                    name = committee.text_content()
+                else:
                     com = ScrapeCommittee(
                         name=name,
                         classification="subcommittee",
                         chamber=self.chamber,
                         parent="Appropriations",
                     )
-                    # print("com", com)
-                    source = CSS("a").match_one(committee).get("href")
-                    # print("HERE2")
-                    return SenateCommitteeDetail(com, source=source)
-            # return SenateCommitteeDetail(com, source=item.get("href"))
+                return SenateCommitteeDetail(com, source=source)
+
+        # for comm_name in title:
+        #     # try:
+        #     print(comm_name.text_content())
+        #     comm_name = comm_name.text_content()
+        #     # except SelectorError:
+        #     if comm_name == "Standing Committees":
+        #         for committee in CSS("ul li").match(item):
+
+        #             name = committee.text_content()
+        #             com = ScrapeCommittee(name=name, chamber=self.chamber)
+        #         #     # print("com", com)
+        #         #     # print("source OKAY", CSS("a").match_one(committee).get("href"))
+        #             source = CSS("a").match_one(committee).get("href")
+        #         #     # print("HERE")
+        #             # yield SenateCommitteeDetail(com, source=source)
+        #         # return [SenateCommitteeDetail(ScrapeCommittee(name=committee.text_content(), chamber=self.chamber), source=CSS("a").match_one(committee).get("href")) for committee in CSS("ul li").match(item)]
+        #     elif comm_name == "Appropriations Subcommittees":
+        #         for committee in CSS("ul li").match(item):
+
+        #             name = committee.text_content()
+        #             com = ScrapeCommittee(
+        #                 name=name,
+        #                 classification="subcommittee",
+        #                 chamber=self.chamber,
+        #                 parent="Appropriations",
+        #             )
+        #             # print("com", com)
+        #             source = CSS("a").match_one(committee).get("href")
+        # print("HERE2")
+        # return SenateCommitteeDetail(com, source=source)
+        # return SenateCommitteeDetail(com, source=item.get("href"))
 
 
 class HouseCommitteeList(HtmlListPage):

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -4,14 +4,73 @@ from openstates.models import ScrapeCommittee
 
 class SenateCommitteeDetail(HtmlPage):
     example_source = (
-        "https://www.senate.mn/committees/committee_bio.html?cmte_id=3087&ls=92"
+        "https://committees.senate.michigan.gov/details?com=ADVC&sessionId=14"
     )
 
     def process_page(self):
         # com = self.input
-        print("a new comm")
+        # print("a new comm")
         # print("item name", )
         print("self source url", self.source.url)
+
+        com = self.input
+        # com.add_source(self.source.url)
+        # com.add_link(self.source.url, note="homepage")
+
+        # committee chair
+        # chair = CSS("#MainContent_HLChair").match_one(self.root).text_content().strip()
+        # print("CHAIR: ", chair)
+
+        # comm members
+        members = CSS("#MainContent_BLMembers li").match(self.root)
+        for member in members:
+
+            member = member.text_content().strip().replace("(D)", "").replace("(R)", "")
+            print("here's a member: ", member)
+            positions = ["Majority Vice Chair", "Minority Vice Chair", "Chair"]
+            # if member.endswith("Majority Vice Chair"):
+            #     position = "Majority Vice Chair"
+            # if member.endswith("Minority Vice Chair"):
+            #     position = "Majority Vice Chair"
+            # if any(member for things in positions):
+            #     print('what', things)
+
+            if any(ext in member for ext in positions):
+                print("okay then", positions)
+            # print [extension for extension in positions if(extension in member)]
+            for position in positions:
+                if member.endswith(position):
+                    position_str = position
+                    break
+                else:
+                    position_str = "member"
+            print("FINAL", member.split("  ")[0], position_str)
+
+            com.add_member(member.split("  ")[0], position_str)
+
+        # extras (clerk and phone number)
+        clerk = CSS("#MainContent_HLComClerk").match_one(self.root).text_content()
+        print("CLERK", clerk)
+        com.extras["clerk"] = clerk
+        com.extras["clerk phone number"] = (
+            CSS("#MainContent_HLCCPhone").match_one(self.root).text_content()
+        )
+
+        # meeting schedule
+        # MainContent_lblDayTime
+        com.extras["meeting time"] = (
+            CSS("#MainContent_lblDayTime").match_one(self.root).text_content()
+        )
+        meeting_location = (
+            CSS("#MainContent_lblLocation").match_one(self.root).text_content()
+        )
+        # TODO: add semicolon after "Building"
+        com.extras["meeting location"] = (
+            # CSS("#MainContent_lblLocation").match_one(self.root).text_content()
+            meeting_location
+        )
+
+        # TODO: links are not directly related?
 
 
 class SenateCommitteeList(HtmlListPage):

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -139,24 +139,24 @@ class HouseCommitteeDetail(HtmlPage):
 
     def process_page(self):
         print("self source url", self.source.url)
-        # TODO: look for subcommittees
+
         com = self.input
-        # com.add_source(self.source.url)
-        # com.add_link(self.source.url, note="homepage")
+        com.add_source(self.source.url)
+        com.add_link(self.source.url, note="homepage")
 
         # comm members
         member_position = CSS("#divMembers div").match(self.root)
         member_name = CSS("#divMembers a").match(self.root)
 
-        print("member pos", member_position)
+        # print("member pos", member_position)
 
-        for i in member_position:
-            print("here's a member pos REALLY", i.text_content())
-        print("member name", member_name)
+        # for i in member_position:
+        #     print("here's a member pos REALLY", i.text_content())
+        # print("member name", member_name)
 
         positions = ["Majority Vice-Chair", "Minority Vice-Chair", "Committee Chair"]
         # TODO: warning if none of the positions are triggered?
-        # TODO:
+        # TODO: subcommittees in Appropriations (only there??)
 
         # ex: [Majority Vice-Chair, 106th District, Committee Chair]
         num_members = range(len(member_name))
@@ -177,8 +177,8 @@ class HouseCommitteeDetail(HtmlPage):
             # else:
             # pos = "member"
             # com.add_member(member_name[i], "member")
-            print(member_name[i].text_content(), pos)
-            # com.add_member(member_name[i], pos)
+            # print(member_name[i].text_content(), pos)
+            com.add_member(member_name[i].text_content(), pos)
 
             # extra clerk info
         # clerk = CSS("#divClerk a").match_one(self.root).text_content()
@@ -189,6 +189,17 @@ class HouseCommitteeDetail(HtmlPage):
         com.extras["clerk phone number"] = (
             CSS("#divClerk").match_one(self.root).text_content()[-10:]
         )
+
+        com.add_link(CSS("#lnkSubscribe").match_one(self.root).get("href"))
+        com.add_link(CSS("#hlPublicVCommitteeSched").match_one(self.root).get("href"))
+
+        # TODO: look for subcommittees
+        # try:
+        #     subcommittee = CSS("#lnkSubcommittees").match_one(self.root).get("href")
+        #     scrapesubcommittees(com, subcommittee)
+        # except SelectorError:
+
+        return com
 
 
 class HouseCommitteeList(HtmlListPage):

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -10,8 +10,6 @@ class SenateCommitteeDetail(HtmlPage):
 
     def process_page(self):
 
-        print("self source url", self.source.url)
-
         com = self.input
         com.add_source(self.source.url)
         com.add_link(self.source.url, note="homepage")
@@ -112,7 +110,6 @@ class HouseCommitteeDetail(HtmlPage):
     )
 
     def process_page(self):
-        print("self source url", self.source.url)
 
         com = self.input
         com.add_source(self.source.url)

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -16,7 +16,6 @@ class SenateCommitteeDetail(HtmlPage):
         com.add_source(self.source.url)
         com.add_link(self.source.url, note="homepage")
 
-        # comm members
         members = CSS("#MainContent_BLMembers li").match(self.root)
         for member in members:
 
@@ -32,15 +31,12 @@ class SenateCommitteeDetail(HtmlPage):
 
             com.add_member(member.split("  ")[0], position_str)
 
-        # extras (clerk and phone number)
         clerk = CSS("#MainContent_HLComClerk").match_one(self.root).text_content()
 
         com.extras["clerk"] = clerk
         com.extras["clerk phone number"] = (
             CSS("#MainContent_HLCCPhone").match_one(self.root).text_content()
         )
-
-        # meeting schedule
 
         com.extras["meeting time"] = (
             CSS("#MainContent_lblDayTime").match_one(self.root).text_content()
@@ -49,8 +45,7 @@ class SenateCommitteeDetail(HtmlPage):
             CSS("#MainContent_lblLocation").match_one(self.root).text_content()
         )
 
-        # if "Room" is the last word on the line, add a space
-
+        # This is some formatting to make the address easier to read
         if "Building" in meeting_location:
             meeting = re.split("(Building)", meeting_location)
             meeting = meeting[0] + meeting[1] + "; " + meeting[2]
@@ -62,21 +57,14 @@ class SenateCommitteeDetail(HtmlPage):
             if " Room" in meeting_location:
                 room = re.split("(Room)|(Tower)", meeting_location)
                 meeting = f"{room[0]}{room[1]}; {room[3]}{room[5]}; {room[6]}"
-                # meeting = room[0] + room[1] + "; " + meeting[0] + meeting[1] + "; " + meeting[2]
             else:
                 meeting = meeting[0] + meeting[1] + "; " + meeting[2]
-        # print("BUILDING MEETING", meeting)
+
         elif "Call of the Chair" in meeting_location:
             meeting = "Call of the Chair"
 
-        print("MEETING", meeting)
-        # TODO: add semicolon after "Building"
-        com.extras["meeting location"] = (
-            # CSS("#MainContent_lblLocation").match_one(self.root).text_content()
-            meeting
-        )
+        com.extras["meeting location"] = meeting
 
-        # TODO: links are not directly related?
         com.add_link(CSS("#MainContent_HLcbr").match_one(self.root).get("href"))
         com.add_link(CSS("#MainContent_HyperLink1").match_one(self.root).get("href"))
         com.add_link(CSS("#MainContent_HLComAudio").match_one(self.root).get("href"))
@@ -103,9 +91,7 @@ class SenateCommitteeList(HtmlListPage):
             ):
                 name_link = CSS("a").match_one(item)
                 name = name_link.text_content()
-                # print("NAME: ", name)
                 source = name_link.get("href")
-                # print("source: ", source)
                 if comm_name == "Standing Committees":
                     com = ScrapeCommittee(name=name, chamber=self.chamber)
                 else:
@@ -132,7 +118,6 @@ class HouseCommitteeDetail(HtmlPage):
         com.add_source(self.source.url)
         com.add_link(self.source.url, note="homepage")
 
-        # comm members
         member_position = CSS("#divMembers div").match(self.root)
         member_name = CSS("#divMembers a").match(self.root)
 
@@ -156,7 +141,7 @@ class HouseCommitteeDetail(HtmlPage):
         com.add_link(CSS("#lnkSubscribe").match_one(self.root).get("href"))
         com.add_link(CSS("#hlPublicVCommitteeSched").match_one(self.root).get("href"))
 
-        # TODO: look for subcommittees
+        # attempt at subcommittees
         # try:
         #     subcommittee = CSS("#lnkSubcommittees").match_one(self.root).get("href")
         #     print("SUBCOMM link", subcommittee)
@@ -180,10 +165,9 @@ class HouseSubcommitteeDetail(HtmlListPage):
     chamber = "lower"
 
     def process_item(self, item):
-        print("this is a subcommittee of", self.input.source)
 
         com = ScrapeCommittee(
-            name="hello",
+            name="name",
             classification="subcommittee",
             chamber=self.chamber,
             parent=CSS("#lblTitle")
@@ -195,7 +179,8 @@ class HouseSubcommitteeDetail(HtmlListPage):
         return com
 
 
-class HouseSubcommittees(HtmlListPage):
+# Due to faulty subcommittee webpages, this doesn't work as intended right now
+class HouseSubcommitteeList(HtmlListPage):
     source = "https://www.house.mi.gov/mhrpublic/committee.aspx"
     selector = CSS("select option")
     chamber = "lower"
@@ -204,14 +189,6 @@ class HouseSubcommittees(HtmlListPage):
         name = item.text_content()
         if name != "Statutory Committees" and name != "Select One":
             comcode = item.get("value")
-
-            # com = ScrapeCommittee(
-            #             name=name,
-            #             classification="subcommittee",
-            #             chamber=self.chamber,
-            #             parent=CSS("#lblTitle").match_one(item).text_content().replace("HOUSE", "").replace("SUBCOMMITTEES", ""),
-            #         )
-
             return HouseSubcommitteeDetail(
                 source="https://www.house.mi.gov/MHRPublic/SubCommittee.aspx?comcode="
                 + comcode,

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -132,6 +132,17 @@ class SenateCommitteeList(HtmlListPage):
                 self.skip()
 
 
+class HouseSubcommittees(HtmlListPage):
+    # source = "https://www.house.mi.gov/mhrpublic/committee.aspx"
+    selector = CSS("#DataList1 tr td")
+    chamber = "lower"
+
+    def process_item(self, item):
+        print("subcommittees gonna be processed")
+        com = ScrapeCommittee(name="hello subcomm", chamber="lower")
+        return com
+
+
 class HouseCommitteeDetail(HtmlPage):
     example_source = (
         "https://www.house.mi.gov/MHRPublic/CommitteeInfo.aspx?comcode=AGRI"
@@ -148,42 +159,19 @@ class HouseCommitteeDetail(HtmlPage):
         member_position = CSS("#divMembers div").match(self.root)
         member_name = CSS("#divMembers a").match(self.root)
 
-        # print("member pos", member_position)
-
-        # for i in member_position:
-        #     print("here's a member pos REALLY", i.text_content())
-        # print("member name", member_name)
-
         positions = ["Majority Vice-Chair", "Minority Vice-Chair", "Committee Chair"]
         # TODO: warning if none of the positions are triggered?
-        # TODO: subcommittees in Appropriations (only there??)
 
         # ex: [Majority Vice-Chair, 106th District, Committee Chair]
         num_members = range(len(member_name))
 
         for i in num_members:
             member_pos_str = member_position[i].text_content()
-
-            # if member_pos_str in positions:
-            # pos = member_pos_str
-            # com.add_member(member_name[i], member_position[i])
-            # if ["Majority Vice-Chair", "Minority Vice-Chair", "Committee Chair"] in member_pos_str:
-            #     print("OH I SEE")
             pos = "member"
             for position in positions:
                 if position in member_pos_str:
                     pos = position
-                    # print("I WAS REACHED")
-            # else:
-            # pos = "member"
-            # com.add_member(member_name[i], "member")
-            # print(member_name[i].text_content(), pos)
             com.add_member(member_name[i].text_content(), pos)
-
-            # extra clerk info
-        # clerk = CSS("#divClerk a").match_one(self.root).text_content()
-        # clerk_phone = CSS("#divClerk").match_one(self.root).text_content()[-10:]
-        # print(clerk, clerk_phone)
 
         com.extras["clerk"] = CSS("#divClerk a").match_one(self.root).text_content()
         com.extras["clerk phone number"] = (
@@ -196,8 +184,17 @@ class HouseCommitteeDetail(HtmlPage):
         # TODO: look for subcommittees
         # try:
         #     subcommittee = CSS("#lnkSubcommittees").match_one(self.root).get("href")
-        #     scrapesubcommittees(com, subcommittee)
+        #     print("SUBCOMM link", subcommittee)
+        #     # return HouseSubcommittees(com, source=subcommittee)
         # except SelectorError:
+        #     print("no subcom")
+        #     pass
+
+        subcommittee = CSS("#lnkSubcommittees").match_one(self.root).get("href")
+        if subcommittee is not None:
+            print("SUBCOMM link", subcommittee)
+            return com, HouseSubcommittees(com, source=subcommittee)
+        # else:
 
         return com
 

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -9,18 +9,12 @@ class SenateCommitteeDetail(HtmlPage):
     )
 
     def process_page(self):
-        # com = self.input
-        # print("a new comm")
-        # print("item name", )
+
         print("self source url", self.source.url)
 
         com = self.input
         com.add_source(self.source.url)
         com.add_link(self.source.url, note="homepage")
-
-        # committee chair
-        # chair = CSS("#MainContent_HLChair").match_one(self.root).text_content().strip()
-        # print("CHAIR: ", chair)
 
         # comm members
         members = CSS("#MainContent_BLMembers li").match(self.root)
@@ -29,16 +23,7 @@ class SenateCommitteeDetail(HtmlPage):
             member = member.text_content().strip().replace("(D)", "").replace("(R)", "")
             # print("here's a member: ", member)
             positions = ["Majority Vice Chair", "Minority Vice Chair", "Chair"]
-            # if member.endswith("Majority Vice Chair"):
-            #     position = "Majority Vice Chair"
-            # if member.endswith("Minority Vice Chair"):
-            #     position = "Majority Vice Chair"
-            # if any(member for things in positions):
-            #     print('what', things)
 
-            # if any(ext in member for ext in positions):
-            # print("okay then", positions)
-            # print [extension for extension in positions if(extension in member)]
             for position in positions:
                 if member.endswith(position):
                     position_str = position
@@ -69,7 +54,6 @@ class SenateCommitteeDetail(HtmlPage):
         # TODO: still iffy for Approps comm: "Room, "
 
         # if "Room" is the last word on the line, add a space
-        # if " Room" in meeting_location:
 
         if "Building" in meeting_location:
             meeting = re.split("(Building)", meeting_location)
@@ -154,18 +138,21 @@ class HouseCommitteeDetail(HtmlPage):
     )
 
     def process_page(self):
-        # com = self.input
-        # print("a new comm")
-        # print("item name", )
         print("self source url", self.source.url)
-
+        # TODO: look for subcommittees
         com = self.input
-        com.add_source(self.source.url)
-        com.add_link(self.source.url, note="homepage")
+        # com.add_source(self.source.url)
+        # com.add_link(self.source.url, note="homepage")
 
         # comm members
-        member_position = CSS("#divMembers").match(self.root)
-        member_name = CSS("a").match(member_position)
+        member_position = CSS("#divMembers div").match(self.root)
+        member_name = CSS("#divMembers a").match(self.root)
+
+        print("member pos", member_position)
+
+        for i in member_position:
+            print("here's a member pos REALLY", i.text_content())
+        print("member name", member_name)
 
         positions = ["Majority Vice-Chair", "Minority Vice-Chair", "Committee Chair"]
         # TODO: warning if none of the positions are triggered?
@@ -175,30 +162,33 @@ class HouseCommitteeDetail(HtmlPage):
         num_members = range(len(member_name))
 
         for i in num_members:
-            if member_position[i] in positions:
-                pos = member_position[i]
-                # com.add_member(member_name[i], member_position[i])
-            else:
-                pos = "member"
-                # com.add_member(member_name[i], "member")
-            com.add_member(member_name[i], pos)
+            member_pos_str = member_position[i].text_content()
 
-        # extras (clerk and phone number)
-        clerk = CSS("#MainContent_HLComClerk").match_one(self.root).text_content()
-        # print("CLERK", clerk)
-        com.extras["clerk"] = clerk
+            # if member_pos_str in positions:
+            # pos = member_pos_str
+            # com.add_member(member_name[i], member_position[i])
+            # if ["Majority Vice-Chair", "Minority Vice-Chair", "Committee Chair"] in member_pos_str:
+            #     print("OH I SEE")
+            pos = "member"
+            for position in positions:
+                if position in member_pos_str:
+                    pos = position
+                    # print("I WAS REACHED")
+            # else:
+            # pos = "member"
+            # com.add_member(member_name[i], "member")
+            print(member_name[i].text_content(), pos)
+            # com.add_member(member_name[i], pos)
+
+            # extra clerk info
+        # clerk = CSS("#divClerk a").match_one(self.root).text_content()
+        # clerk_phone = CSS("#divClerk").match_one(self.root).text_content()[-10:]
+        # print(clerk, clerk_phone)
+
+        com.extras["clerk"] = CSS("#divClerk a").match_one(self.root).text_content()
         com.extras["clerk phone number"] = (
-            CSS("#MainContent_HLCCPhone").match_one(self.root).text_content()
+            CSS("#divClerk").match_one(self.root).text_content()[-10:]
         )
-
-        # meeting schedule
-        # MainContent_lblDayTime
-        com.extras["meeting time"] = (
-            CSS("#MainContent_lblDayTime").match_one(self.root).text_content()
-        )
-        # meeting_location = (
-        #     CSS("#MainContent_lblLocation").match_one(self.root).text_content()
-        # )
 
 
 class HouseCommitteeList(HtmlListPage):

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -67,12 +67,24 @@ class SenateCommitteeDetail(HtmlPage):
         )
         # meeting = meeting_location.split("(Building)")
         # TODO: still iffy for Approps comm: "Room, "
+
+        # if "Room" is the last word on the line, add a space
+        # if " Room" in meeting_location:
+
         if "Building" in meeting_location:
             meeting = re.split("(Building)", meeting_location)
             meeting = meeting[0] + meeting[1] + "; " + meeting[2]
+            if " Room" in meeting_location:
+                room = re.split("(Room)|(Building)", meeting_location)
+                meeting = f"{room[0]}{room[1]}; {room[3]}{room[5]}; {room[6]}"
         elif "Tower" in meeting_location:
             meeting = re.split("(Tower)", meeting_location)
-            meeting = meeting[0] + meeting[1] + "; " + meeting[2]
+            if " Room" in meeting_location:
+                room = re.split("(Room)|(Tower)", meeting_location)
+                meeting = f"{room[0]}{room[1]}; {room[3]}{room[5]}; {room[6]}"
+                # meeting = room[0] + room[1] + "; " + meeting[0] + meeting[1] + "; " + meeting[2]
+            else:
+                meeting = meeting[0] + meeting[1] + "; " + meeting[2]
         # print("BUILDING MEETING", meeting)
         elif "Call of the Chair" in meeting_location:
             meeting = "Call of the Chair"
@@ -134,38 +146,6 @@ class SenateCommitteeList(HtmlListPage):
                 return SenateCommitteeDetail(com, source=source)
             else:
                 return None
-
-        # for comm_name in title:
-        #     # try:
-        #     print(comm_name.text_content())
-        #     comm_name = comm_name.text_content()
-        #     # except SelectorError:
-        #     if comm_name == "Standing Committees":
-        #         for committee in CSS("ul li").match(item):
-
-        #             name = committee.text_content()
-        #             com = ScrapeCommittee(name=name, chamber=self.chamber)
-        #         #     # print("com", com)
-        #         #     # print("source OKAY", CSS("a").match_one(committee).get("href"))
-        #             source = CSS("a").match_one(committee).get("href")
-        #         #     # print("HERE")
-        #             # yield SenateCommitteeDetail(com, source=source)
-        #         # return [SenateCommitteeDetail(ScrapeCommittee(name=committee.text_content(), chamber=self.chamber), source=CSS("a").match_one(committee).get("href")) for committee in CSS("ul li").match(item)]
-        #     elif comm_name == "Appropriations Subcommittees":
-        #         for committee in CSS("ul li").match(item):
-
-        #             name = committee.text_content()
-        #             com = ScrapeCommittee(
-        #                 name=name,
-        #                 classification="subcommittee",
-        #                 chamber=self.chamber,
-        #                 parent="Appropriations",
-        #             )
-        #             # print("com", com)
-        #             source = CSS("a").match_one(committee).get("href")
-        # print("HERE2")
-        # return SenateCommitteeDetail(com, source=source)
-        # return SenateCommitteeDetail(com, source=item.get("href"))
 
 
 class HouseCommitteeList(HtmlListPage):

--- a/scrapers_next/mi/committees.py
+++ b/scrapers_next/mi/committees.py
@@ -1,0 +1,60 @@
+from spatula import HtmlPage, HtmlListPage, CSS, XPath, SelectorError
+from openstates.models import ScrapeCommittee
+
+
+class SenateCommitteeDetail(HtmlPage):
+    example_source = (
+        "https://www.senate.mn/committees/committee_bio.html?cmte_id=3087&ls=92"
+    )
+
+    def process_page(self):
+        # com = self.input
+        print("a new comm")
+
+
+class SenateCommitteeList(HtmlListPage):
+    source = "https://committees.senate.michigan.gov/"
+    selector = CSS("form .col-md-6")
+    chamber = "upper"
+
+    def process_item(self, item):
+        try:
+            title = CSS("h3").match(item)
+        except SelectorError:
+            title = XPath("..//preceding-sibling::h3").match(item)
+
+        for comm_name in title:
+            # try:
+            print(comm_name.text_content())
+            comm_name = comm_name.text_content()
+            # except SelectorError:
+            if comm_name == "Standing Committees":
+                for committee in CSS("ul li").match(item):
+
+                    name = committee.text_content()
+                    com = ScrapeCommittee(name=name, chamber=self.chamber)
+                    # print("com", com)
+                    # print("source OKAY", CSS("a").match_one(committee).get("href"))
+                    source = CSS("a").match_one(committee).get("href")
+                    # print("HERE")
+                    return SenateCommitteeDetail(com, source=source)
+            elif comm_name == "Appropriations Subcommittees":
+                for committee in CSS("ul li").match(item):
+
+                    name = committee.text_content()
+                    com = ScrapeCommittee(
+                        name=name,
+                        classification="subcommittee",
+                        chamber=self.chamber,
+                        parent="Appropriations",
+                    )
+                    # print("com", com)
+                    source = CSS("a").match_one(committee).get("href")
+                    # print("HERE2")
+                    return SenateCommitteeDetail(com, source=source)
+            # return SenateCommitteeDetail(com, source=item.get("href"))
+
+
+class HouseCommitteeList(HtmlListPage):
+    source = "https://capitol.texas.gov/Committees/CommitteesMbrs.aspx?Chamber=H"
+    chamber = "lower"


### PR DESCRIPTION
I think there's only one [subcommittee list page](https://www.house.mi.gov/MHRPublic/SubCommittee.aspx?comcode=APPR), but it only sometimes loads, even from just the browser. I'm not sure how to approach scraping subcommittee list pages in general--first I tried to scrape from within HouseCommitteeDetail, and then I decided to try a separate HouseSubcommitteeList (but got stuck when the web page just seemed faulty).

Other than that, the links Iisted on each committee page (here's an [example](https://www.house.mi.gov/MHRPublic/CommitteeInfo.aspx?comcode=AGRI) for the links, "Click here to subscribe" and "All Currently Scheduled Committee Meetings") aren't super relevant to that committee in particular, but I included them in the scraper just in case.