### PR TITLE
ND: ignore 2023 session

### DIFF
--- a/scrapers/nd/__init__.py
+++ b/scrapers/nd/__init__.py
@@ -58,6 +58,7 @@ class NorthDakota(State):
         },
     ]
     ignored_scraped_sessions = [
+        "68th Legislative Assembly (2023-24)",
         "61st Legislative Assembly (2009-10)",
         "60th Legislative Assembly (2007-08)",
         "59th Legislative Assembly (2005-06)",


### PR DESCRIPTION
Scraper failing from new session being listed in the general assembly page even though no bills are prefiled yet.