### PR TITLE
AZ committee spatula scrape

### DIFF
--- a/scrapers_next/az/committees.py
+++ b/scrapers_next/az/committees.py
@@ -1,0 +1,50 @@
+# import re
+from spatula import XPath, URL, XmlListPage
+
+# from openstates.models import ScrapeCommittee
+
+# to get all committees: https://apps.azleg.gov/api/Committee
+
+#
+
+
+class SenateCommitteeList(XmlListPage):
+    # source = "https://www.senate.mo.gov/committee/"
+    # source = URL("https://apps.azleg.gov/api/Committee", headers={sessionId=session_id,
+    #         includeOnlyCommitteesWithAgendas="false",
+    #         legislativeBody="S" if chamber == "upper" else "H",})
+
+    # https://apps.azleg.gov/api/StandingCommittee/?legislativeBody=S&sessionId=123&includeMembers=true
+
+    # OKAY SO THE PLAN:
+    # first go here: https://apps.azleg.gov/api/Committee/?legislativeBody=S&sessionId=123&includeMembers=true
+    # how to get session_id? idk lol
+    # then go to each of the standing committees on that list, for ex.
+
+    # or actually, go here for Senate: https://apps.azleg.gov/api/Committee/?legislativeBody=S&sessionId=123&includeMembers=true
+    # then here for House: https://apps.azleg.gov/api/Committee/?legislativeBody=H&sessionId=123&includeMembers=true
+
+    # class Legislators(XmlListPage):
+    # session_num = "32"
+    # source = URL(
+    #     "http://www.legis.state.ak.us/publicservice/basis/members"
+    #     f"?minifyresult=false&session={session_num}",
+    #     headers={"X-Alaska-Legislature-Basis-Version": "1.4"},
+    # )
+    session_id = "123"
+    source = URL(
+        "https://apps.azleg.gov/api/Committee/"
+        f"?legislativeBody=S&sessionId={session_id}&includeMembers=true"
+    )
+    selector = XPath("//CommitteeModel")
+
+    def process_item(self, item):
+        print("HUH")
+        # type = item.text_content()
+        # if type == "Standing" or type == "Statutory":
+
+        #     print("WHAT WHAT", item.get("href"))
+        #     # return SenateTypeCommitteeList(source=item.get("href"))
+        # else:
+        #     print("HEREEE")
+        #     self.skip()

--- a/scrapers_next/az/committees.py
+++ b/scrapers_next/az/committees.py
@@ -39,17 +39,10 @@ class SenateCommitteeList(JsonListPage):
     chamber = "upper"
 
     def process_item(self, item):
-        print("HUH")
-        # print("ITEM", item[""])
-        # name = XPath("/CommitteeName").match(item)
-        name = item["CommitteeName"]
-        print("NAME", name)
-        print("item", item)
 
-        # print("UM", item[I])
-        print(item["IsSubCommittee"])
+        name = item["CommitteeName"]
+
         if item["IsSubCommittee"] is False:
-            # print("NOT HER")
             com = ScrapeCommittee(name=name, chamber=self.chamber)
 
         else:
@@ -62,12 +55,9 @@ class SenateCommitteeList(JsonListPage):
                 parent="Appropriations",
             )
 
-        # members = self.data["d3p1:CommitteeMemberModel"]
-        # members = item["d3p1:CommitteeMemberModel"]
+        # TODO: for repeat problem, not sure that this is the best approach?
+        members = []
         for member in item["Members"]:
-            # print("MEMBERS", member)
-            # com.add_member(member)
-            # print("MEMBER NAME", member["FirstName"] + " " + member["LastName"])
 
             name = member["FirstName"] + " " + member["LastName"]
             if member["IsChair"]:
@@ -77,9 +67,12 @@ class SenateCommitteeList(JsonListPage):
             else:
                 position = "member"
 
-            com.add_member(name, position)
-        # for member in members:
-        #     print("hi")
+            # As of now, the API lists all members twice, so we must check for duplicates for members
+            if f"{name} {position}" in members:
+                continue
+            else:
+                members.append(f"{name} {position}")
+                com.add_member(name, position)
 
         com.extras["Committee ID"] = item["CommitteeId"]
         com.extras["Committee Short Name"] = item["CommitteeShortName"]


### PR DESCRIPTION
AZ committee scraper conversion to spatula!
- Unsure of where to get the session id, so that was hardcoded :(
- All the members of the committee are repeated twice, so to be extra safe, I checked each member against a list of previously added member names with their positions, before adding it as a new member in the scrape. It's not foolproof because two members can have the same name and same positions (probably "member").
- I only scraped the standing committees for House and Senate, and I think the old scraper did too. There's no documentation on the Arizona API, but there are a lot of committees listed [here](https://apps.azleg.gov/api/Committee), most of which probably are not active currently?
- I wasn't able to add a "homepage" link, I guess the closest would be this: https://apps.azleg.gov/BillStatus/CommitteeOverView?SessionID=123. Although this is not specific to each committee, I can add it!
- There are no subcommittees in the current standing committees for House and Senate, but I wrote that part based on the subcommittees here, just in case: https://apps.azleg.gov/api/Committee