### PR TITLE
Id committee spatula

### DIFF
--- a/scrapers_next/id/committees.py
+++ b/scrapers_next/id/committees.py
@@ -1,0 +1,62 @@
+from spatula import HtmlListPage, CSS, URL
+from openstates.models import ScrapeCommittee
+
+
+class JointCommitteeList(HtmlListPage):
+    selector = CSS("div .vc-column-innner-wrapper ul li", num_items=5)
+
+    def process_item(self, item):
+        com_link = CSS("a").match_one(item)
+        name = com_link.text_content()
+
+        com = ScrapeCommittee(
+            name=name,
+            chamber=self.chamber,
+        )
+
+        detail_link = com_link.get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com
+
+
+class CommitteeList(HtmlListPage):
+    selector = CSS("div .padding-one-top.hcode-inner-row")
+
+    def process_item(self, item):
+        name = CSS("strong").match(item)[0].text_content()
+
+        # skip header row
+        if name == "Committees":
+            self.skip()
+
+        com = ScrapeCommittee(
+            name=name,
+            chamber=self.chamber,
+        )
+
+        detail_link = CSS("a").match(item)[0].get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com
+
+
+class Senate(CommitteeList):
+    source = URL("https://legislature.idaho.gov/committees/senatecommittees/")
+    chamber = "upper"
+
+
+class House(CommitteeList):
+    source = URL("https://legislature.idaho.gov/committees/housecommittees/")
+    chamber = "lower"
+
+
+class Joint(JointCommitteeList):
+    source = URL("https://legislature.idaho.gov/committees/jointcommittees/")
+    chamber = "legislature"

--- a/scrapers_next/id/committees.py
+++ b/scrapers_next/id/committees.py
@@ -3,16 +3,6 @@ from openstates.models import ScrapeCommittee
 import re
 
 
-# "html body section.parent-section.no-padding div.container-fluid div.row section.parallax-fix div.container div.row div div div div.tab-content div div div div.insert-page.insert-page-522202 div.hidden-print section.row-equal-height.no-padding div"
-# "html body section.parent-section.no-padding div.container-fluid div.row div"
-# "https://legislature.idaho.gov/sessioninfo/2021/joint/cec/"
-# this link might have broken html
-
-# https://legislature.idaho.gov/lso/bpa/eora/
-# https://legislature.idaho.gov/sessioninfo/2021/standingcommittees/HETH/
-# these links have 'Ad Hoc' in names
-
-
 class DetailCommitteePage(HtmlPage):
     def process_page(self):
         com = self.input
@@ -28,7 +18,6 @@ class DetailCommitteePage(HtmlPage):
             else:
                 role = "member"
             com.add_member(name, role)
-            # print(name, role)
 
         return com
 
@@ -51,6 +40,8 @@ class JointCommitteeList(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
+        # this link has broken html (not able to grab member info)
+        # just returning name, chamber, and link
         if detail_link == "https://legislature.idaho.gov/sessioninfo/2021/joint/cec/":
             return com
 

--- a/scrapers_next/id/committees.py
+++ b/scrapers_next/id/committees.py
@@ -13,11 +13,14 @@ class DetailCommitteePage(HtmlPage):
         for member in members:
             name = CSS("strong").match_one(member).text_content().strip()
             name = re.search(r"(Sen\.|Rep\.)\s(.+)", name).groups()[1]
+
+            if re.search(r"Ad\sHoc", name):
+                name, _, role = re.search(r"(.+)(\s–\s|\()(Ad\sHoc)\)?", name).groups()
+
             if re.search(r",\s", name):
                 name, role = re.search(r"(.+),\s(.+)", name).groups()
-            else:
-                role = "member"
-            com.add_member(name, role)
+
+            com.add_member(name, role if role else "member")
 
         return com
 

--- a/scrapers_next/id/committees.py
+++ b/scrapers_next/id/committees.py
@@ -5,6 +5,12 @@ import re
 
 # "html body section.parent-section.no-padding div.container-fluid div.row section.parallax-fix div.container div.row div div div div.tab-content div div div div.insert-page.insert-page-522202 div.hidden-print section.row-equal-height.no-padding div"
 # "html body section.parent-section.no-padding div.container-fluid div.row div"
+# "https://legislature.idaho.gov/sessioninfo/2021/joint/cec/"
+# this link might have broken html
+
+# https://legislature.idaho.gov/lso/bpa/eora/
+# https://legislature.idaho.gov/sessioninfo/2021/standingcommittees/HETH/
+# these links have 'Ad Hoc' in names
 
 
 class DetailCommitteePage(HtmlPage):
@@ -43,6 +49,9 @@ class JointCommitteeList(HtmlListPage):
         com.add_source(self.source.url)
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
+
+        if detail_link == "https://legislature.idaho.gov/sessioninfo/2021/joint/cec/":
+            return com
 
         return DetailCommitteePage(com, source=detail_link)
 

--- a/scrapers_next/id/committees.py
+++ b/scrapers_next/id/committees.py
@@ -27,7 +27,8 @@ class DetailCommitteePage(HtmlPage):
                 name, role = re.search(r"(.+),\s(.+)", name).groups()
             else:
                 role = "member"
-            print(name, role)
+            com.add_member(name, role)
+            # print(name, role)
 
         return com
 
@@ -70,6 +71,14 @@ class CommitteeList(HtmlListPage):
             name=name,
             chamber=self.chamber,
         )
+
+        all_text = CSS("p").match(item)[0].text_content().strip()
+        secretary, email, phone = re.search(
+            r"\n?Secretary:(.+)\n?Email:(.+)\n?Phone:(.+)", all_text
+        ).groups()
+        com.extras["secretary"] = secretary.strip()
+        com.extras["email"] = email.strip()
+        com.extras["phone"] = phone.strip()
 
         detail_link = CSS("a").match(item)[0].get("href")
 


### PR DESCRIPTION
Writing ID committee scraper using spatula framework. Notes:

1. The following Joint Committee has broken html. Not able to grab member names/info. Just returning ScrapeCommittee() object with name, chamber, sources, and link. https://legislature.idaho.gov/sessioninfo/2021/joint/cec/

2. These links have 'Ad Hoc' in names:
https://legislature.idaho.gov/lso/bpa/eora/ (ex: "Sen. Peter Riggs – Ad Hoc")
https://legislature.idaho.gov/sessioninfo/2021/standingcommittees/HETH/

@jamesturk 