### PR TITLE
Nh people spatula

### DIFF
--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -134,10 +134,6 @@ class Legislators(CsvListPage):
     def postprocess_response(self) -> None:
         self.reader = csv.DictReader(io.StringIO(self.response.text), delimiter="\t")
 
-    # house_profile_url = (
-    #     "http://www.gencourt.state.nh.us/house/members/member.aspx?member={}"
-    # )
-
     source = URL("http://gencourt.state.nh.us/downloads/members.txt")
 
     def process_item(self, item):
@@ -178,61 +174,35 @@ class Legislators(CsvListPage):
         p.family_name = lastname
         p.given_name = firstname
 
-        # seatno
-        # County
-        # electedStatus
-        # Address
-        # address2
-        # city
-        # Zipcode
-        # State
-        # Phone
-        # WorkEmail
-        # GenderCode
-        # PersonTitle
+        county = item["County"]
+        if county != "":
+            p.extras["county"] = county
+
+        electedStatus = item["electedStatus"].strip()
+        if electedStatus != "":
+            p.extras["elected status"] = electedStatus
+
+        addr = item["Address"].strip()
+        if addr != "":
+            addr += " "
+            if item["address2"].strip() != "":
+                addr += item["address2"]
+                addr += " "
+            addr += item["city"]
+            addr += ", NH "
+            addr += item["Zipcode"]
+            if item["Phone"].strip() != "":
+                p.add_office(
+                    contact_type="Primary Office", address=addr, voice=item["Phone"]
+                )
+            else:
+                p.add_office(contact_type="Primary Office", address=addr)
+            # is this primary office? or district office?
+
+        if item["WorkEmail"].strip() != "":
+            p.email = item["WorkEmail"].strip()
+
+        if item["GenderCode"].strip() != "":
+            p.extras["gender code"] = item["GenderCode"].strip()
 
         return p
-
-
-# # print(len(member))
-# if len(member) > 9:
-#     party = member[15]
-
-#     p = ScrapePerson(
-#         name=name,
-#         state="nh",
-#         chamber=chamber,
-#         district=district,
-#         party=party,
-#     )
-
-#     # seat_num = member[4]
-
-#     p.add_source(self.source.url)
-
-#     county = member[5]
-#     if county != "":
-#         p.extras["county"] = county
-
-#     address = member[8]
-
-#     address2 = member[9]
-#     city = member[10]
-#     zipcode = member[11]
-#     full_addr = (
-#         address + " " + address2 + " " + city + ", New Hampshire" + zipcode
-#     )
-#     p.district_office.address = full_addr
-
-#     phone = member[13]
-#     p.district_office.voice = phone
-
-#     email = member[14]
-#     p.email = email
-
-#     gendercode = member[16]
-#     p.extras["gender code"] = gendercode
-#     title = member[17]
-#     p.extras["title"] = title
-
-#     return p

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,4 +1,4 @@
-from spatula import URL, CsvListPage, HtmlPage, CSS, XPath
+from spatula import URL, HtmlPage, CSS, XPath, HtmlListPage
 from openstates.models import ScrapePerson
 from dataclasses import dataclass
 import re
@@ -10,21 +10,72 @@ class PartialPerson:
     chamber: str
     district: str
     source: str
+    staff_name: str
+    staff_email: str
 
 
 # 418 total
 # 24 total senators
 # total representatives
 
+# class SenDetail(HtmlPage):
+#     input_type = PartialPerson
+
+#     def process_page(self):
+
+#         party = CSS("span.MemberHeader").match_one(self.root).text_content().strip()
+#         party = re.search(r"(.+)\(([A-Z])-.+\)", party).groups()[1]
+#         print(party)
+
+#         p = ScrapePerson(
+#             name=self.input.name,
+#             state="nh",
+#             chamber=self.input.chamber,
+#             district=self.input.district,
+#             party=party,
+#         )
+
+#         p.add_source(self.input.source)
+#         p.add_source(self.source.url)
+#         p.add_link(self.source.url, note="homepage")
+
+#         img = CSS("img.auto-style2").match_one(self.root).get("src")
+#         p.image = img
+
+#         contact_info = XPath("//*[@id='page_content']/table/tr[2]/td//strong[3]").match(
+#             self.root
+#         )[0]
+#         cap_addr = contact_info.getnext().tail.strip()
+#         cap_addr += " "
+#         cap_addr += contact_info.getnext().getnext().tail.strip()
+#         cap_addr += " "
+#         cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
+#         p.capitol_office.address = cap_addr
+
+#         # phone = XPath("//*[@id='page_content']/table/tr[2]/td//strong[4]").match(self.root)[0].tail.strip()
+#         # print(phone)
+
+#         # capitol_office.voice
+#         # education
+
+#         # some might be missing, most already have
+#         # party
+#         # email
+
+#         return p
+
 
 class SenDetail(HtmlPage):
     input_type = PartialPerson
 
     def process_page(self):
-
         party = CSS("span.MemberHeader").match_one(self.root).text_content().strip()
         party = re.search(r"(.+)\(([A-Z])-.+\)", party).groups()[1]
-        print(party)
+
+        if party == "D":
+            party = "Democratic"
+        elif party == "R":
+            party = "Republican"
 
         p = ScrapePerson(
             name=self.input.name,
@@ -37,6 +88,9 @@ class SenDetail(HtmlPage):
         p.add_source(self.input.source)
         p.add_source(self.source.url)
         p.add_link(self.source.url, note="homepage")
+
+        p.extras["staff name"] = self.input.staff_name
+        p.extras["staff email"] = self.input.staff_email
 
         img = CSS("img.auto-style2").match_one(self.root).get("src")
         p.image = img
@@ -51,101 +105,144 @@ class SenDetail(HtmlPage):
         cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
         p.capitol_office.address = cap_addr
 
-        # phone = XPath("//*[@id='page_content']/table/tr[2]/td//strong[4]").match(self.root)[0].tail.strip()
-        # print(phone)
-        # capitol_office.voice
-        # education
-
-        # some might be missing, most already have
-        # party
-        # email
+        if (
+            self.source.url
+            == "http://gencourt.state.nh.us/Senate/members/webpages/district14.aspx"
+        ):
+            phone = CSS("table tr td strong").match(self.root)[5].tail.strip()
+        else:
+            phone = (
+                XPath(
+                    "//*[@id='page_content']/table/tr[2]/td//strong[contains(text(), 'Phone:')]"
+                )
+                .match(self.root)[0]
+                .tail.strip()
+            )
+            phone = re.search(r"(\d{3}-\d{3}-\d{4})(.+)?", phone).groups()[0]
+            p.capitol_office.voice = phone
 
         return p
 
 
-class Legislators(CsvListPage):
-
-    # house_profile_url = (
-    #     "http://www.gencourt.state.nh.us/house/members/member.aspx?member={}"
-    # )
-
-    source = URL("http://gencourt.state.nh.us/downloads/members.txt")
+class Senate(HtmlListPage):
+    source = URL("http://gencourt.state.nh.us/Senate/members/senate_roster.aspx")
+    selector = CSS("div#roseterWrap > div", num_items=24)
 
     def process_item(self, item):
-        for line in item.values():
-            print(line)
-            member = line.split("\t")
 
-            lastname = member[0]
-            firstname = member[1]
-            middlename = member[2]
-            name = firstname + " " + middlename + " " + lastname
+        header_line = CSS("div").match(item)[0].text_content().strip()
+        header_line_lst = re.search(
+            r"District\s(.+)\s-\sSenator\s(.+)", header_line
+        ).groups()
 
-            legislativebody = member[3]
-            if legislativebody == "H":
-                chamber = "lower"
-            elif legislativebody == "S":
-                chamber = "upper"
+        district = header_line_lst[0]
+        if district[0] == "0":
+            district = district[1]
+        name = header_line_lst[1].strip()
 
-            district = member[6]
+        staff = CSS("a").match(item)[1]
+        staff_email = staff.get("href")
+        staff_email = re.search(r"mailto:(.+)", staff_email).groups()[0]
+        staff_name = staff.text_content().strip()
 
-            # 39 out of 116 legislators have incomplete info (len(member) < 19)
-            # 24 senators and 15 reps
-            if chamber == "upper":
-                if len(district) == 1:
-                    district_id = "0" + district
-                else:
-                    district_id = district
-                detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
+        partial = PartialPerson(
+            name=name,
+            chamber="upper",
+            district=district,
+            source=self.source.url,
+            staff_name=staff_name,
+            staff_email=staff_email,
+        )
 
-                partial = PartialPerson(
-                    name=name,
-                    chamber=chamber,
-                    district=district,
-                    source=self.source.url,
-                )
+        detail_link = CSS("a").match(item)[0].get("href")
 
-                return SenDetail(partial, source=detail_link)
+        return SenDetail(partial, source=detail_link)
 
-            # print(len(member))
-            if len(member) > 9:
-                party = member[15]
 
-                p = ScrapePerson(
-                    name=name,
-                    state="nh",
-                    chamber=chamber,
-                    district=district,
-                    party=party,
-                )
+# class Legislators(CsvListPage):
 
-                # seat_num = member[4]
+#     # house_profile_url = (
+#     #     "http://www.gencourt.state.nh.us/house/members/member.aspx?member={}"
+#     # )
 
-                p.add_source(self.source.url)
+#     source = URL("http://gencourt.state.nh.us/downloads/members.txt")
 
-                county = member[5]
-                if county != "":
-                    p.extras["county"] = county
+#     def process_item(self, item):
+#         for line in item.values():
+#             # print(line)
+#             member = line.split("\t")
 
-                address = member[8]
+#             lastname = member[0]
+#             firstname = member[1]
+#             middlename = member[2]
+#             name = firstname + " " + middlename + " " + lastname
 
-                address2 = member[9]
-                city = member[10]
-                zipcode = member[11]
-                full_addr = (
-                    address + " " + address2 + " " + city + ", New Hampshire" + zipcode
-                )
-                p.district_office.address = full_addr
+#             legislativebody = member[3]
+#             if legislativebody == "H":
+#                 chamber = "lower"
+#             elif legislativebody == "S":
+#                 chamber = "upper"
 
-                phone = member[13]
-                p.district_office.voice = phone
+#             district = member[6]
 
-                email = member[14]
-                p.email = email
+#             # 39 out of 116 legislators have incomplete info (len(member) < 19)
+#             # 24 senators and 15 reps
+#             if chamber == "upper":
+#                 if len(district) == 1:
+#                     district_id = "0" + district
+#                 else:
+#                     district_id = district
+#                 detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
 
-                gendercode = member[16]
-                p.extras["gender code"] = gendercode
-                title = member[17]
-                p.extras["title"] = title
+#                 partial = PartialPerson(
+#                     name=name,
+#                     chamber=chamber,
+#                     district=district,
+#                     source=self.source.url,
+#                 )
 
-                return p
+#                 return SenDetail(partial, source=detail_link)
+
+
+# # print(len(member))
+# if len(member) > 9:
+#     party = member[15]
+
+#     p = ScrapePerson(
+#         name=name,
+#         state="nh",
+#         chamber=chamber,
+#         district=district,
+#         party=party,
+#     )
+
+#     # seat_num = member[4]
+
+#     p.add_source(self.source.url)
+
+#     county = member[5]
+#     if county != "":
+#         p.extras["county"] = county
+
+#     address = member[8]
+
+#     address2 = member[9]
+#     city = member[10]
+#     zipcode = member[11]
+#     full_addr = (
+#         address + " " + address2 + " " + city + ", New Hampshire" + zipcode
+#     )
+#     p.district_office.address = full_addr
+
+#     phone = member[13]
+#     p.district_office.voice = phone
+
+#     email = member[14]
+#     p.email = email
+
+#     gendercode = member[16]
+#     p.extras["gender code"] = gendercode
+#     title = member[17]
+#     p.extras["title"] = title
+
+#     return p

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,8 +1,15 @@
 import io
 import csv
-from spatula import URL, CsvListPage, HtmlPage, CSS, XPath
+from spatula import URL, CsvListPage, HtmlPage, CSS, XPath  # , XmlPage
 from openstates.models import ScrapePerson
 import re
+
+
+class HouseDetail(HtmlPage):
+    def process_page(self):
+        p = self.input
+
+        return p
 
 
 class SenDetail(HtmlPage):
@@ -39,53 +46,6 @@ class SenDetail(HtmlPage):
             p.capitol_office.voice = phone
 
         return p
-
-
-# class Senate(HtmlListPage):
-#     source = URL("http://gencourt.state.nh.us/Senate/members/senate_roster.aspx")
-#     selector = CSS("div#roseterWrap > div", num_items=24)
-
-#     def process_item(self, item):
-
-#         header_line = CSS("div").match(item)[0].text_content().strip()
-#         header_line_lst = re.search(
-#             r"District\s(.+)\s-\sSenator\s(.+)", header_line
-#         ).groups()
-
-#         district = header_line_lst[0]
-#         if district[0] == "0":
-#             district = district[1]
-#         name = header_line_lst[1].strip()
-
-#         staff = CSS("a").match(item)[1]
-#         staff_email = staff.get("href")
-#         staff_email = re.search(r"mailto:(.+)", staff_email).groups()[0]
-#         staff_name = staff.text_content().strip()
-
-#         partial = PartialPerson(
-#             name=name,
-#             chamber="upper",
-#             district=district,
-#             source=self.source.url,
-#             staff_name=staff_name,
-#             staff_email=staff_email,
-#         )
-
-#         detail_link = CSS("a").match(item)[0].get("href")
-
-#         return SenDetail(partial, source=detail_link)
-
-
-# class House(HtmlPage):
-#     source = URL("http://gencourt.state.nh.us/house/members/default.aspx")
-
-#     def process_page(self):
-#         members = XPath("//*[@id='ContentPlaceHolder1_ddlReps']/option").match(
-#             self.root
-#         )
-#         print(len(members))
-#         # for member in members:
-#         # print(member.text_content())
 
 
 class Legislators(CsvListPage):
@@ -160,16 +120,45 @@ class Legislators(CsvListPage):
             p.add_link(detail_link, note="homepage")
             return SenDetail(p, source=detail_link)
 
+        # seat_map = SeatMap()
+        # seat_number = seat_map[item["seatno"]]
+        # detail_link = f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={seat_number}"
+        # return HouseDetail(p, source=detail_link)
         return p
 
 
-# members_url = "http://gencourt.state.nh.us/downloads/Members.txt"
-
 # lookup_url = "http://www.gencourt.state.nh.us/house/members/memberlookup.aspx"
+
 # house_profile_url = (
 #     f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={item["seatno"]}"
 # )
 
-# senate_profile_url = (
-#     f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district}.aspx"
-# )
+# seat_number = seat_map[row["seatno"]]
+# profile_url = self.house_profile_url.format(seat_number)
+
+# class SeatMap(XmlPage):
+#     source = "http://www.gencourt.state.nh.us/house/members/memberlookup.aspx"
+
+#     def process_page(self):
+#         """Get mapping between seat numbers and legislator identifiers."""
+#         seat_map = {}
+#         # page = self.lxmlize(self.lookup_url)
+#         options = XPath('//select[@id="member"]/option').match(self.root)
+#         print(options)
+#         for option in options:
+#             member_url = f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={option.attrib['value']}"
+#             table = MemberPage(source=member_url)
+
+# member_page = self.lxmlize(member_url)
+# table = member_page.xpath('//table[@id="Table1"]')
+#     if table:
+#         res = re.search(r"seat #:(\d+)", table[0].text_content(), re.IGNORECASE)
+#         if res:
+#             seat_map[res.groups()[0]] = option.attrib["value"]
+# return seat_map
+
+
+# class MemberPage(XmlPage):
+#     def process_page(self):
+#         table = XPath('//table[@id="Table1"]').match(self.root)[0]
+#         return table

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -5,11 +5,11 @@ from openstates.models import ScrapePerson
 import re
 
 
-class HouseDetail(HtmlPage):
-    def process_page(self):
-        p = self.input
+# class HouseDetail(HtmlPage):
+#     def process_page(self):
+#         p = self.input
 
-        return p
+#         return p
 
 
 class SenDetail(HtmlPage):
@@ -120,45 +120,7 @@ class Legislators(CsvListPage):
             p.add_link(detail_link, note="homepage")
             return SenDetail(p, source=detail_link)
 
-        # seat_map = SeatMap()
         # seat_number = seat_map[item["seatno"]]
         # detail_link = f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={seat_number}"
         # return HouseDetail(p, source=detail_link)
         return p
-
-
-# lookup_url = "http://www.gencourt.state.nh.us/house/members/memberlookup.aspx"
-
-# house_profile_url = (
-#     f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={item["seatno"]}"
-# )
-
-# seat_number = seat_map[row["seatno"]]
-# profile_url = self.house_profile_url.format(seat_number)
-
-# class SeatMap(XmlPage):
-#     source = "http://www.gencourt.state.nh.us/house/members/memberlookup.aspx"
-
-#     def process_page(self):
-#         """Get mapping between seat numbers and legislator identifiers."""
-#         seat_map = {}
-#         # page = self.lxmlize(self.lookup_url)
-#         options = XPath('//select[@id="member"]/option').match(self.root)
-#         print(options)
-#         for option in options:
-#             member_url = f"http://www.gencourt.state.nh.us/house/members/member.aspx?member={option.attrib['value']}"
-#             table = MemberPage(source=member_url)
-
-# member_page = self.lxmlize(member_url)
-# table = member_page.xpath('//table[@id="Table1"]')
-#     if table:
-#         res = re.search(r"seat #:(\d+)", table[0].text_content(), re.IGNORECASE)
-#         if res:
-#             seat_map[res.groups()[0]] = option.attrib["value"]
-# return seat_map
-
-
-# class MemberPage(XmlPage):
-#     def process_page(self):
-#         table = XPath('//table[@id="Table1"]').match(self.root)[0]
-#         return table

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -31,6 +31,8 @@ class Legislators(CsvListPage):
                 party=party,
             )
 
+            p.add_source(self.source.url)
+
             address = member[8]
             address2 = member[9]
             city = member[10]

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,0 +1,56 @@
+from spatula import URL, CsvListPage
+from openstates.models import ScrapePerson
+
+
+class Legislators(CsvListPage):
+    source = URL("http://gencourt.state.nh.us/downloads/members.txt")
+
+    def process_item(self, item):
+        for line in item.values():
+            member = line.split("\t")
+
+            lastname = member[0]
+            firstname = member[1]
+            middlename = member[2]
+            name = firstname + " " + middlename + " " + lastname
+
+            legislativebody = member[3]
+            if legislativebody == "H":
+                chamber = "lower"
+            elif legislativebody == "S":
+                chamber = "upper"
+
+            district = member[6]
+            party = member[15]
+
+            p = ScrapePerson(
+                name=name,
+                state="nh",
+                chamber=chamber,
+                district=district,
+                party=party,
+            )
+
+            address = member[8]
+            address2 = member[9]
+            city = member[10]
+            zipcode = member[11]
+            full_addr = (
+                address + " " + address2 + " " + city + ", New Hampshire" + zipcode
+            )
+            p.district_office.address = full_addr
+
+            phone = member[13]
+            p.district_office.voice = phone
+
+            email = member[14]
+            p.email = email
+
+            gendercode = member[16]
+            p.extras["gender code"] = gendercode
+            title = member[17]
+            p.extras["title"] = title
+            county = member[5]
+            p.extras["county"] = county
+
+            yield p

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,4 +1,6 @@
-from spatula import URL, HtmlPage, CSS, XPath, HtmlListPage
+import io
+import csv
+from spatula import URL, HtmlPage, CSS, XPath, HtmlListPage, CsvListPage
 from openstates.models import ScrapePerson
 from dataclasses import dataclass
 import re
@@ -127,49 +129,52 @@ class House(HtmlPage):
         # print(member.text_content())
 
 
-# class Legislators(CsvListPage):
+class Legislators(CsvListPage):
+    def postprocess_response(self) -> None:
+        self.reader = csv.DictReader(io.StringIO(self.response.text), delimiter="\t")
 
-#     # house_profile_url = (
-#     #     "http://www.gencourt.state.nh.us/house/members/member.aspx?member={}"
-#     # )
+    # house_profile_url = (
+    #     "http://www.gencourt.state.nh.us/house/members/member.aspx?member={}"
+    # )
 
-#     source = URL("http://gencourt.state.nh.us/downloads/members.txt")
+    source = URL("http://gencourt.state.nh.us/downloads/members.txt")
 
-#     def process_item(self, item):
-#         for line in item.values():
-#             # print(line)
-#             member = line.split("\t")
+    def process_item(self, item):
+        print(item)
+        for line in item.values():
+            # print(line)
+            member = line.split("\t")
 
-#             lastname = member[0]
-#             firstname = member[1]
-#             middlename = member[2]
-#             name = firstname + " " + middlename + " " + lastname
+            lastname = member[0]
+            firstname = member[1]
+            middlename = member[2]
+            name = firstname + " " + middlename + " " + lastname
 
-#             legislativebody = member[3]
-#             if legislativebody == "H":
-#                 chamber = "lower"
-#             elif legislativebody == "S":
-#                 chamber = "upper"
+            legislativebody = member[3]
+            if legislativebody == "H":
+                chamber = "lower"
+            elif legislativebody == "S":
+                chamber = "upper"
 
-#             district = member[6]
+            district = member[6]
 
-#             # 39 out of 116 legislators have incomplete info (len(member) < 19)
-#             # 24 senators and 15 reps
-#             if chamber == "upper":
-#                 if len(district) == 1:
-#                     district_id = "0" + district
-#                 else:
-#                     district_id = district
-#                 detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
+            # 39 out of 116 legislators have incomplete info (len(member) < 19)
+            # 24 senators and 15 reps
+            if chamber == "upper":
+                if len(district) == 1:
+                    district_id = "0" + district
+                else:
+                    district_id = district
+                detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
 
-#                 partial = PartialPerson(
-#                     name=name,
-#                     chamber=chamber,
-#                     district=district,
-#                     source=self.source.url,
-#                 )
+                partial = PartialPerson(
+                    name=name,
+                    chamber=chamber,
+                    district=district,
+                    source=self.source.url,
+                )
 
-#                 return SenDetail(partial, source=detail_link)
+                return SenDetail(partial, source=detail_link)
 
 
 # # print(len(member))

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -14,55 +14,8 @@ class PartialPerson:
     staff_email: str
 
 
-# 418 total
 # 24 total senators
 # total representatives
-
-# class SenDetail(HtmlPage):
-#     input_type = PartialPerson
-
-#     def process_page(self):
-
-#         party = CSS("span.MemberHeader").match_one(self.root).text_content().strip()
-#         party = re.search(r"(.+)\(([A-Z])-.+\)", party).groups()[1]
-#         print(party)
-
-#         p = ScrapePerson(
-#             name=self.input.name,
-#             state="nh",
-#             chamber=self.input.chamber,
-#             district=self.input.district,
-#             party=party,
-#         )
-
-#         p.add_source(self.input.source)
-#         p.add_source(self.source.url)
-#         p.add_link(self.source.url, note="homepage")
-
-#         img = CSS("img.auto-style2").match_one(self.root).get("src")
-#         p.image = img
-
-#         contact_info = XPath("//*[@id='page_content']/table/tr[2]/td//strong[3]").match(
-#             self.root
-#         )[0]
-#         cap_addr = contact_info.getnext().tail.strip()
-#         cap_addr += " "
-#         cap_addr += contact_info.getnext().getnext().tail.strip()
-#         cap_addr += " "
-#         cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
-#         p.capitol_office.address = cap_addr
-
-#         # phone = XPath("//*[@id='page_content']/table/tr[2]/td//strong[4]").match(self.root)[0].tail.strip()
-#         # print(phone)
-
-#         # capitol_office.voice
-#         # education
-
-#         # some might be missing, most already have
-#         # party
-#         # email
-
-#         return p
 
 
 class SenDetail(HtmlPage):
@@ -120,6 +73,9 @@ class SenDetail(HtmlPage):
             )
             phone = re.search(r"(\d{3}-\d{3}-\d{4})(.+)?", phone).groups()[0]
             p.capitol_office.voice = phone
+
+        email = CSS("table tr td a").match(self.root)[1].text_content().strip()
+        p.email = email
 
         return p
 

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -15,7 +15,7 @@ class PartialPerson:
 
 
 # 24 total senators
-# total representatives
+# 395 total representatives?
 
 
 class SenDetail(HtmlPage):
@@ -113,6 +113,18 @@ class Senate(HtmlListPage):
         detail_link = CSS("a").match(item)[0].get("href")
 
         return SenDetail(partial, source=detail_link)
+
+
+class House(HtmlPage):
+    source = URL("http://gencourt.state.nh.us/house/members/default.aspx")
+
+    def process_page(self):
+        members = XPath("//*[@id='ContentPlaceHolder1_ddlReps']/option").match(
+            self.root
+        )
+        print(len(members))
+        # for member in members:
+        # print(member.text_content())
 
 
 # class Legislators(CsvListPage):

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,10 +1,32 @@
-from spatula import URL, CsvListPage, HtmlPage
+from spatula import URL, CsvListPage, HtmlPage, CSS, XPath
 from openstates.models import ScrapePerson
 
 
-class LegDetail(HtmlPage):
+class SenDetail(HtmlPage):
     def process_page(self):
         p = self.input
+
+        img = CSS("img.auto-style2").match_one(self.root).get("src")
+        p.image = img
+
+        contact_info = XPath("//*[@id='page_content']/table/tr[2]/td//strong[3]").match(
+            self.root
+        )[0]
+        cap_addr = contact_info.getnext().tail.strip()
+        cap_addr += " "
+        cap_addr += contact_info.getnext().getnext().tail.strip()
+        cap_addr += " "
+        cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
+        p.capitol_office.address = cap_addr
+
+        # phone = XPath("//*[@id='page_content']/table/tr[2]/td//strong[4]").match(self.root)[0].tail.strip()
+        # print(phone)
+        # capitol_office.voice
+        # education
+
+        # some might be missing, most already have
+        # party
+        # email
 
         return p
 
@@ -88,5 +110,5 @@ class Legislators(CsvListPage):
                 p.district_office.address = address
 
             if chamber == "upper":
-                return LegDetail(p, source=detail_link)
+                return SenDetail(p, source=detail_link)
             return p

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -1,9 +1,10 @@
 import io
 import csv
-from spatula import URL, HtmlPage, CSS, XPath, HtmlListPage, CsvListPage
+from spatula import URL, CsvListPage  # HtmlPage, CSS, XPath, HtmlListPage
 from openstates.models import ScrapePerson
 from dataclasses import dataclass
-import re
+
+# import re
 
 
 @dataclass
@@ -12,121 +13,121 @@ class PartialPerson:
     chamber: str
     district: str
     source: str
-    staff_name: str
-    staff_email: str
+    # staff_name: str
+    # staff_email: str
 
 
 # 24 total senators
 # 395 total representatives?
 
 
-class SenDetail(HtmlPage):
-    input_type = PartialPerson
+# class SenDetail(HtmlPage):
+#     input_type = PartialPerson
 
-    def process_page(self):
-        party = CSS("span.MemberHeader").match_one(self.root).text_content().strip()
-        party = re.search(r"(.+)\(([A-Z])-.+\)", party).groups()[1]
+#     def process_page(self):
+#         party = CSS("span.MemberHeader").match_one(self.root).text_content().strip()
+#         party = re.search(r"(.+)\(([A-Z])-.+\)", party).groups()[1]
 
-        if party == "D":
-            party = "Democratic"
-        elif party == "R":
-            party = "Republican"
+#         if party == "D":
+#             party = "Democratic"
+#         elif party == "R":
+#             party = "Republican"
 
-        p = ScrapePerson(
-            name=self.input.name,
-            state="nh",
-            chamber=self.input.chamber,
-            district=self.input.district,
-            party=party,
-        )
+#         p = ScrapePerson(
+#             name=self.input.name,
+#             state="nh",
+#             chamber=self.input.chamber,
+#             district=self.input.district,
+#             party=party,
+#         )
 
-        p.add_source(self.input.source)
-        p.add_source(self.source.url)
-        p.add_link(self.source.url, note="homepage")
+#         p.add_source(self.input.source)
+#         p.add_source(self.source.url)
+#         p.add_link(self.source.url, note="homepage")
 
-        p.extras["staff name"] = self.input.staff_name
-        p.extras["staff email"] = self.input.staff_email
+#         p.extras["staff name"] = self.input.staff_name
+#         p.extras["staff email"] = self.input.staff_email
 
-        img = CSS("img.auto-style2").match_one(self.root).get("src")
-        p.image = img
+#         img = CSS("img.auto-style2").match_one(self.root).get("src")
+#         p.image = img
 
-        contact_info = XPath("//*[@id='page_content']/table/tr[2]/td//strong[3]").match(
-            self.root
-        )[0]
-        cap_addr = contact_info.getnext().tail.strip()
-        cap_addr += " "
-        cap_addr += contact_info.getnext().getnext().tail.strip()
-        cap_addr += " "
-        cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
-        p.capitol_office.address = cap_addr
+#         contact_info = XPath("//*[@id='page_content']/table/tr[2]/td//strong[3]").match(
+#             self.root
+#         )[0]
+#         cap_addr = contact_info.getnext().tail.strip()
+#         cap_addr += " "
+#         cap_addr += contact_info.getnext().getnext().tail.strip()
+#         cap_addr += " "
+#         cap_addr += contact_info.getnext().getnext().getnext().tail.strip()
+#         p.capitol_office.address = cap_addr
 
-        if (
-            self.source.url
-            == "http://gencourt.state.nh.us/Senate/members/webpages/district14.aspx"
-        ):
-            phone = CSS("table tr td strong").match(self.root)[5].tail.strip()
-        else:
-            phone = (
-                XPath(
-                    "//*[@id='page_content']/table/tr[2]/td//strong[contains(text(), 'Phone:')]"
-                )
-                .match(self.root)[0]
-                .tail.strip()
-            )
-            phone = re.search(r"(\d{3}-\d{3}-\d{4})(.+)?", phone).groups()[0]
-            p.capitol_office.voice = phone
+#         if (
+#             self.source.url
+#             == "http://gencourt.state.nh.us/Senate/members/webpages/district14.aspx"
+#         ):
+#             phone = CSS("table tr td strong").match(self.root)[5].tail.strip()
+#         else:
+#             phone = (
+#                 XPath(
+#                     "//*[@id='page_content']/table/tr[2]/td//strong[contains(text(), 'Phone:')]"
+#                 )
+#                 .match(self.root)[0]
+#                 .tail.strip()
+#             )
+#             phone = re.search(r"(\d{3}-\d{3}-\d{4})(.+)?", phone).groups()[0]
+#             p.capitol_office.voice = phone
 
-        email = CSS("table tr td a").match(self.root)[1].text_content().strip()
-        p.email = email
+#         email = CSS("table tr td a").match(self.root)[1].text_content().strip()
+#         p.email = email
 
-        return p
-
-
-class Senate(HtmlListPage):
-    source = URL("http://gencourt.state.nh.us/Senate/members/senate_roster.aspx")
-    selector = CSS("div#roseterWrap > div", num_items=24)
-
-    def process_item(self, item):
-
-        header_line = CSS("div").match(item)[0].text_content().strip()
-        header_line_lst = re.search(
-            r"District\s(.+)\s-\sSenator\s(.+)", header_line
-        ).groups()
-
-        district = header_line_lst[0]
-        if district[0] == "0":
-            district = district[1]
-        name = header_line_lst[1].strip()
-
-        staff = CSS("a").match(item)[1]
-        staff_email = staff.get("href")
-        staff_email = re.search(r"mailto:(.+)", staff_email).groups()[0]
-        staff_name = staff.text_content().strip()
-
-        partial = PartialPerson(
-            name=name,
-            chamber="upper",
-            district=district,
-            source=self.source.url,
-            staff_name=staff_name,
-            staff_email=staff_email,
-        )
-
-        detail_link = CSS("a").match(item)[0].get("href")
-
-        return SenDetail(partial, source=detail_link)
+#         return p
 
 
-class House(HtmlPage):
-    source = URL("http://gencourt.state.nh.us/house/members/default.aspx")
+# class Senate(HtmlListPage):
+#     source = URL("http://gencourt.state.nh.us/Senate/members/senate_roster.aspx")
+#     selector = CSS("div#roseterWrap > div", num_items=24)
 
-    def process_page(self):
-        members = XPath("//*[@id='ContentPlaceHolder1_ddlReps']/option").match(
-            self.root
-        )
-        print(len(members))
-        # for member in members:
-        # print(member.text_content())
+#     def process_item(self, item):
+
+#         header_line = CSS("div").match(item)[0].text_content().strip()
+#         header_line_lst = re.search(
+#             r"District\s(.+)\s-\sSenator\s(.+)", header_line
+#         ).groups()
+
+#         district = header_line_lst[0]
+#         if district[0] == "0":
+#             district = district[1]
+#         name = header_line_lst[1].strip()
+
+#         staff = CSS("a").match(item)[1]
+#         staff_email = staff.get("href")
+#         staff_email = re.search(r"mailto:(.+)", staff_email).groups()[0]
+#         staff_name = staff.text_content().strip()
+
+#         partial = PartialPerson(
+#             name=name,
+#             chamber="upper",
+#             district=district,
+#             source=self.source.url,
+#             staff_name=staff_name,
+#             staff_email=staff_email,
+#         )
+
+#         detail_link = CSS("a").match(item)[0].get("href")
+
+#         return SenDetail(partial, source=detail_link)
+
+
+# class House(HtmlPage):
+#     source = URL("http://gencourt.state.nh.us/house/members/default.aspx")
+
+#     def process_page(self):
+#         members = XPath("//*[@id='ContentPlaceHolder1_ddlReps']/option").match(
+#             self.root
+#         )
+#         print(len(members))
+#         # for member in members:
+#         # print(member.text_content())
 
 
 class Legislators(CsvListPage):
@@ -140,41 +141,57 @@ class Legislators(CsvListPage):
     source = URL("http://gencourt.state.nh.us/downloads/members.txt")
 
     def process_item(self, item):
-        print(item)
-        for line in item.values():
-            # print(line)
-            member = line.split("\t")
+        lastname = item["LastName"]
+        firstname = item["FirstName"]
+        middlename = item["MiddleName"]
+        name = firstname + " " + middlename + " " + lastname
 
-            lastname = member[0]
-            firstname = member[1]
-            middlename = member[2]
-            name = firstname + " " + middlename + " " + lastname
+        legislativebody = item["LegislativeBody"]
+        if legislativebody == "H":
+            chamber = "lower"
+        elif legislativebody == "S":
+            chamber = "upper"
 
-            legislativebody = member[3]
-            if legislativebody == "H":
-                chamber = "lower"
-            elif legislativebody == "S":
-                chamber = "upper"
+        district = item["District"]
 
-            district = member[6]
+        # 39 out of 116 legislators have incomplete info (len(member) < 19)
+        # 24 senators and 15 reps
+        # if chamber == "upper":
+        #     if len(district) == 1:
+        #         district_id = "0" + district
+        #     else:
+        #         district_id = district
+        #     # detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
 
-            # 39 out of 116 legislators have incomplete info (len(member) < 19)
-            # 24 senators and 15 reps
-            if chamber == "upper":
-                if len(district) == 1:
-                    district_id = "0" + district
-                else:
-                    district_id = district
-                detail_link = f"http://www.gencourt.state.nh.us/Senate/members/webpages/district{district_id}.aspx"
+        party = item["party"]
+        if party == "D" or party == "d":
+            party = "Democratic"
+        elif party == "R" or party == "r":
+            party = "Republican"
 
-                partial = PartialPerson(
-                    name=name,
-                    chamber=chamber,
-                    district=district,
-                    source=self.source.url,
-                )
+        p = ScrapePerson(
+            name=name, state="nh", chamber=chamber, district=district, party=party
+        )
 
-                return SenDetail(partial, source=detail_link)
+        p.add_source(self.source.url)
+
+        p.family_name = lastname
+        p.given_name = firstname
+
+        # seatno
+        # County
+        # electedStatus
+        # Address
+        # address2
+        # city
+        # Zipcode
+        # State
+        # Phone
+        # WorkEmail
+        # GenderCode
+        # PersonTitle
+
+        return p
 
 
 # # print(len(member))

--- a/scrapers_next/nh/people.py
+++ b/scrapers_next/nh/people.py
@@ -9,6 +9,10 @@ class Legislators(CsvListPage):
         for line in item.values():
             member = line.split("\t")
 
+            # 39 out of 116 legislators have incomplete info
+            if len(member) < 19:
+                print(member)
+
             lastname = member[0]
             firstname = member[1]
             middlename = member[2]
@@ -21,7 +25,11 @@ class Legislators(CsvListPage):
                 chamber = "upper"
 
             district = member[6]
-            party = member[15]
+            if len(member) > 15:
+                party = member[15]
+            else:
+                party = "Democratic"
+                # what should I do when party is not available?
 
             p = ScrapePerson(
                 name=name,
@@ -33,26 +41,32 @@ class Legislators(CsvListPage):
 
             p.add_source(self.source.url)
 
-            address = member[8]
-            address2 = member[9]
-            city = member[10]
-            zipcode = member[11]
-            full_addr = (
-                address + " " + address2 + " " + city + ", New Hampshire" + zipcode
-            )
-            p.district_office.address = full_addr
-
-            phone = member[13]
-            p.district_office.voice = phone
-
-            email = member[14]
-            p.email = email
-
-            gendercode = member[16]
-            p.extras["gender code"] = gendercode
-            title = member[17]
-            p.extras["title"] = title
             county = member[5]
-            p.extras["county"] = county
+            if county != "":
+                p.extras["county"] = county
 
-            yield p
+            address = member[8]
+
+            if len(member) > 9:
+                address2 = member[9]
+                city = member[10]
+                zipcode = member[11]
+                full_addr = (
+                    address + " " + address2 + " " + city + ", New Hampshire" + zipcode
+                )
+                p.district_office.address = full_addr
+
+                phone = member[13]
+                p.district_office.voice = phone
+
+                email = member[14]
+                p.email = email
+
+                gendercode = member[16]
+                p.extras["gender code"] = gendercode
+                title = member[17]
+                p.extras["title"] = title
+            else:
+                p.district_office.address = address
+
+            return p


### PR DESCRIPTION
Writing NH people scraper using spatula framework. Notes:

1. This scraper uses a .txt file as the source and CsvListPage for the Legislators() class. .txt file is actually tab separated instead of a comma separated file.

2. Addresses/phones from the .txt file are not labeled as capitol or district. I am assigning them to additional_offices with contact_type='Primary Office'. Could alternatively assign to district_office.address/voice.

3. The old code did a number of steps to get a detail page for representatives. It used a lookup_url to get some sort of 'seat_map'. seat_map maps 'seatno' (from.txt) to 'seat_number'. 'seat_number' is then inserted into house_profile_url. I could not get this to work for me, but maybe someone else can figure it out. Without this, we are missing detail pages for all House legislators, their images, and any additional address information outside of the .txt file.

@jamesturk 