### PR TITLE
NE: Scrape special differently

### DIFF
--- a/scrapers/ne/__init__.py
+++ b/scrapers/ne/__init__.py
@@ -58,6 +58,14 @@ class Nebraska(State):
             "start_date": "2021-01-06",
             "end_date": "2021-12-31",
         },
+        {
+            "_scraped_name": "107th Legislature 1st Special Session",
+            "identifier": "107S1",
+            "name": "107th Legislature 1st Special Session",
+            "start_date": "2021-09-13",
+            "end_date": "2021-09-30",
+            "classification": "special",
+        },
     ]
     ignored_scraped_sessions = [
         "101st Legislature 1st and 2nd Sessions",


### PR DESCRIPTION
NE Special is dumping all the data into the main search results, with duplicates of the same bill number. 

This changes the code to scrape specials based on intro date. If they end up filing additional bills after session start, this code may need mods to scrape the entire range of days.