### PR TITLE
Wy people spatula

### DIFF
--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -13,7 +13,8 @@ class LegDetail(JsonPage):
         distr_addr = f"{self.data['address']}, {self.data['city']}, {self.data['state']} {self.data['zip']}"
         p.district_office.address = distr_addr
 
-        # self.data['phoneType']
+        # if self.data['phoneType'].strip() not in ["Cell", "Home"]:
+        #     print(self.data['phoneType'])
 
         p.extras["county"] = self.data["county"]
         if self.data["legEducation"] != []:
@@ -81,7 +82,6 @@ class LegList(JsonListPage):
 
         detail_link = f"https://wyoleg.gov/LsoService/api/legislator/{item['legID']}"
         p.add_source(detail_link)
-        # should I add detail_link as homepage?
 
         leg_url = f"http://wyoleg.gov/Legislators/2021/{item['party']}/{item['legID']}"
         p.add_link(leg_url, note="homepage")

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -13,6 +13,8 @@ class LegDetail(JsonPage):
         distr_addr = f"{self.data['address']}, {self.data['city']}, {self.data['state']} {self.data['zip']}"
         p.district_office.address = distr_addr
 
+        p.extras["county"] = self.data["county"]
+
         if self.data["legEducation"] != []:
             p.extras["education"] = self.data["legEducation"]
         if self.data["currentLeadershipPosition"] is not None:
@@ -29,15 +31,12 @@ class LegDetail(JsonPage):
             p.extras["birth place"] = self.data["birthPlace"]
         if self.data["occupationDesc"] is not None:
             p.extras["occupation"] = self.data["occupationDesc"]
-
-        print(self.data[""])
+        if self.data["legLeadership"] != []:
+            p.extras["leadership"] = self.data["legLeadership"]
 
         # self.data['phoneType']
-        # self.data['county']
-        # self.data['countyList']
 
         # self.data['civicOrgs']
-        # self.data['legLeadership']
         # self.data['cityList']
         # self.data['legPriorService']
         # self.data['districtList']
@@ -83,8 +82,6 @@ class LegList(JsonListPage):
         p.family_name = item["lastName"].strip()
 
         p.email = item["eMail"].strip()
-
-        # item['county']
 
         # assuming this is a district office phone
         p.district_office.voice = item["phone"].strip()

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -33,45 +33,13 @@ class LegList(JsonListPage):
 
         p.email = item["eMail"].strip()
 
-        # item['city']
-        # item['state']
-        # item['zip']
+        # item['leadershipOrder']
+        # item['legStatus']
+        # item['county']
+        # item['legID']
 
         # assuming this is a district office phone
         p.district_office.voice = item["phone"].strip()
-
-        # item['religion']
-        # item['onWeb']
-        # item['districtList']
-        # item['lastYrSenate']
-        # item['officesHeld']
-        # item['noGChildren']
-        # item['legStatus']
-        # item['legID']
-        # item['occupationDesc']
-        # item['legEducation']
-        # item['houseYears']
-        # item['currentLeadershipPosition']
-        # item['dob']
-        # item['spouseName']
-        # item['legPriorService']
-        # item['county']
-        # item['birthPlace']
-        # item['occupWeb']
-        # item['leadershipPosition']
-        # item['lastYrHouse']
-        # item['legSponsorYears']
-        # item['countyList']
-        # item['senateYears']
-        # item['remarks']
-        # item['noChildren']
-        # item['firstYrHouse']
-        # item['legCommYears']
-        # item['cityList']
-        # item['firstYrSenate']
-        # item['leadershipOrder']
-        # item['civicOrgs']
-        # item['legLeadership']
 
         return p
 

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -9,42 +9,46 @@ class LegDetail(JsonPage):
         img = f"https://wyoleg.gov/LegislatorSummary/Photos/{self.data['legPhoto']}"
         p.image = img
 
+        # assuming this is a district address
+        distr_addr = f"{self.data['address']}, {self.data['city']}, {self.data['state']} {self.data['zip']}"
+        p.district_office.address = distr_addr
+
+        if self.data["legEducation"] != []:
+            p.extras["education"] = self.data["legEducation"]
+        if self.data["currentLeadershipPosition"] is not None:
+            p.extras["title"] = self.data["currentLeadershipPosition"].strip()
+        if self.data["religion"].strip() != "":
+            p.extras["religion"] = self.data["religion"].strip()
+        if self.data["spouseName"] is not None:
+            p.extras["spouse name"] = self.data["spouseName"]
+        if self.data["noChildren"].strip() != "":
+            p.extras["number of children"] = self.data["noChildren"]
+        if self.data["noGChildren"].strip() != "":
+            p.extras["number of grandchildren"] = self.data["noGChildren"]
+        if self.data["birthPlace"].strip() != "":
+            p.extras["birth place"] = self.data["birthPlace"]
+        if self.data["occupationDesc"] is not None:
+            p.extras["occupation"] = self.data["occupationDesc"]
+
+        print(self.data[""])
+
+        # self.data['phoneType']
         # self.data['county']
-        # self.data['remarks']
-        # self.data['occupationDesc']
+        # self.data['countyList']
+
         # self.data['civicOrgs']
-        # self.data['legEducation']
         # self.data['legLeadership']
         # self.data['cityList']
-        # self.data['countyList']
         # self.data['legPriorService']
         # self.data['districtList']
         # self.data['officesHeld']
-        # self.data['spouseName']
-        # self.data['noChildren']
-        # self.data['noGChildren']
         # self.data['occupWeb']
-        # self.data['dob']
-        # self.data['birthPlace']
-        # self.data['religion']
         # self.data['firstYrHouse']
         # self.data['lastYrHouse']
         # self.data['firstYrSenate']
         # self.data['lastYrSenate']
         # self.data['houseYears']
         # self.data['senateYears']
-
-        # self.data['address']
-        # self.data['city']
-        # self.data['state']
-        # self.data['zip']
-        # self.data['onWeb']
-        # self.data['areaCode']
-        # self.data['phoneType']
-        # self.data['leadershipPosition']
-        # self.data['leadershipOrder']
-        # self.data['currentLeadershipPosition']
-        # self.data['legStatus']
 
         return p
 
@@ -80,8 +84,6 @@ class LegList(JsonListPage):
 
         p.email = item["eMail"].strip()
 
-        # item['leadershipOrder']
-        # item['legStatus']
         # item['county']
 
         # assuming this is a district office phone

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -13,8 +13,9 @@ class LegDetail(JsonPage):
         distr_addr = f"{self.data['address']}, {self.data['city']}, {self.data['state']} {self.data['zip']}"
         p.district_office.address = distr_addr
 
-        p.extras["county"] = self.data["county"]
+        # self.data['phoneType']
 
+        p.extras["county"] = self.data["county"]
         if self.data["legEducation"] != []:
             p.extras["education"] = self.data["legEducation"]
         if self.data["currentLeadershipPosition"] is not None:
@@ -33,21 +34,13 @@ class LegDetail(JsonPage):
             p.extras["occupation"] = self.data["occupationDesc"]
         if self.data["legLeadership"] != []:
             p.extras["leadership"] = self.data["legLeadership"]
-
-        # self.data['phoneType']
-
-        # self.data['civicOrgs']
-        # self.data['cityList']
-        # self.data['legPriorService']
-        # self.data['districtList']
-        # self.data['officesHeld']
-        # self.data['occupWeb']
-        # self.data['firstYrHouse']
-        # self.data['lastYrHouse']
-        # self.data['firstYrSenate']
-        # self.data['lastYrSenate']
-        # self.data['houseYears']
-        # self.data['senateYears']
+        if self.data["civicOrgs"] != []:
+            p.extras["organizations"] = self.data["civicOrgs"]
+        if self.data["houseYears"].strip() != "":
+            p.extras["house years"] = self.data["houseYears"]
+        if self.data["senateYears"].strip() != "":
+            p.extras["senate years"] = self.data["senateYears"]
+        p.extras["prior service"] = self.data["legPriorService"]
 
         return p
 
@@ -89,6 +82,9 @@ class LegList(JsonListPage):
         detail_link = f"https://wyoleg.gov/LsoService/api/legislator/{item['legID']}"
         p.add_source(detail_link)
         # should I add detail_link as homepage?
+
+        leg_url = f"http://wyoleg.gov/Legislators/2021/{item['party']}/{item['legID']}"
+        p.add_link(leg_url, note="homepage")
 
         return LegDetail(p, source=detail_link)
 

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -1,0 +1,86 @@
+from spatula import URL, JsonListPage
+from openstates.models import ScrapePerson
+
+
+class LegList(JsonListPage):
+    def process_item(self, item):
+        name = item["name"].strip()
+
+        party = item["party"].strip()
+        if party == "D":
+            party = "Democratic"
+        elif party == "R":
+            party = "Republican"
+        elif party == "I":
+            party = "Independent"
+        elif party == "L":
+            party = "Libertarian"
+
+        district = item["district"].strip().lstrip("SH0")
+
+        p = ScrapePerson(
+            name=name,
+            state="wy",
+            chamber=self.chamber,
+            district=district,
+            party=party,
+        )
+
+        p.add_source(self.source.url)
+
+        p.given_name = item["firstName"].strip()
+        p.family_name = item["lastName"].strip()
+
+        p.email = item["eMail"].strip()
+
+        # item['city']
+        # item['state']
+        # item['zip']
+
+        # assuming this is a district office phone
+        p.district_office.voice = item["phone"].strip()
+
+        # item['religion']
+        # item['onWeb']
+        # item['districtList']
+        # item['lastYrSenate']
+        # item['officesHeld']
+        # item['noGChildren']
+        # item['legStatus']
+        # item['legID']
+        # item['occupationDesc']
+        # item['legEducation']
+        # item['houseYears']
+        # item['currentLeadershipPosition']
+        # item['dob']
+        # item['spouseName']
+        # item['legPriorService']
+        # item['county']
+        # item['birthPlace']
+        # item['occupWeb']
+        # item['leadershipPosition']
+        # item['lastYrHouse']
+        # item['legSponsorYears']
+        # item['countyList']
+        # item['senateYears']
+        # item['remarks']
+        # item['noChildren']
+        # item['firstYrHouse']
+        # item['legCommYears']
+        # item['cityList']
+        # item['firstYrSenate']
+        # item['leadershipOrder']
+        # item['civicOrgs']
+        # item['legLeadership']
+
+        return p
+
+
+class Senate(LegList):
+    source = URL("https://wyoleg.gov/LsoService/api/legislator/2021/S")
+    chamber = "upper"
+
+
+class House(LegList):
+    source = URL("https://wyoleg.gov/LsoService/api/legislator/2021/H")
+    chamber = "lower"

--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -1,5 +1,52 @@
-from spatula import URL, JsonListPage
+from spatula import URL, JsonListPage, JsonPage
 from openstates.models import ScrapePerson
+
+
+class LegDetail(JsonPage):
+    def process_page(self):
+        p = self.input
+
+        img = f"https://wyoleg.gov/LegislatorSummary/Photos/{self.data['legPhoto']}"
+        p.image = img
+
+        # self.data['county']
+        # self.data['remarks']
+        # self.data['occupationDesc']
+        # self.data['civicOrgs']
+        # self.data['legEducation']
+        # self.data['legLeadership']
+        # self.data['cityList']
+        # self.data['countyList']
+        # self.data['legPriorService']
+        # self.data['districtList']
+        # self.data['officesHeld']
+        # self.data['spouseName']
+        # self.data['noChildren']
+        # self.data['noGChildren']
+        # self.data['occupWeb']
+        # self.data['dob']
+        # self.data['birthPlace']
+        # self.data['religion']
+        # self.data['firstYrHouse']
+        # self.data['lastYrHouse']
+        # self.data['firstYrSenate']
+        # self.data['lastYrSenate']
+        # self.data['houseYears']
+        # self.data['senateYears']
+
+        # self.data['address']
+        # self.data['city']
+        # self.data['state']
+        # self.data['zip']
+        # self.data['onWeb']
+        # self.data['areaCode']
+        # self.data['phoneType']
+        # self.data['leadershipPosition']
+        # self.data['leadershipOrder']
+        # self.data['currentLeadershipPosition']
+        # self.data['legStatus']
+
+        return p
 
 
 class LegList(JsonListPage):
@@ -36,12 +83,15 @@ class LegList(JsonListPage):
         # item['leadershipOrder']
         # item['legStatus']
         # item['county']
-        # item['legID']
 
         # assuming this is a district office phone
         p.district_office.voice = item["phone"].strip()
 
-        return p
+        detail_link = f"https://wyoleg.gov/LsoService/api/legislator/{item['legID']}"
+        p.add_source(detail_link)
+        # should I add detail_link as homepage?
+
+        return LegDetail(p, source=detail_link)
 
 
 class Senate(LegList):


### PR DESCRIPTION
Writing WY people scraper using spatula library. Notes:

1. I assumed item["phone"] is a district office phone. There is a field 'phoneType' ('Cell', 'Home', or 'Work'). Should I assign 'Work' as district office phone and the others as extras? Only 5 out of 90 phones are labeled 'Work'.

2. Note that "https://wyoleg.gov/LsoService/api/legislator/2021/(S|H)" and "https://wyoleg.gov/LsoService/api/legislator/{item['legID']}" are being added to sources while "http://wyoleg.gov/Legislators/2021/{item['party']}/{item['legID']}" is being added to links (homepage).

3. I assumed that self.data['address'] is a district office address.

4. No capitol office information available.

@jamesturk 
We did it! 52 jurisdictions now in spatula!!