### PR TITLE
WV: Events: Catch additional bill references

### DIFF
--- a/scrapers/wv/events.py
+++ b/scrapers/wv/events.py
@@ -12,7 +12,7 @@ class WVEventScraper(Scraper, LXMLMixin):
     _tz = pytz.timezone("US/Eastern")
     # "house bill 123" "senate bill 123" "H.B. 4043" "HB 23" "SCR 29" "S. C. R 23"
     bill_regex = (
-        r"((House Bill|Senate Bill|[HS]\.\s*[BCR]\.\s*([R]\.)*|H\.\s*B\.)\s*\d+)"
+        r"((House Bill|Senate Bill|[HS]\.\s*[BCR]\.\s*([R]\.)*|H\.?\s*B\.?)\s*\d+)"
     )
 
     def scrape(self):


### PR DESCRIPTION
Catches HB1234 which was being missed before due to missing periods after H and B.