### PR TITLE
Ak committee spatula

### DIFF
--- a/scrapers_next/ak/committees.py
+++ b/scrapers_next/ak/committees.py
@@ -1,0 +1,51 @@
+from spatula import URL, CSS, HtmlListPage
+from openstates.models import ScrapeCommittee
+
+
+class CommitteeList(HtmlListPage):
+    source = URL("http://www.akleg.gov/basis/Committee/List/32")
+    selector = CSS("div.area-frame ul.list li", num_items=112)
+
+    def process_item(self, item):
+        comm_name = item.text_content().strip()
+
+        chamber = item.getparent().getprevious().getprevious().text_content().strip()
+        if chamber == "House":
+            chamber = "lower"
+        elif chamber == "Senate":
+            chamber = "upper"
+        elif chamber == "Joint Committee":
+            chamber = "legislature"
+
+        classification = item.getparent().getprevious().text_content().strip()
+
+        if classification == "Finance Subcommittee":
+            com = ScrapeCommittee(
+                name=comm_name,
+                classification="subcommittee",
+                chamber=chamber,
+                parent="FINANCE(FIN)",
+            )
+        else:
+            com = ScrapeCommittee(
+                name=comm_name,
+                classification="committee",
+                chamber=chamber,
+            )
+
+        return com
+
+
+# class House(CommitteeList):
+#     source = URL("http://www.akleg.gov/basis/Committee/List/32")
+#     chamber = "lower"
+
+
+# class Senate(CommitteeList):
+#     source = URL("http://www.akleg.gov/basis/Committee/List/32")
+#     chamber = "upper"
+
+
+# class Joint(CommitteeList):
+#     source = URL("http://www.akleg.gov/basis/Committee/List/32#tabCom3")
+#     chamber = "legislature"


### PR DESCRIPTION
Writing AK committee scraper using spatula library. Notes:

1. There are 6 types of committees for AK: Standing Committees, Special Committees, Other Committees, Joint Committees, Finance Subcommittees, and Conference Committees. All classifications are 'committee' except for Finance Subcommittees. Hard coding the Finance Subcommittee parent as 'FINANCE (FIN)'.

2. Some committees do not have members listed (ex: http://www.akleg.gov/basis/Committee/Details/32?code=HPFG). Just returning their com objects without members.

3. Some committees have 'Public Members'. I am skipping over these members. ex: http://www.akleg.gov/basis/Committee/Details/32?code=SASC#tab1_7

@jamesturk 