### PR TITLE
Ar committee spatula

### DIFF
--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -28,6 +28,15 @@ class HouseJointDetail(HtmlPage):
         except SelectorError:
             pass
 
+        try:
+            extra_info = CSS("div#bodyContent b").match(self.root)
+            for title in extra_info:
+                position = title.text_content().strip()
+                name = title.getnext().tail.strip()
+                com.extras[position] = name
+        except SelectorError:
+            pass
+
         return com
 
 

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -1,0 +1,41 @@
+from spatula import URL, CSS, HtmlListPage
+from openstates.models import ScrapeCommittee
+
+
+class SenList(HtmlListPage):
+    source = URL("https://senate.arkansas.gov/senators/committees/")
+    selector = CSS("ins > ul > li > a")
+
+    def process_item(self, item):
+        comm_name = item.text_content().strip()
+
+        previous_sibs = item.getparent().getparent().itersiblings(preceding=True)
+        for sib in previous_sibs:
+            if len(sib.getchildren()) == 0:
+                chamber_type = sib.text_content().strip()
+                break
+
+        if chamber_type == "Senate Committees":
+            chamber = "upper"
+        elif chamber_type == "Joint Committees":
+            self.skip()
+        elif chamber_type == "Task Forces":
+            self.skip()
+
+        com = ScrapeCommittee(
+            name=comm_name,
+            classification="committee",
+            chamber=chamber,
+        )
+
+        return com
+
+
+# class House(CommList):
+#     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=House")
+#     chamber = "lower"
+
+
+# class Joint(CommList):
+#     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=Joint")
+#     chamber = "legislature"

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -79,6 +79,15 @@ class SenDetail(HtmlPage):
         except SelectorError:
             pass
 
+        try:
+            extra_info = CSS("section.content strong").match(self.root)
+            for title in extra_info:
+                position = title.text_content().strip()
+                name = title.tail.strip().lstrip(":").strip()
+                com.extras[position] = name
+        except SelectorError:
+            pass
+
         return com
 
 

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -3,7 +3,35 @@ from openstates.models import ScrapeCommittee
 import re
 
 
-class CommDetail(HtmlPage):
+class HouseDetail(HtmlPage):
+    def process_page(self):
+        com = self.input
+
+        try:
+            members = XPath("//*[@id='committeesIntroRoster']/div/div/div/a").match(
+                self.root
+            )
+            for member in members:
+                member_dirty = member.text_content().strip().split("\n")
+                mem_name = member_dirty[0].strip() + " " + member_dirty[1].strip()
+                role = (
+                    member.getparent()
+                    .getprevious()
+                    .getprevious()
+                    .text_content()
+                    .strip()
+                )
+                if role.strip() == "":
+                    role = "member"
+                com.add_member(mem_name, role)
+                # many 'ex officio' for House Subcommittees
+        except SelectorError:
+            pass
+
+        return com
+
+
+class SenDetail(HtmlPage):
     def process_page(self):
         com = self.input
 
@@ -93,7 +121,7 @@ class SenSubComms(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return CommDetail(com, source=detail_link)
+        return SenDetail(com, source=detail_link)
 
 
 class SenList(HtmlListPage):
@@ -128,7 +156,7 @@ class SenList(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return CommDetail(com, source=detail_link)
+        return SenDetail(com, source=detail_link)
 
 
 class HouseSubComms(HtmlListPage):
@@ -161,7 +189,7 @@ class HouseSubComms(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return com
+        return HouseDetail(com, source=detail_link)
 
 
 class HouseList(HtmlListPage):
@@ -183,7 +211,7 @@ class HouseList(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return com
+        return HouseDetail(com, source=detail_link)
 
 
 class JointSubComms(HtmlListPage):

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -134,6 +134,39 @@ class HouseList(HtmlListPage):
         return com
 
 
+class JointSubComms(HtmlListPage):
+    source = URL("https://www.arkleg.state.ar.us/Committees/List?type=Joint")
+    selector = CSS("div#bodyContent li a", num_items=31)
+
+    def process_item(self, item):
+        sub_name = item.text_content().strip()
+
+        parent = (
+            item.getparent()
+            .getparent()
+            .getparent()
+            .getparent()
+            .getchildren()[0]
+            .text_content()
+            .strip()
+        )
+
+        com = ScrapeCommittee(
+            name=sub_name.title(),
+            classification="subcommittee",
+            chamber="legislature",
+            parent=parent.title(),
+        )
+
+        detail_link = item.get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com
+
+
 class Joint(HtmlListPage):
     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=Joint")
     selector = CSS("div#bodyContent div.row p a", num_items=19)

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -134,6 +134,23 @@ class HouseList(HtmlListPage):
         return com
 
 
-# class Joint(CommList):
-#     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=Joint")
-#     chamber = "legislature"
+class Joint(HtmlListPage):
+    source = URL("https://www.arkleg.state.ar.us/Committees/List?type=Joint")
+    selector = CSS("div#bodyContent div.row p a", num_items=19)
+
+    def process_item(self, item):
+        comm_name = item.text_content().strip()
+
+        com = ScrapeCommittee(
+            name=comm_name.title(),
+            classification="committee",
+            chamber="legislature",
+        )
+
+        detail_link = item.get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -79,6 +79,39 @@ class SenList(HtmlListPage):
         return com
 
 
+class HouseSubComms(HtmlListPage):
+    source = URL("https://www.arkleg.state.ar.us/Committees/List?type=House")
+    selector = CSS("div#bodyContent li a", num_items=30)
+
+    def process_item(self, item):
+        sub_name = item.text_content().strip()
+
+        parent = (
+            item.getparent()
+            .getparent()
+            .getparent()
+            .getparent()
+            .getchildren()[0]
+            .text_content()
+            .strip()
+        )
+
+        com = ScrapeCommittee(
+            name=sub_name.title(),
+            classification="subcommittee",
+            chamber="lower",
+            parent=parent.title(),
+        )
+
+        detail_link = item.get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com
+
+
 class HouseList(HtmlListPage):
     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=House")
     selector = CSS("div#bodyContent div.row p a", num_items=16)

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -1,10 +1,46 @@
-from spatula import URL, CSS, HtmlListPage, SelectorError
+from spatula import URL, CSS, HtmlListPage
 from openstates.models import ScrapeCommittee
+
+
+class SenSubComms(HtmlListPage):
+    source = URL("https://senate.arkansas.gov/senators/committees/")
+    selector = CSS("ins > ul > li > ul > li", num_items=87)
+
+    def process_item(self, item):
+        sub_name = CSS("a").match_one(item).text_content().strip()
+
+        previous_sibs = (
+            item.getparent().getparent().getparent().itersiblings(preceding=True)
+        )
+        for sib in previous_sibs:
+            if len(sib.getchildren()) == 0:
+                chamber_type = sib.text_content().strip()
+                break
+
+        if chamber_type == "Senate Committees":
+            chamber = "upper"
+        elif chamber_type == "Joint Committees":
+            self.skip()
+        elif chamber_type == "Task Forces":
+            self.skip()
+
+        comm_name = (
+            CSS("a").match(item.getparent().getparent())[0].text_content().strip()
+        )
+
+        com = ScrapeCommittee(
+            name=sub_name,
+            classification="subcommittee",
+            chamber=chamber,
+            parent=comm_name,
+        )
+
+        return com
 
 
 class SenList(HtmlListPage):
     source = URL("https://senate.arkansas.gov/senators/committees/")
-    selector = CSS("ins > ul > li")
+    selector = CSS("ins > ul > li", num_items=45)
 
     def process_item(self, item):
         comm_name = CSS("a").match(item)[0].text_content().strip()
@@ -29,21 +65,6 @@ class SenList(HtmlListPage):
         )
 
         com.add_source(self.source.url)
-
-        try:
-            sub_committees = CSS("ul li a").match(item)
-            for sub_comm in sub_committees:
-                sub_name = sub_comm.text_content().strip()
-
-                com = ScrapeCommittee(
-                    name=sub_name,
-                    classification="subcommittee",
-                    chamber=chamber,
-                    parent=comm_name,
-                )
-                return com
-        except SelectorError:
-            pass
 
         return com
 

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -35,6 +35,12 @@ class SenSubComms(HtmlListPage):
             parent=comm_name,
         )
 
+        detail_link = CSS("a").match_one(item).get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
         return com
 
 
@@ -64,14 +70,35 @@ class SenList(HtmlListPage):
             chamber=chamber,
         )
 
+        detail_link = CSS("a").match(item)[0].get("href")
+
         com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
 
         return com
 
 
-# class House(CommList):
-#     source = URL("https://www.arkleg.state.ar.us/Committees/List?type=House")
-#     chamber = "lower"
+class HouseList(HtmlListPage):
+    source = URL("https://www.arkleg.state.ar.us/Committees/List?type=House")
+    selector = CSS("div#bodyContent div.row p a", num_items=16)
+
+    def process_item(self, item):
+        comm_name = item.text_content().strip()
+
+        com = ScrapeCommittee(
+            name=comm_name.title(),
+            classification="committee",
+            chamber="lower",
+        )
+
+        detail_link = item.get("href")
+
+        com.add_source(self.source.url)
+        com.add_source(detail_link)
+        com.add_link(detail_link, note="homepage")
+
+        return com
 
 
 # class Joint(CommList):

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -3,7 +3,7 @@ from openstates.models import ScrapeCommittee
 import re
 
 
-class HouseDetail(HtmlPage):
+class HouseJointDetail(HtmlPage):
     def process_page(self):
         com = self.input
 
@@ -24,7 +24,7 @@ class HouseDetail(HtmlPage):
                 if role.strip() == "":
                     role = "member"
                 com.add_member(mem_name, role)
-                # many 'ex officio' for House Subcommittees
+                # many 'ex officio' roles for House Subcommittees, Joint Committees, and Joint Subcommittees
         except SelectorError:
             pass
 
@@ -189,7 +189,7 @@ class HouseSubComms(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return HouseDetail(com, source=detail_link)
+        return HouseJointDetail(com, source=detail_link)
 
 
 class HouseList(HtmlListPage):
@@ -211,7 +211,7 @@ class HouseList(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return HouseDetail(com, source=detail_link)
+        return HouseJointDetail(com, source=detail_link)
 
 
 class JointSubComms(HtmlListPage):
@@ -244,7 +244,7 @@ class JointSubComms(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return com
+        return HouseJointDetail(com, source=detail_link)
 
 
 class Joint(HtmlListPage):
@@ -266,4 +266,4 @@ class Joint(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return com
+        return HouseJointDetail(com, source=detail_link)

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -1,15 +1,15 @@
-from spatula import URL, CSS, HtmlListPage
+from spatula import URL, CSS, HtmlListPage, SelectorError
 from openstates.models import ScrapeCommittee
 
 
 class SenList(HtmlListPage):
     source = URL("https://senate.arkansas.gov/senators/committees/")
-    selector = CSS("ins > ul > li > a")
+    selector = CSS("ins > ul > li")
 
     def process_item(self, item):
-        comm_name = item.text_content().strip()
+        comm_name = CSS("a").match(item)[0].text_content().strip()
 
-        previous_sibs = item.getparent().getparent().itersiblings(preceding=True)
+        previous_sibs = item.getparent().itersiblings(preceding=True)
         for sib in previous_sibs:
             if len(sib.getchildren()) == 0:
                 chamber_type = sib.text_content().strip()
@@ -27,6 +27,23 @@ class SenList(HtmlListPage):
             classification="committee",
             chamber=chamber,
         )
+
+        com.add_source(self.source.url)
+
+        try:
+            sub_committees = CSS("ul li a").match(item)
+            for sub_comm in sub_committees:
+                sub_name = sub_comm.text_content().strip()
+
+                com = ScrapeCommittee(
+                    name=sub_name,
+                    classification="subcommittee",
+                    chamber=chamber,
+                    parent=comm_name,
+                )
+                return com
+        except SelectorError:
+            pass
 
         return com
 

--- a/scrapers_next/ar/committees.py
+++ b/scrapers_next/ar/committees.py
@@ -15,7 +15,7 @@ class CommDetail(HtmlPage):
                 .text_content()
                 .strip()
             )
-            chair = re.search(r"Senator\s(.+)", chair).groups()[0]
+            chair = re.search(r"(Senator|Representative)\s(.+)", chair).groups()[1]
             com.add_member(chair, "Chair")
         except SelectorError:
             pass
@@ -28,7 +28,9 @@ class CommDetail(HtmlPage):
                 .text_content()
                 .strip()
             )
-            vice_chair = re.search(r"Senator\s(.+)", vice_chair).groups()[0]
+            vice_chair = re.search(
+                r"(Senator|Representative)\s(.+)", vice_chair
+            ).groups()[1]
             com.add_member(vice_chair, "Vice-Chair")
         except SelectorError:
             pass
@@ -42,7 +44,9 @@ class CommDetail(HtmlPage):
             )
             for member in additional_members:
                 member = member.text_content().strip()
-                member = re.search(r"Senator\s(.+)", member).groups()[0]
+                member = re.search(r"(Senator|Representative)\s(.+)", member).groups()[
+                    1
+                ]
                 com.add_member(member, "member")
         except SelectorError:
             pass
@@ -89,7 +93,7 @@ class SenSubComms(HtmlListPage):
         com.add_source(detail_link)
         com.add_link(detail_link, note="homepage")
 
-        return com
+        return CommDetail(com, source=detail_link)
 
 
 class SenList(HtmlListPage):


### PR DESCRIPTION
Writing AR committee scraper using spatula library. Notes:

1. Just to give you an idea of the structure/outline of this code, there are 8 classes:
- HouseJointDetail() scrapes Joint Committee, Joint Subcommittee, House Committee, and House Subcommittee details.
- SenDetail() scrapes Senate Committee and Senate Subcommittee details.
- SenSubComms() scrapes Senate Subcommittees.
- SenList() scrapes Senate Committees.
- HouseSubComms() scrapes House Subcommittees.
- HouseList() scrapes House Committees.
- JointSubComms() scrapes Joint Subcommittees.
- Joint() scrapes Joint Committees.

There may be a way to combine the following classes as they have the same sources, but different selectors. I did not do this due to time constraints:
Joint() and JointSubComms() 
HouseList() and HouseSubComms()
SenList() and SenSubComms()

2. Skipping Joint Committees and Task Forces in SenList() and SenSubComms(). Joint Committees are being scraped in Joint() and JointSubComms().

3. Some committees/subcommittees do not have any members listed. Should these be skipped? At the moment their com objects are being returned without members. What if a committee/subcommittee has Legislative Analyst, Administrative Assistant, or Legislative Attorney but no members listed?

4. Many House Subcommittees, Joint Committees, and Joint Subcommittees have members with the role 'ex officio'. These members are currently being added. Should they be included?

@jamesturk 