### PR TITLE
AR: Stabilize event source url

### DIFF
--- a/scrapers/ar/events.py
+++ b/scrapers/ar/events.py
@@ -62,7 +62,7 @@ class AREventScraper(Scraper):
                 location_name=location,
                 description="",
             )
-            event.add_source(url)
+            event.add_source("https://www.arkleg.state.ar.us/Calendars/Meetings")
 
             if row.xpath(".//a[@aria-label='Agenda']"):
                 agenda_url = row.xpath(".//a[@aria-label='Agenda']/@href")[0]


### PR DESCRIPTION
The AR Event source URL was changing on every scrape, lock it to the real url without args.