### PR TITLE
Enable EmptyScrape for Events scrapers

### DIFF
--- a/scrapers/de/events.py
+++ b/scrapers/de/events.py
@@ -2,6 +2,7 @@ import datetime as dt
 
 from utils import LXMLMixin
 from openstates.scrape import Event, Scraper
+from openstates.exceptions import EmptyScrape
 import json
 import pytz
 
@@ -61,6 +62,12 @@ class DEEventScraper(Scraper, LXMLMixin):
 
     def scrape(self):
         url = "https://legis.delaware.gov/json/CommitteeMeetings/GetUpcomingCommitteeMeetings"
-        data = self.post(url).json()["Data"]
+        resp = self.post(url)
+
+        if resp.text == "":
+            raise EmptyScrape
+            return
+
+        data = resp.json()["Data"]
         for item in data:
             yield from self.scrape_meeting_notice(item, url)

--- a/scrapers/id/events.py
+++ b/scrapers/id/events.py
@@ -2,15 +2,20 @@ import pytz
 import dateutil.parser
 import lxml
 from openstates.scrape import Scraper, Event
+from openstates.exceptions import EmptyScrape
 
 
 class IDEventScraper(Scraper):
     _tz = pytz.timezone("America/Boise")
+    empty = []
 
     def scrape(self, chamber=None):
         chambers = [chamber] if chamber is not None else ["upper", "lower"]
         for chamber in chambers:
             yield from self.scrape_chamber(chamber)
+
+        if self.empty == ["upper", "lower"]:
+            raise EmptyScrape
 
     def scrape_chamber(self, chamber):
         if chamber == "upper":
@@ -20,6 +25,11 @@ class IDEventScraper(Scraper):
 
         page = self.get(url).content
         page = lxml.html.fromstring(page)
+
+        if page.xpath(
+            "//div[@id='allDiv' and contains(text(),'No meetings scheduled')]"
+        ):
+            self.empty.append(chamber)
 
         for row in page.xpath('//div[@id="ai1ec-container"]/div'):
             month = row.xpath(

--- a/scrapers/id/events.py
+++ b/scrapers/id/events.py
@@ -7,14 +7,14 @@ from openstates.exceptions import EmptyScrape
 
 class IDEventScraper(Scraper):
     _tz = pytz.timezone("America/Boise")
-    empty = []
+    empty_chambers = []
 
     def scrape(self, chamber=None):
         chambers = [chamber] if chamber is not None else ["upper", "lower"]
         for chamber in chambers:
             yield from self.scrape_chamber(chamber)
 
-        if self.empty == ["upper", "lower"]:
+        if self.empty_chambers == ["upper", "lower"]:
             raise EmptyScrape
 
     def scrape_chamber(self, chamber):
@@ -29,7 +29,7 @@ class IDEventScraper(Scraper):
         if page.xpath(
             "//div[@id='allDiv' and contains(text(),'No meetings scheduled')]"
         ):
-            self.empty.append(chamber)
+            self.empty_chambers.append(chamber)
 
         for row in page.xpath('//div[@id="ai1ec-container"]/div'):
             month = row.xpath(

--- a/scrapers/me/events.py
+++ b/scrapers/me/events.py
@@ -4,6 +4,7 @@ import datetime
 import json
 from utils import LXMLMixin
 from openstates.scrape import Scraper, Event
+from openstates.exceptions import EmptyScrape
 
 
 class MEEventScraper(Scraper, LXMLMixin):
@@ -72,6 +73,9 @@ class MEEventScraper(Scraper, LXMLMixin):
         url = url.format(start_date, end_date)
 
         page = json.loads(self.get(url).content)
+
+        if len(page) == 0:
+            raise EmptyScrape
 
         for row in page:
             if row["Cancelled"] is True or row["Postponed"] is True:

--- a/scrapers/mt/events.py
+++ b/scrapers/mt/events.py
@@ -1,4 +1,5 @@
 from openstates.scrape import Scraper, Event
+from openstates.exceptions import EmptyScrape
 from dateutil import parser, relativedelta
 import datetime
 import lxml
@@ -38,6 +39,8 @@ class MTEventScraper(Scraper):
 
         page = self.get(url).content
         page = lxml.html.fromstring(page)
+        if len(page.xpath("//p[contains(text(), 'No Records')]")) == 2:
+            raise EmptyScrape
         page.make_links_absolute(url)
 
         for row in page.xpath("//table[@border]/tr"):

--- a/scrapers/or/events.py
+++ b/scrapers/or/events.py
@@ -3,6 +3,7 @@ import logging
 import pytz
 
 from openstates.scrape import Scraper, Event
+from openstates.exceptions import EmptyScrape
 from .apiclient import OregonLegislatorODataClient
 from .utils import SESSION_KEYS
 
@@ -43,6 +44,9 @@ class OREventScraper(Scraper):
             start_date=start_date.strftime(self._DATE_FORMAT),
             session=session_key,
         )
+
+        if len(meetings_response) == 0:
+            raise EmptyScrape
 
         for meeting in meetings_response:
             event_date = self._TZ.localize(


### PR DESCRIPTION
Raise EmptyScrape for event scrapers when there are no events scheduled, as opposed to the scrapers emitting no results due to an error.

