### PR TITLE
AL: correct session for version urls

### DIFF
--- a/scrapers/al/bills.py
+++ b/scrapers/al/bills.py
@@ -281,12 +281,11 @@ class ALBillScraper(Scraper):
             if not title:
                 title = "[No title given by state]"
             bill.title = title
+            session = "2021FS" if self.session == "2021s1" else self.session
 
             version_url_base = (
                 "http://alisondb.legislature.state.al.us/ALISON/"
-                "SearchableInstruments/{0}/PrintFiles/{1}-".format(
-                    self.session, bill_id
-                )
+                "SearchableInstruments/{0}/PrintFiles/{1}-".format(session, bill_id)
             )
             versions = bill_doc.xpath(
                 '//table[@class="box_versions"]/tr/td[2]/font/text()'


### PR DESCRIPTION
AL has different url structure for 2021S1 bills, so just updates the version url to not be 404

Ex: 
http://alisondb.legislature.state.al.us/ALISON/SearchableInstruments/2021s1/PrintFiles/HR1-int.pdf should actually be
http://alisondb.legislature.state.al.us/ALISON/SearchableInstruments/2021FS/PrintFiles/HR1-int.pdf
