### PR TITLE
FL: ignore 2021B until bills posted

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -149,6 +149,7 @@ class Florida(State):
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),
         "2022",
+        "2021B",
         "2020 Org.",
         "2019 I",  # Empty, maybe informational session
         "2010",


### PR DESCRIPTION
New session starting [November 15th through 19th](https://www.flgov.com/2021/10/29/governor-ron-desantis-announces-date-of-special-session-to-protect-florida-jobs/)