### PR TITLE
FL: Added session for 2022 prefiled bills

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -145,10 +145,16 @@ class Florida(State):
             "start_date": "2021-05-12",
             "end_date": "2021-05-21",
         },
+        {
+            "name": "2022 Regular Session",
+            "identifier": "2022",
+            "classification": "primary",
+            "start_date": "2022-01-11",
+            "end_date": "2022-03-11",
+        },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),
-        "2022",
         "2021B",
         "2020 Org.",
         "2019 I",  # Empty, maybe informational session

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -557,6 +557,7 @@ class HouseSearchPage(HtmlListPage):
         # Keep the digits and all following characters in the bill's ID
         bill_number = re.search(r"^\w+\s(\d+\w*)$", self.input.identifier).group(1)
         session_number = {
+            "2022": "93",
             "2021A": "92",
             "2021": "90",
             "2020": "89",


### PR DESCRIPTION
openstates/issues#491
Prefiled bills are now being introduced for the Florida 2022 session. Added the 2022 session to the Florida scraper.

Source of the FL 2022 session dates:
https://www.myfloridahouse.gov/FileStores/Web/HouseContent/Approved/ClerksOffice/ImportantLegislativeDates.pdf