### PR TITLE
GA: Add 2021s1 meta, fix broken source links

### DIFF
--- a/scrapers/ga/__init__.py
+++ b/scrapers/ga/__init__.py
@@ -74,9 +74,16 @@ class Georgia(State):
             "end_date": "2021-04-02",
             "active": True,
         },
+        {
+            "_scraped_name": "2021 Special Session",
+            "identifier": "2021_ss",
+            "name": "2021 Special Session",
+            "start_date": "2021-11-03",
+            "end_date": "2021-11-10",
+            "active": True,
+        },
     ]
     ignored_scraped_sessions = [
-        "2021 Special Session",
         "2009-2010 Regular Session",
         "2007-2008 Regular Session",
         "2005 Special Session",

--- a/scrapers/ga/bills.py
+++ b/scrapers/ga/bills.py
@@ -157,6 +157,9 @@ class GABillScraper(Scraper):
             if instrument["Suffix"]:
                 bill_id += instrument["Suffix"]
 
+            # special session bills get a suffix that doesn't show up in the site
+            bill_id = bill_id.replace("EX", "")
+
             title = instrument["Caption"]
             description = instrument["Summary"]
 

--- a/scrapers/ga/util.py
+++ b/scrapers/ga/util.py
@@ -52,6 +52,7 @@ def backoff(function, *args, **kwargs):
 # available via the session dropdown on
 # http://www.legis.ga.gov/Legislation/en-US/Search.aspx
 SESSION_SITE_IDS = {
+    "2021_ss": 1030,
     "2021_22": 1029,
     "2020_ss": "1027",
     "2019_20": 27,


### PR DESCRIPTION
Just flagging this one -- changing the source link for bills will blow away the cache for other sessions. 

Feel free to merge when ready, bills are filed.

@NewAgeAirbender @jamesturk 