### PR TITLE
GA: correct pdf links

### DIFF
--- a/scrapers/ga/bills.py
+++ b/scrapers/ga/bills.py
@@ -275,6 +275,13 @@ class GABillScraper(Scraper):
                 name, url, doc_id, version_id = [
                     version[x] for x in ["Description", "Url", "Id", "Version"]
                 ]
+                if session == "2021_ss":
+                    # gets http://www.legis.ga.gov/Legislation/2021EX/202712.pdf
+                    # need https://www.legis.ga.gov/api/legislation/document/2021EX/202712
+                    bill_bit = re.search(r"n/(.*)\.pdf", url).group(1)
+                    url = (
+                        f"https://www.legis.ga.gov/api/legislation/document/{bill_bit}"
+                    )
                 link = bill.add_version_link(name, url, media_type="application/pdf")
                 link["extras"] = {
                     "_internal_document_id": doc_id,


### PR DESCRIPTION
Special session links have been leading to a 404 page. Takes the version url from incorrect `http://www.legis.ga.gov/Legislation/2021EX/202712.pdf` and gives correct link `https://www.legis.ga.gov/api/legislation/document/2021EX/202712`