### PR TITLE
MD: ignore special session until bills posted

### DIFF
--- a/scrapers/md/__init__.py
+++ b/scrapers/md/__init__.py
@@ -167,6 +167,7 @@ class Maryland(State):
         },
     ]
     ignored_scraped_sessions = [
+        "2021 Special Session",
         "1996 Regular Session",
         "1997 Regular Session",
         "1998 Regular Session",


### PR DESCRIPTION
Special session starting [Dec 6](https://www.marylandmatters.org/2021/07/23/legislative-leaders-eye-early-december-special-session-to-draw-congressional-map/)