### PR TITLE
AR: Remove microseconds from bill action dates

### DIFF
--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -105,7 +105,9 @@ class ARBillScraper(Scraper):
             actor = {"H": "lower", "S": "upper"}[row[7].upper()]
 
             date = TIMEZONE.localize(
-                datetime.datetime.strptime(row[5], "%Y-%m-%d %H:%M:%S.%f")
+                datetime.datetime.strptime(row[5], "%Y-%m-%d %H:%M:%S.%f").replace(
+                    microsecond=0
+                )
             )
 
             action = row[6]


### PR DESCRIPTION
This is the only state where we store microseconds, and occasionally these seem to change in the API and break cache for no reason. 