### PR TITLE
VT: ignore special session for now

### DIFF
--- a/scrapers/vt/__init__.py
+++ b/scrapers/vt/__init__.py
@@ -87,6 +87,7 @@ class Vermont(State):
         },
     ]
     ignored_scraped_sessions = [
+        "2021 Special Session",
         "2020 Training Session",
         "2009 Special Session",
     ]


### PR DESCRIPTION
New special session [starts monday](https://www.wcax.com/2021/11/16/special-session-begin-monday-municipal-mask-mandates/)