### PR TITLE
AR: ignore 2022 until bills posted

### DIFF
--- a/scrapers/ar/__init__.py
+++ b/scrapers/ar/__init__.py
@@ -182,6 +182,7 @@ class Arkansas(State):
         },
     ]
     ignored_scraped_sessions = [
+        "Fiscal Session, 2022",
         "Regular Session, 2009",
         "Fiscal Session, 2010",
         "Regular Session, 2007",


### PR DESCRIPTION
Bills scheduled to [prefile 1-10-22](https://www.arkleg.state.ar.us/Bureau/Document?type=pdf&source=assembly%2F2021%2F2021R%2FDocuments&filename=BLR-JBC+2022+Important+Dates)