### PR TITLE
SD: Vote Null Check

### DIFF
--- a/scrapers/sd/__init__.py
+++ b/scrapers/sd/__init__.py
@@ -134,7 +134,7 @@ class SouthDakota(State):
             "name": "2021 Regular Session",
             "start_date": "2021-01-12",
             "end_date": "2021-03-29",
-            "active": True,
+            # "active": True,
         },
         {
             "_scraped_name": "2021r",
@@ -152,7 +152,7 @@ class SouthDakota(State):
             "start_date": "2021-11-08",
             "end_date": "2021-11-12",
             "classification": "special",
-            "active": True,
+            # "active": True,
         },
     ]
     ignored_scraped_sessions = ["2022"]

--- a/scrapers/sd/__init__.py
+++ b/scrapers/sd/__init__.py
@@ -134,7 +134,7 @@ class SouthDakota(State):
             "name": "2021 Regular Session",
             "start_date": "2021-01-12",
             "end_date": "2021-03-29",
-            # "active": True,
+            "active": True,
         },
         {
             "_scraped_name": "2021r",
@@ -152,7 +152,7 @@ class SouthDakota(State):
             "start_date": "2021-11-08",
             "end_date": "2021-11-12",
             "classification": "special",
-            # "active": True,
+            "active": True,
         },
     ]
     ignored_scraped_sessions = ["2022"]

--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -284,6 +284,9 @@ class SDBillScraper(Scraper, LXMLMixin):
                 chamber = "upper"
             elif "Joint" in location:
                 chamber = "legislature"
+            else:
+                self.warning("Bad Vote chamber: '%s', skipping" % location)
+                return
         else:
             self.warning("Bad Vote chamber: '%s', skipping" % location)
             return

--- a/scrapers/sd/bills.py
+++ b/scrapers/sd/bills.py
@@ -277,12 +277,13 @@ class SDBillScraper(Scraper, LXMLMixin):
         page = self.get(url).json()
 
         location = page["actionLog"]["FullName"]
-        if "House" in location:
-            chamber = "lower"
-        elif "Senate" in location:
-            chamber = "upper"
-        elif "Joint" in location:
-            chamber = "legislature"
+        if location:
+            if "House" in location:
+                chamber = "lower"
+            elif "Senate" in location:
+                chamber = "upper"
+            elif "Joint" in location:
+                chamber = "legislature"
         else:
             self.warning("Bad Vote chamber: '%s', skipping" % location)
             return


### PR DESCRIPTION
Scraper was failing because of null values on the location on the ActionLog part of the api, add a check for that and throw warning.