### PR TITLE
KS: add back regular session for carryover bills

### DIFF
--- a/scrapers/ks/__init__.py
+++ b/scrapers/ks/__init__.py
@@ -73,7 +73,7 @@ class Kansas(State):
             "start_date": "2021-01-11",
             # TODO: set real end date
             "end_date": "2022-05-31",
-            "active": False,
+            "active": True,
         },
         {
             "_scraped_name": "b2021s",
@@ -82,7 +82,7 @@ class Kansas(State):
             "name": "2021 Special Session",
             "start_date": "2021-11-22",
             "end_date": "2021-11-25",
-            "active": True,
+            "active": False,
         },
     ]
     ignored_scraped_sessions = []


### PR DESCRIPTION
2022 prefiles are being posted ([HB 2458](http://www.kslegislature.org/li/b2021_22/measures/hb2458/) for example), so adds back the regular session and removes active from special session.