### PR TITLE
HI: update urls to avoid SSLErrors

### DIFF
--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -103,7 +103,7 @@ class Hawaii(State):
     def get_session_list(self):
         # doesn't include current session, we need to change it
         sessions = url_xpath(
-            "http://www.capitol.hawaii.gov/archives/main.aspx",
+            "https://capitol.hawaii.gov/archives/main.aspx",
             "//div[@class='roundedrect gradientgray shadow archiveyears']/a/text()",
         )
         sessions.remove("Archives Main")

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -5,7 +5,7 @@ from openstates.scrape import Scraper, Bill, VoteEvent
 from .utils import get_short_codes
 from urllib import parse as urlparse
 
-HI_URL_BASE = "https://www.capitol.hawaii.gov"
+HI_URL_BASE = "https://capitol.hawaii.gov"
 SHORT_CODES = "%s/committees/committees.aspx?chamber=all" % (HI_URL_BASE)
 
 
@@ -192,8 +192,8 @@ class HIBillScraper(Scraper):
                 name = http_href[0].text_content().strip()
                 pdf_href = tds[1].xpath("./a")
 
-                http_link = http_href[0].attrib["href"]
-                pdf_link = pdf_href[0].attrib["href"]
+                http_link = http_href[0].attrib["href"].replace("www.", "")
+                pdf_link = pdf_href[0].attrib["href"].replace("www.", "")
 
                 # some bills (and GMs) swap the order or double-link to the same format
                 # so detect the type, and ignore dupes
@@ -226,7 +226,7 @@ class HIBillScraper(Scraper):
         last_item = ""
 
         for link in links:
-            filename = link.attrib["href"]
+            filename = link.attrib["href"].replace("www.", "")
             name = link.text_content().strip()
             if name == "" and last_item != "":
                 name = last_item
@@ -244,7 +244,7 @@ class HIBillScraper(Scraper):
         last_item = ""
 
         for link in links:
-            filename = link.attrib["href"]
+            filename = link.attrib["href"].replace("www.", "")
             name = link.text_content().strip()
             if name == "" and last_item != "":
                 name = last_item
@@ -361,7 +361,7 @@ class HIBillScraper(Scraper):
         list_html = self.get(report_page_url).text
         list_page = lxml.html.fromstring(list_html)
         for bill_url in list_page.xpath("//a[@class='report']"):
-            bill_url = bill_url.attrib["href"]
+            bill_url = bill_url.attrib["href"].replace("www.", "")
             yield from self.scrape_bill(session, chamber, billtype_map, bill_url)
 
     def scrape(self, chamber=None, session=None):

--- a/scrapers/hi/committees.py
+++ b/scrapers/hi/committees.py
@@ -3,7 +3,7 @@ from openstates.scrape import Scraper, Organization
 import lxml.html
 
 
-HI_URL_BASE = "http://capitol.hawaii.gov"
+HI_URL_BASE = "https://capitol.hawaii.gov"
 
 
 def get_chamber_url(chamber):

--- a/scrapers/hi/events.py
+++ b/scrapers/hi/events.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 import pytz
 
 
-URL = "http://www.capitol.hawaii.gov/upcominghearings.aspx"
+URL = "https://capitol.hawaii.gov/upcominghearings.aspx"
 
 TIMEZONE = pytz.timezone("Pacific/Honolulu")
 


### PR DESCRIPTION
HI has updated their site, causing SSL errors. Updates the base urls on all HI scrapers, but looks like the site has fixed hrefs for bill links, so popped a replace link on those. The committee scraper is fine since the links pulled from the page aren't fixed to a "www." url.