### PR TITLE
FL: Avoid SSL Error

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -15,7 +15,7 @@ class Florida(State):
         # "events": FlEventScraper,
     }
     # Full session list through 2019:
-    # https://www.flsenate.gov/PublishedContent/OFFICES/SECRETARY/SessionsoftheFloridaSenateFromStatehood.pdf
+    # https://flsenate.gov/PublishedContent/OFFICES/SECRETARY/SessionsoftheFloridaSenateFromStatehood.pdf
     legislative_sessions = [
         {
             "name": "2011 Regular Session",
@@ -136,7 +136,7 @@ class Florida(State):
             "classification": "primary",
             "start_date": "2021-03-02",
             "end_date": "2021-05-01",
-            "active": True,
+            "active": False,
         },
         {
             "name": "2021 Special Session A",
@@ -151,7 +151,7 @@ class Florida(State):
             "classification": "special",
             "start_date": "2021-11-15",
             "end_date": "2021-11-19",
-            "active": True,
+            "active": False,
         },
         {
             "name": "2022 Regular Session",
@@ -212,4 +212,4 @@ class Florida(State):
 
         requests.packages.urllib3.disable_warnings()
         requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ":HIGH:!DH:!aNULL"
-        return url_xpath("http://flsenate.gov", "//option/text()")
+        return url_xpath("https://flsenate.gov", "//option/text()", False)

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode
 from collections import defaultdict
 from openstates.scrape import Bill, VoteEvent, Scraper
 from openstates.utils import format_datetime
-from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage
+from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage, URL
 
 # from https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small
 import requests
@@ -58,8 +58,9 @@ class BillList(HtmlListPage):
 
     def get_source_from_input(self):
         # to test scrape an individual bill, add &billNumber=1351
-        return (
-            f"https://flsenate.gov/Session/Bills/{self.input['session']}?chamber=both"
+        return URL(
+            f"https://flsenate.gov/Session/Bills/{self.input['session']}?chamber=both",
+            verify=False,
         )
 
     def get_next_source(self):


### PR DESCRIPTION
So the scraper has been failing due to SSL errors like [this one](https://bobsled.openstates.org/run/fcb1cb8f3c164324a11068fd8b698684), so figured out how to get around it for the initial session list, but still getting the error on bill scrapes trying to hit `https://flsenate.gov/Session/Bills/2022?chamber=both`. Wasn't sure how to get around it using spatula, @jamesturk any thoughts?

Error text:
`requests.exceptions.SSLError: HTTPSConnectionPool(host='flsenate.gov', port=443): Max retries exceeded with url: /Session/Bills/2022?chamber=both (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))`

Also updating current sessions.