### PR TITLE
HI: capture 2022 bills

### DIFF
--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -81,6 +81,14 @@ class Hawaii(State):
             "name": "2021 Regular Session",
             "start_date": "2021-01-20",
             "end_date": "2021-05-09",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2022",
+            "identifier": "2022 Regular Session",
+            "name": "2022 Regular Session",
+            "start_date": "2022-01-19",
+            "end_date": "2022-04-28",
             "active": True,
         },
     ]


### PR DESCRIPTION
2021 has a bunch of bills [carrying over into 2022](https://www.capitol.hawaii.gov/session2022/bills/) that have already been posted