### PR TITLE
WIP RI 2022

### DIFF
--- a/scrapers/ri/__init__.py
+++ b/scrapers/ri/__init__.py
@@ -89,6 +89,15 @@ class RhodeIsland(State):
             "name": "2021 Regular Session",
             "start_date": "2021-01-05",
             "end_date": "2021-06-30",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2022",
+            "classification": "primary",
+            "identifier": "2022",
+            "name": "2022 Regular Session",
+            "start_date": "2022-01-04",
+            "end_date": "2022-06-30",
             "active": True,
         },
     ]


### PR DESCRIPTION
- remove utils.State, now in openstates.scrape
- update to os 6.8.0
- AL update for OS 6.8.0
- move to openstates.state.Scrape import
- set latest sessions as active
- remove session checks
- copy active sessions from bobsled config
- MN: catch bills that are only mentioned in description
- FL: ignore 2021B until bills posted
- FL: Added session for 2022 prefiled bills
- NC: Fix bad date range confusing dateutil parser
- VA: ignore 2022 until bills posted
- The co committee scraper done
- The wi committee scraper
- The dc committe scraper
- NH: add 2022 session
- WV: ignore legacy sessions
- FL: add active tag to 2022 session
- GA: ignore special session until bills posted
- GA: Add 2021s1 meta, fix broken source links
- NE: remove table class thats no longer on page
- GA: correct pdf links
- UT: Add 2021S2
- ND:  Add 2021S1, adjust scraper for specials
- CO: use timeout parameter
- DC: no duplicate sources/links
- SD: Add 2021S1
- SD: Add 2021S1
- CO: fix for duplicates
- FL: second special session
- FL: update active tags
- poetry updates
- no empty committees
- USA: Move to structured legal cites
- SD: add 2021 second special
- MD: ignore special session until bills posted
- WV: Ignore more legacy sessions
- NV: 2021 first special
- NV: set 2021 special to active
- TN: add active flag to third special session
- OK: add 2021 special session
- OK: add special session to meta session id map
- AR: Remove microseconds from bill action dates
- AZ: Add 2022 prefiles
- Clean Branch
- Clean branch for NH committee
- NH: update urls
- NH: skip versions and resolutions check
- NH: update 2022 end date
- VT: ignore special session for now
- Tried to clean branch
- specified my except
- Clean branch
- bump versions
- remove some ported committees
- NH: timeout=30
- OK: skip empty members
- OK: skip empty members, all of 'em
- remove more obsolete committees scrapers
- LA: Ignore 2022 for now, add session commented out
- NH: update source and amendment urls
- VA: update session info
- VA: add 2022 to site id map
- KS: 2021S1
- VA: remove active on past session
- VT: Add 2021 first special, and fix some hardcoded broken document links
- AR: ignore 2022 until bills posted
- SD: skip location on vote if null
- SD: add check if bad chamber
- add db to scrapers
- openstates 6.9.2
- add initdb.sh
- rename init-db
- FL: move scraper from old to new
- FL: committees fix
- MD: support special session
- MO: support 2022 prefiles
- AR: support special
- NM: 2021 Second Special
- FL: small fixes for new spatula
- DE: disable data: image
- ME: remove home phone
- KY: fix districts
- SD: fix for email
- OK: people fixes
- RI: skip bad phone number and fix source
- IL people fix for phone #s
- NM: Change casing on bills ftp file
- WY: Add 2022 Session
- KY: grab 2022 prefiles
- OR: support second special session
- HI: add new class to session listing page xpath
- IN: support 2022 prefiles
- SD: update ignored
- IN: update name for 2022 session
- IN: timeouts
- KS: timeout and refactor
- MD: fixes for 2022
- FL: name fixes
- OR: fix for 404s and Taylor image
- WA: emails were removed from site
- MN: senate fix
- MO: senate
- NH: senate fixes
- ID: alternates
- ME: not voting members
- NV: skip vacancies
- ME: not voting members
- OK: wrong chamber specified
- NY: people
- PA: people fixes
- PA: people fixes redux
- MI: rewrite reps scraper
- KS: add back regular session for carryover bills
- MD: support 2022 prefiles
- NH: strip 0
- AL: skip empty
- update OS core, timeouts
- AK: skip empty coms
- HI: update urls to avoid SSLErrors
- VA: 2022 comms
- AR: empty coms
- FL: avoid ssl error on init
- MI: coms rewrite for house
- FL: avoid ssl error on senate bills
- MO: coms
- WA: committee num items fixes
- WA: empty coms
- FL: committees scraper SSL/fixes
- CA: required number
- FL: lower
- NY: coms fixes
- UT: switch to 2022 session
- HI: capture 2022 bills
- Additional Event Scrapers (#3681)
- IN: Update events scraper to deal with cloudflare (#3895)
- MS: 2022
- VA 2022 people
- SD: Events: Scrape Interim Meetings (#3899)
- LA: Raise Empty Scrape if there are no bills yet. (#3900)
- NH: people fixes
- update OS core
- NE: Events: Support EmptyScrape (#3902)
- IN: people fix
- black IN
- VT: 2022 bills posted
- MI: Events: Empty Scrapes (#3905)
- RI: 2022
