### PR TITLE
AZ: Fix session selector for bill list

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -317,7 +317,7 @@ class AZBillScraper(Scraper):
         form = {"sessionID": session_id}
         headers = {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-            "Content-Type": "application/json; charset=utf-8",
+            "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
             "Referer": "https://www.azleg.gov/azlegwp/",
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36",
         }
@@ -332,6 +332,7 @@ class AZBillScraper(Scraper):
         bill_list_url = "https://www.azleg.gov/bills/"
 
         page = self.get(bill_list_url, cookies=req.cookies).content
+        assert f"SessionId={session_id}" in str(page), "Session ID not in bill list"
         # There's an errant close-comment that browsers handle
         # but LXML gets really confused.
         page = page.replace(b"--!>", b"-->")


### PR DESCRIPTION
The session selector wasn't working, so the scraper always collected bill numbers from the latest session. This corrects a header to fix session selection and adds an assertion to verify the session ID.