### PR TITLE
NJ: 2022 Session

### DIFF
--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -64,7 +64,7 @@ class NewJersey(State):
             "active": False,
         },
         {
-            "_scraped_name": "2022-2023",
+            "_scraped_name": "2022-2023 Session",
             "identifier": "220",
             "name": "2022-2023 Regular Session",
             "start_date": "2022-01-11",

--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -61,6 +61,14 @@ class NewJersey(State):
             "name": "2020-2021 Regular Session",
             "start_date": "2020-01-14",
             "end_date": "2020-12-31",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2022-2023",
+            "identifier": "220",
+            "name": "2022-2023 Regular Session",
+            "start_date": "2022-01-11",
+            "end_date": "2022-12-31",
             "active": True,
         },
     ]

--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -373,7 +373,7 @@ class NJBillScraper(Scraper, MDBMixin):
             s_vote_url = f"https://www.njleg.state.nj.us/votes/{filename}.zip"
             try:
                 s_vote_zip, resp = self.urlretrieve(s_vote_url)
-            except scrapelib.FTPError:
+            except scrapelib.HTTPError:
                 self.warning("could not find %s" % s_vote_url)
                 continue
             zippedfile = zipfile.ZipFile(s_vote_zip)


### PR DESCRIPTION
[2022 Bills are posted](https://www.njleg.state.nj.us/bill-search), adds new session and updates error expected when there isn't a vote at the url so the scrape doesn't fail.