### PR TITLE
AZ: fix key check in subject logic

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -130,7 +130,7 @@ class AZBillScraper(Scraper):
         )
         page = json.loads(self.get(subjects_url).content.decode("utf-8"))
         for subject in page:
-            if subject["Name"] and len(subject["Name"]) > 0:
+            if "Name" in subject and len(subject["Name"]) > 0:
                 bill.add_subject(subject["Name"])
 
     def scrape_actions(self, bill, page, self_chamber):


### PR DESCRIPTION
@NewAgeAirbender -- based on https://github.com/openstates/openstates-scrapers/commit/d393b0067725c27016adf054d02b08c65904d0b5 we might be ping-ponging on this change; right now with the main branch when I scrape AZ bills I'm getting the following:

```
09:57:00 INFO scrapelib: GET - 'https://apps.azleg.gov/api/Keyword/?billStatusId=76229'
Traceback (most recent call last):
  <snip unimportant stuff>
  File "/home/showerst/work/ocd/openstates-scrapers/scrapers/az/bills.py", line 133, in scrape_subjects
    if subject["Name"] and len(subject["Name"]) > 0:
KeyError: 'Name'
````

Do you see the same? 

The API result looks like

```
<ArrayOfgetKeywords_Result xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.datacontract.org/2004/07/AZLeg.Data.POCO">
<getKeywords_Result>
<Keyword>COURTS AND CIVIL PROCEEDINGS - TITLE 12</Keyword>
<KeywordID>115320</KeywordID>
</getKeywords_Result>
<getKeywords_Result>
<Keyword>QUALIFICATIONS</Keyword>
<KeywordID>117366</KeywordID>
</getKeywords_Result>
<getKeywords_Result>
<Keyword>TAX COURT</Keyword>
<KeywordID>115858</KeywordID>
</getKeywords_Result>
<getKeywords_Result>
<Keyword>TAX JUDGES</Keyword>
<KeywordID>115391</KeywordID>
</getKeywords_Result>
<getKeywords_Result>
<Keyword>TECHNICAL CORRECTION</Keyword>
<KeywordID>115239</KeywordID>
</getKeywords_Result>
</ArrayOfgetKeywords_Result>
```

So i think we need the "in" check here.