### PR TITLE
IN: Up timeouts for slower bills

### DIFF
--- a/scrapers/in/__init__.py
+++ b/scrapers/in/__init__.py
@@ -4,6 +4,8 @@ from openstates.scrape import State
 from .bills import INBillScraper
 from .events import INEventScraper
 
+settings = dict(SCRAPELIB_TIMEOUT=600)
+
 
 class Indiana(State):
     scrapers = {

--- a/scrapers/in/apiclient.py
+++ b/scrapers/in/apiclient.py
@@ -12,6 +12,7 @@ If you're trying to hit api links through your browser you
 need to install a header-modifying extension to do this, on firefox:
 https://addons.mozilla.org/en-US/firefox/addon/modify-headers/
 """
+settings = dict(SCRAPELIB_TIMEOUT=300)
 
 
 class BadApiResponse(Exception):

--- a/scrapers/in/bills.py
+++ b/scrapers/in/bills.py
@@ -12,6 +12,7 @@ from openstates.utils import convert_pdf
 
 from .apiclient import ApiClient
 
+settings = dict(SCRAPELIB_TIMEOUT=600)
 
 PROXY_BASE_URL = "http://in-proxy.openstates.org"
 SCRAPE_WEB_VERSIONS = "INDIANA_SCRAPE_WEB_VERSIONS" in os.environ


### PR DESCRIPTION
Indiana has a few bills in the API that take multiple minutes to load, so up the timeouts so they clear.