### PR TITLE
MN: add version fix for biannual if fail initially

### DIFF
--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -145,6 +145,7 @@ class MNBillScraper(Scraper, LXMLMixin):
 
                 # Get each bill
                 for b in bills:
+                    print(b["version_url"])
                     yield self.get_bill_info(
                         chamber, session, b["bill_url"], b["version_url"]
                     )
@@ -495,7 +496,14 @@ class MNBillScraper(Scraper, LXMLMixin):
             version_resp = self.get(version_list_url)
         except scrapelib.HTTPError:
             self.warning("Bad version URL detected: {}".format(version_list_url))
-            return bill
+            new_year_version = version_list_url.replace("2021", "2022")
+            try:
+                version_resp = self.get(new_year_version)
+            except scrapelib.HTTPError:
+                self.warning(
+                    "Really bad version URL detected: {}".format(new_year_version)
+                )
+                return bill
 
         version_html = version_resp.text
         if "resolution" in version_resp.url:

--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -145,7 +145,6 @@ class MNBillScraper(Scraper, LXMLMixin):
 
                 # Get each bill
                 for b in bills:
-                    print(b["version_url"])
                     yield self.get_bill_info(
                         chamber, session, b["bill_url"], b["version_url"]
                     )
@@ -496,6 +495,7 @@ class MNBillScraper(Scraper, LXMLMixin):
             version_resp = self.get(version_list_url)
         except scrapelib.HTTPError:
             self.warning("Bad version URL detected: {}".format(version_list_url))
+            # There are issues with scraping resolution versions in biannual session since the year could be different, so attempt new year here
             new_year_version = version_list_url.replace("2021", "2022")
             try:
                 version_resp = self.get(new_year_version)

--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -495,7 +495,8 @@ class MNBillScraper(Scraper, LXMLMixin):
             version_resp = self.get(version_list_url)
         except scrapelib.HTTPError:
             self.warning("Bad version URL detected: {}".format(version_list_url))
-            # There are issues with scraping resolution versions in biannual session since the year could be different, so attempt new year here
+            # There are issues with scraping resolution versions in biannual session
+            # since the year could be different, so attempt new year here
             new_year_version = version_list_url.replace("2021", "2022")
             try:
                 version_resp = self.get(new_year_version)


### PR DESCRIPTION
There's an issue with resolutions versions not getting scraped if the year on the url is incorrect. Just adds an attempt to try the new year in the url, and another warning if it is legitimately bad.