### PR TITLE
NY: Make sure scraping with window arg only returns current bills

### DIFF
--- a/scrapers/ny/bills.py
+++ b/scrapers/ny/bills.py
@@ -247,6 +247,13 @@ class NYBillScraper(Scraper):
             (prefix, number, active_version),
         ) = details
 
+        if str(bill_data["session"]) != self.term_start_year:
+            self.warning(self.term_start_year)
+            self.warning(
+                f"Bill {bill_id} appears to be from previous session: {bill_data['session']}. Skipping"
+            )
+            return
+
         bill = Bill(
             bill_id,
             legislative_session=session,


### PR DESCRIPTION
If you scrape NY using the window argument (as opposed to the defaults), the API returns bills from previous sessions if they were recently updated for some reason. We were scraping those and accidentally marking them as current session. This resolves that issue.