### PR TITLE
US: Add live pair vote code

### DIFF
--- a/scrapers/usa/votes.py
+++ b/scrapers/usa/votes.py
@@ -15,6 +15,7 @@ class USVoteScraper(Scraper):
         "Nay": "no",
         "Not Voting": "not voting",
         "Present": "other",
+        "Present, Giving Live Pair": "other",
     }
 
     senate_statuses = {


### PR DESCRIPTION
US Vote Scraper was blowing up due to a new voting classification.