### PR TITLE
HI: update split for bill subjects for commas

### DIFF
--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -273,7 +273,7 @@ class HIBillScraper(Scraper):
 
         meta = self.parse_bill_metainf_table(metainf_table)
 
-        subs = [s.strip() for s in meta["Report Title"].split(";")]
+        subs = [s.strip() for s in re.split(r";|,", meta["Report Title"])]
         if "" in subs:
             subs.remove("")
         b = Bill(


### PR DESCRIPTION
Some bills like [HB 2111](https://www.capitol.hawaii.gov/measure_indiv.aspx?billtype=HB&billnumber=2111&year=2022) and [SB 3080](https://www.capitol.hawaii.gov/measure_indiv.aspx?billtype=SB&billnumber=3080&year=2022) have bill subjects by comma instead of semicolon. Updates split to catch that.