### PR TITLE
NY: Scrape lower events

### DIFF
--- a/scrapers/ny/events.py
+++ b/scrapers/ny/events.py
@@ -43,6 +43,7 @@ class NYEventScraper(Scraper):
         end = end.strftime("%Y-%m-%d")
 
         yield from self.scrape_upper(start, end)
+        yield from self.scrape_lower()
 
     def scrape_lower(self):
         url = "https://nyassembly.gov/leg/?sh=agen"


### PR DESCRIPTION
We'd disabled this at some point because the assembly wasn't posting events any more, but they've restarted.