### PR TITLE
TN: Make session explicit when pulling bill listing

### DIFF
--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -250,7 +250,8 @@ class TNBillScraper(Scraper):
         session_details = self.jurisdiction.sessions_by_id[session]
 
         # The index page gives us links to the paginated bill pages
-        index_page = "http://wapp.capitol.tn.gov/apps/indexes/"
+        # ?year=
+        index_page = f"http://wapp.capitol.tn.gov/apps/indexes/?year={session}"
         if session_details["classification"] == "special":
             xpath = '//a[contains(text(), "{}")]'.format(
                 session_details["_scraped_name"]

--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -250,7 +250,6 @@ class TNBillScraper(Scraper):
         session_details = self.jurisdiction.sessions_by_id[session]
 
         # The index page gives us links to the paginated bill pages
-        # ?year=
         index_page = f"http://wapp.capitol.tn.gov/apps/indexes/?year={session}"
         if session_details["classification"] == "special":
             xpath = '//a[contains(text(), "{}")]'.format(


### PR DESCRIPTION
We had a case where TN scraped some old data but assumed it was in the newest session, presumably due to an issue with the state site posting old info to the current bill listing page. This should avoid that in the future.