### PR TITLE
MN: skip verify for get on upper events

### DIFF
--- a/scrapers/mn/events.py
+++ b/scrapers/mn/events.py
@@ -125,7 +125,7 @@ class MNEventScraper(Scraper, LXMLMixin):
 
     def scrape_upper(self):
         url = "https://www.senate.mn/api/schedule/upcoming"
-        data = self.get(url).json()
+        data = self.get(url, verify=False).json()
 
         for row in data["events"]:
             com = row["committee"]["committee_name"]


### PR DESCRIPTION
Event scraper was failing from [SSL errors](https://bobsled.openstates.org/run/8f6ea7ac9cae4434bc38ce80c37ea04d), avoiding verification for now.