### PR TITLE
FL & LA: New Sessions

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -161,9 +161,18 @@ class Florida(State):
             "end_date": "2022-03-11",
             "active": True,
         },
+        # {
+        #     "name": "2022 Special Session C",
+        #     "identifier": "2022C",
+        #     "classification": "special",
+        #     "start_date": "2022-04-19",
+        #     "end_date": "2022-04-22",
+        #     "active": True,
+        # },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),
+        "2022C",
         "2020 Org.",
         "2019 I",  # Empty, maybe informational session
         "2010",

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -558,6 +558,7 @@ class HouseSearchPage(HtmlListPage):
         # Keep the digits and all following characters in the bill's ID
         bill_number = re.search(r"^\w+\s(\d+\w*)$", self.input.identifier).group(1)
         session_number = {
+            "2022C": "95",
             "2022": "93",
             "2021B": "94",
             "2021A": "92",

--- a/scrapers/la/__init__.py
+++ b/scrapers/la/__init__.py
@@ -216,7 +216,7 @@ class Louisiana(State):
         },
     ]
     ignored_scraped_sessions = [
-        "2022 Regular Session",
+        "2022 Veto Session",
         "2021 Veto Session",
         "2020 Organizational Session",
         "2016 Organizational Session",


### PR DESCRIPTION
Ignores both new sessions. FL has a redistricting session [coming April](https://www.heraldtribune.com/story/news/politics/state/2022/03/29/florida-special-session-coming-desantis-vetoes-congressional-boundaries-redistricting/7204709001/), prepped an addition to the scraper in case & will check in, and LA added a veto session so no new bills will be introduced.