### PR TITLE
VA: add pdf option to versions

### DIFF
--- a/scrapers/va/csv_bills.py
+++ b/scrapers/va/csv_bills.py
@@ -403,6 +403,7 @@ class VaCSVBillScraper(Scraper):
                         bill_url_base
                         + f"legp604.exe?{session_id}+ful+{version['doc_abbr']}"
                     )
+                    pdf_url = version_url + "+pdf"
 
                     version_date = datetime.datetime.strptime(
                         version["doc_date"], "%m/%d/%y"
@@ -418,6 +419,13 @@ class VaCSVBillScraper(Scraper):
                         version_url,
                         date=version_date,
                         media_type="text/html",
+                        on_duplicate="ignore",
+                    )
+                    b.add_version_link(
+                        version_text,
+                        pdf_url,
+                        date=version_date,
+                        media_type="application/pdf",
                         on_duplicate="ignore",
                     )
 


### PR DESCRIPTION
VA has pdf versions available, can just add "+pdf" to the version url to get to it so adds that as a link for the bill version