### PR TITLE
NH: check that bill id exists before continuing

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -109,7 +109,11 @@ class NHBillScraper(Scraper):
             expanded_bill_id = line[9]
             bill_id = line[10]
 
-            if body == body_code[chamber] and session_yr == session:
+            if (
+                body == body_code[chamber]
+                and session_yr == session
+                and expanded_bill_id != ""
+            ):
                 if expanded_bill_id.startswith("CACR"):
                     bill_type = "constitutional amendment"
                 elif expanded_bill_id.startswith("PET"):


### PR DESCRIPTION
NH is starting on a bill that doesn't have a bill id assigned yet and it's breaking the scrape. Adds a check for the bill id being an empty string before continuing the scrape.