### PR TITLE
ND: Events Enhancements

### DIFF
--- a/scrapers/nd/events.py
+++ b/scrapers/nd/events.py
@@ -58,7 +58,6 @@ class NDEventScraper(Scraper):
                     )
 
                 self.events[event_url] = event
-                # yield event
 
         for year_month in self.event_months:
             self.scrape_calendar(year_month)

--- a/scrapers/nd/events.py
+++ b/scrapers/nd/events.py
@@ -1,6 +1,7 @@
 import dateutil.parser
 import lxml
 import pytz
+import re
 from openstates.scrape import Scraper, Event
 
 
@@ -100,5 +101,15 @@ class NDEventScraper(Scraper):
 
             date = dateutil.parser.parse(new_start)
             date = self._tz.localize(date)
-
             self.events[event_url].__setattr__("start_date", date)
+
+            if row.xpath(".//div[contains(@class,'vcard')]"):
+                raw_loc = row.xpath(".//div[contains(@class,'vcard')]")[
+                    0
+                ].text_content()
+                loc = raw_loc.strip()
+                loc = re.sub(r"\s+", " ", loc)
+                loc = loc.replace("State Capitol", "600 East Boulevard Avenue")
+                loc_dict = {"name": loc, "note": "", "coordinates": None}
+                if len(loc) > 0:
+                    self.events[event_url].__setattr__("location", loc_dict)


### PR DESCRIPTION
Add start time and location to events in ND.

@jamesturk @NewAgeAirbender this scrape has an unusual situation where the easiest path was to create Event objects and then update two attributes later in the code. 

  `self.events[event_url].__setattr__("start_date", date)` feels sorta hacky, let me know if there's a better way update those objects after the fact. You can't subscript them after creation so we can't just say `event['start_date'] = date`