### PR TITLE
AL: return on empty vote pages

### DIFF
--- a/scrapers/al/bills.py
+++ b/scrapers/al/bills.py
@@ -470,7 +470,10 @@ class ALBillScraper(Scraper):
         capture_vote = False
         name = ""
         for item in voters_and_votes:
-            if capture_vote:
+            item = item.replace("\xa0", " ").strip()
+            if item == "":
+                return
+            elif capture_vote:
                 capture_vote = False
                 if name:
                     voters[item].append(name)


### PR DESCRIPTION
Ran into a page with an empty character, so strips vote string and returns if it's an empty string for the page.