### PR TITLE
OK: Support Second Special Session

### DIFF
--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -107,7 +107,7 @@ class Oklahoma(State):
             "name": "2022 Regular Session",
             "start_date": "2022-02-01",
             "end_date": "2022-05-29",
-            # "active": True,
+            "active": True,
         },
         {
             "_scraped_name": "2021 First Special Session",

--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -107,7 +107,7 @@ class Oklahoma(State):
             "name": "2022 Regular Session",
             "start_date": "2022-02-01",
             "end_date": "2022-05-29",
-            "active": True,
+            # "active": True,
         },
         {
             "_scraped_name": "2021 First Special Session",
@@ -116,6 +116,14 @@ class Oklahoma(State):
             "start_date": "2021-11-15",
             "end_date": "2021-11-26",
             "active": False,
+        },
+        {
+            "_scraped_name": "2022 Second Special Session",
+            "identifier": "2022SS2",
+            "name": "2022 Second Special Session",
+            "start_date": "2022-05-18",
+            "end_date": "2022-05-27",
+            "active": True,
         },
     ]
     ignored_scraped_sessions = [

--- a/scrapers/ok/bills.py
+++ b/scrapers/ok/bills.py
@@ -31,6 +31,7 @@ class OKBillScraper(Scraper):
         "2021": "2100",
         "2021SS1": "211X",
         "2022": "2200",
+        "2022SS2": "222X",
     }
 
     def scrape(self, chamber=None, session=None, only_bills=None):


### PR DESCRIPTION
OK has a special session that [started yesterday](https://www.oklahoman.com/story/news/2022/05/18/stimulus-fund-arpa-spending-focus-of-oklahoma-legislature-special-session/9828952002/), scheduled through the 27th