### PR TITLE
OK: prep for 3rd special and 2023 sessions

### DIFF
--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -125,8 +125,27 @@ class Oklahoma(State):
             "end_date": "2022-05-27",
             "active": True,
         },
+        # {
+        #     "_scraped_name": "2022 Third Special Session",
+        #     "identifier": "2022SS3",
+        #     "name": "2022 Third Special Session",
+        #     "start_date": "2022-06-13",
+        #     "end_date": "2022-06-23",
+        #     "active": True,
+        # },
+        # {
+        #     "_scraped_name": "2023 Regular Session",
+        #     "identifier": "2023",
+        #     "name": "2023 Regular Session",
+        #     # TODO: update dates
+        #     "start_date": "2023-02-01",
+        #     "end_date": "2023-05-29",
+        #     "active": True,
+        # },
     ]
     ignored_scraped_sessions = [
+        "2022 Third Special Session",
+        "2023 Regular Session",
         "2021 Regular Session - Web",
         "2020 Regular Session (web)",
         "2017 Regular Session",

--- a/scrapers/ok/bills.py
+++ b/scrapers/ok/bills.py
@@ -32,6 +32,8 @@ class OKBillScraper(Scraper):
         "2021SS1": "211X",
         "2022": "2200",
         "2022SS2": "222X",
+        "2022SS3": "223X",
+        "2023": "2300",
     }
 
     def scrape(self, chamber=None, session=None, only_bills=None):


### PR DESCRIPTION
OK has third special session starting the [13th](https://www.koco.com/article/oklahoma-kevin-stitt-2022-legislative-session/40118674), ignore for now.