### PR TITLE
MI: update to pull reps without a link yet

### DIFF
--- a/scrapers_next/mi/people.py
+++ b/scrapers_next/mi/people.py
@@ -76,13 +76,20 @@ class Representatives(HtmlListPage):
     def process_item(self, item):
         if "Vacant" in item.text_content():
             self.skip("vacant")
-        link = item.xpath(".//a")[0]
-        url = link.get("href")
-        (
-            name,
-            party,
-            district,
-        ) = re.match(r"\s+([^\(]+)\((\w+)\)\s+District-(\d+)", link.text).groups()
+
+        link = ""
+        url = ""
+        try:
+            link = item.xpath("./div[1]/div/a")[0]
+            url = item.xpath("./div[1]/div/a")[0].get("href")
+        except IndexError:
+            link = item.xpath("./div[1]/div/div")[0]
+        finally:
+            (
+                name,
+                party,
+                district,
+            ) = re.match(r"\s+([^\(]+)\((\w+)\)\s+District-(\d+)", link.text).groups()
 
         contact = item.getchildren()[1].getchildren()[0:3]
         office = contact[0].text_content().strip()


### PR DESCRIPTION
There are a few house representatives that are posted to the site, but they don't have a link so the scraper would skip them. The regex would already capture their name, party, and district from the text in the same cell that the typical link gets pulled from, so just needed to capture that text to pass in.