### PR TITLE
handle Nones for Ayes/Nays in action object for AZ

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -288,16 +288,20 @@ class AZBillScraper(Scraper):
                 action_date = datetime.datetime.strptime(
                     cleaned_date, "%Y-%m-%dT%H:%M:%S"
                 )
-                vote = VoteEvent(
-                    chamber={"S": "upper", "H": "lower"}[header["LegislativeBody"]],
-                    motion_text=action["Action"],
-                    classification="passage",
-                    result=(
+                if not action.get("Ayes", None) or not action.get("Nays", None):
+                    result = "fail"
+                else:
+                    result = (
                         "pass"
                         if action["UnanimouslyAdopted"]
                         or action["Ayes"] > action["Nays"]
                         else "fail"
-                    ),
+                    )
+                vote = VoteEvent(
+                    chamber={"S": "upper", "H": "lower"}[header["LegislativeBody"]],
+                    motion_text=action["Action"],
+                    classification="passage",
+                    result=result,
                     start_date=action_date.strftime("%Y-%m-%d"),
                     bill=bill,
                 )

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -298,8 +298,8 @@ class AZBillScraper(Scraper):
                 result = "fail"
                 if (
                     action.get("UnanimouslyAdopted", False)
-                    or action["Action"] == "Passed"
                     or action.get("Ayes", 0) > action.get("Nays", 0)
+                    or action["Action"] == "Passed"
                 ):
                     result = "pass"
 

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -299,6 +299,7 @@ class AZBillScraper(Scraper):
                 if (
                     action.get("UnanimouslyAdopted", False)
                     or action["Action"] == "Passed"
+                    or action.get("Ayes", 0) > action.get("Nays", 0)
                 ):
                     result = "pass"
 

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -288,6 +288,7 @@ class AZBillScraper(Scraper):
                 action_date = datetime.datetime.strptime(
                     cleaned_date, "%Y-%m-%dT%H:%M:%S"
                 )
+                # handle empty vote objects
                 if not action.get("Ayes", None) or not action.get("Nays", None):
                     result = "fail"
                 else:
@@ -306,12 +307,12 @@ class AZBillScraper(Scraper):
                     bill=bill,
                 )
                 vote.add_source(resp.url)
-                vote.set_count("yes", action["Ayes"] or 0)
-                vote.set_count("no", action["Nays"] or 0)
-                vote.set_count("other", (action["Present"] or 0))
-                vote.set_count("absent", (action["Absent"] or 0))
-                vote.set_count("excused", (action["Excused"] or 0))
-                vote.set_count("not voting", (action["NotVoting"] or 0))
+                vote.set_count("yes", action.get("Ayes", 0))
+                vote.set_count("no", action.get("Nays", 0))
+                vote.set_count("other", action.get("Present", 0))
+                vote.set_count("absent", action.get("Absent", 0))
+                vote.set_count("excused", action.get("Excused", 0))
+                vote.set_count("not voting", action.get("NotVoting", 0))
 
                 for v in action["Votes"]:
                     vote_type = {"Y": "yes", "N": "no"}.get(v["Vote"], "other")


### PR DESCRIPTION
Should handle errors like the following:

```
Traceback (most recent call last):
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/bin/os-update", line 8, in <module>
    sys.exit(main())
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 361, in main
    report = do_update(args, other, juris)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 248, in do_update
    report["scrape"] = do_scrape(juris, args, scrapers, active_sessions)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/cli/update.py", line 106, in do_scrape
    partial_report = scraper.do_scrape(**scrape_args, session=session)
  File "/root/.cache/pypoetry/virtualenvs/openstates-scrapers-vRcYrsYN-py3.9/lib/python3.9/site-packages/openstates/scrape/base.py", line 164, in do_scrape
    for obj in self.scrape(**kwargs) or []:
  File "/opt/openstates/openstates/scrapers/az/bills.py", line 360, in scrape
    yield from self.scrape_bill(chamber, session, bill_id, session_id)
  File "/opt/openstates/openstates/scrapers/az/bills.py", line 53, in scrape_bill
    yield from self.scrape_votes(bill, page)
  File "/opt/openstates/openstates/scrapers/az/bills.py", line 298, in scrape_votes
    or action["Ayes"] > action["Nays"]
TypeError: '>' not supported between instances of 'NoneType' and 'NoneType'
```

Signed-off-by: John Seekins <john@civiceagle.com>