### PR TITLE
NY: Fix Assembly Party Associations

### DIFF
--- a/scrapers_next/ny/people.py
+++ b/scrapers_next/ny/people.py
@@ -28,12 +28,8 @@ class PartyAugmentation(HtmlPage):
             tds = row.getchildren()
             dist = tds[0].text_content().strip()
             name = tds[2].text_content().strip()
-            print(dist + " " + name)
-            party = CSS("[style]").match_one(tds[2])
-            print(party)
-            # party = CSS("td:first-child").match_one(row).get("style")
-            # if "[" in party:
-            #     party = party.split("[")[0]
+            party_style = tds[1].get("style")[-6:]
+            party = "Democrat" if party_style == "3333FF" else "Republican"
             mapping[dist] = (name, party)
         return mapping
 

--- a/scrapers_next/ny/people.py
+++ b/scrapers_next/ny/people.py
@@ -28,7 +28,8 @@ class PartyAugmentation(HtmlPage):
             tds = row.getchildren()
             dist = tds[0].text_content().strip()
             name = tds[2].text_content().strip()
-            # get the last 6 characters off the background-color to see if it's red or blue
+            # party is indicated by just a red or blue cell in the table
+            # get the last 6 characters off the background-color to see which color it is
             party_style = tds[1].get("style")[-6:]
             party = "Democrat" if party_style == "3333FF" else "Republican"
             mapping[dist] = (name, party)

--- a/scrapers_next/ny/people.py
+++ b/scrapers_next/ny/people.py
@@ -24,13 +24,16 @@ class PartyAugmentation(HtmlPage):
     def process_page(self):
         mapping = {}
         rows = self.find_rows()
-        for row in rows:
+        for row in rows[1:]:
             tds = row.getchildren()
             dist = tds[0].text_content().strip()
-            name = tds[1].text_content().strip()
-            party = tds[2].text_content().strip()
-            if "[" in party:
-                party = party.split("[")[0]
+            name = tds[2].text_content().strip()
+            print(dist + " " + name)
+            party = CSS("[style]").match_one(tds[2])
+            print(party)
+            # party = CSS("td:first-child").match_one(row).get("style")
+            # if "[" in party:
+            #     party = party.split("[")[0]
             mapping[dist] = (name, party)
         return mapping
 

--- a/scrapers_next/ny/people.py
+++ b/scrapers_next/ny/people.py
@@ -28,6 +28,7 @@ class PartyAugmentation(HtmlPage):
             tds = row.getchildren()
             dist = tds[0].text_content().strip()
             name = tds[2].text_content().strip()
+            # get the last 6 characters off the background-color to see if it's red or blue
             party_style = tds[1].get("style")[-6:]
             party = "Democrat" if party_style == "3333FF" else "Republican"
             mapping[dist] = (name, party)


### PR DESCRIPTION
Wiki updated the style for how they display [Assembly member's party association](https://en.wikipedia.org/wiki/New_York_State_Assembly), so this fixes that.
Has to skip first row of headers, but party is either a blue or red square, so pulls the style and declares party based on that color.