### PR TITLE
ID, NJ, OR: Fix dates for several sessions

### DIFF
--- a/scrapers/id/__init__.py
+++ b/scrapers/id/__init__.py
@@ -40,7 +40,7 @@ class Idaho(State):
             "identifier": "2014",
             "name": "63nd Legislature, 1st Regular Session (2014)",
             "start_date": "2014-01-06",
-            "end_date": "2014-03-21",
+            "end_date": "2014-03-20",
         },
         {
             "_scraped_name": "2015 Session",
@@ -48,7 +48,7 @@ class Idaho(State):
             "identifier": "2015",
             "name": "64th Legislature, 1st Regular Session (2015)",
             "start_date": "2015-01-12",
-            "end_date": "2015-04-10",
+            "end_date": "2015-04-11",
         },
         {
             "_scraped_name": "2015 Extraordinary Session",
@@ -72,7 +72,7 @@ class Idaho(State):
             "identifier": "2017",
             "name": "64th Legislature, 1st Regular Session (2017)",
             "start_date": "2017-01-09",
-            "end_date": "2017-04-07",
+            "end_date": "2017-03-29",
         },
         {
             "_scraped_name": "2018 Session",
@@ -80,7 +80,7 @@ class Idaho(State):
             "identifier": "2018",
             "name": "64th Legislature, 2nd Regular Session (2018)",
             "start_date": "2018-01-08",
-            "end_date": "2018-03-27",
+            "end_date": "2018-03-28",
         },
         {
             "_scraped_name": "2019 Session",
@@ -88,7 +88,7 @@ class Idaho(State):
             "identifier": "2019",
             "name": "65th Legislature, 1st Regular Session (2019)",
             "start_date": "2019-01-07",
-            "end_date": "2019-03-29",
+            "end_date": "2019-04-11",
         },
         {
             "_scraped_name": "2020 Session",
@@ -96,7 +96,7 @@ class Idaho(State):
             "identifier": "2020",
             "name": "65th Legislature, 2nd Regular Session (2020)",
             "start_date": "2020-01-06",
-            "end_date": "2020-03-27",
+            "end_date": "2020-03-20",
         },
         {
             "_scraped_name": "2020 Extraordinary Session",
@@ -104,16 +104,15 @@ class Idaho(State):
             "identifier": "2020spcl",
             "name": "65th Legislature, First Extraordinary Session (2020)",
             "start_date": "2020-08-24",
-            # TODO: Set real end date after session completes
-            "end_date": "2020-08-28",
+            "end_date": "2020-08-26",
         },
         {
             "_scraped_name": "2021 Session",
             "classification": "primary",
             "identifier": "2021",
             "name": "66th Legislature, 1st Regular Session (2021)",
-            "start_date": "2020-01-11",
-            "end_date": "2020-04-07",
+            "start_date": "2021-01-11",
+            "end_date": "2021-11-17",
             "active": False,
         },
         {
@@ -122,8 +121,7 @@ class Idaho(State):
             "identifier": "2022",
             "name": "66th Legislature, 2nd Regular Session (2022)",
             "start_date": "2022-01-10",
-            # TODO: Set real end date after session completes
-            "end_date": "2022-04-07",
+            "end_date": "2022-03-31",
             "active": True,
         },
     ]

--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -60,7 +60,7 @@ class NewJersey(State):
             "identifier": "219",
             "name": "2020-2021 Regular Session",
             "start_date": "2020-01-14",
-            "end_date": "2020-12-31",
+            "end_date": "2022-01-11",
             "active": False,
         },
         {

--- a/scrapers/or/__init__.py
+++ b/scrapers/or/__init__.py
@@ -142,8 +142,7 @@ class Oregon(State):
             "identifier": "2020S2",
             "name": "2020 Special Session 2",
             "start_date": "2020-08-10",
-            # TODO: real end date when session ends
-            "end_date": "2020-08-14",
+            "end_date": "2020-08-10",
         },
         {
             "_scraped_name": "2020 3rd Special Session",
@@ -151,15 +150,14 @@ class Oregon(State):
             "identifier": "2020S3",
             "name": "2020 Special Session 3",
             "start_date": "2020-12-21",
-            # TODO: real end date when session ends
-            "end_date": "2020-12-23",
+            "end_date": "2020-12-21",
         },
         {
             "_scraped_name": "2021 Regular Session",
             "identifier": "2021 Regular Session",
             "name": "2021 Regular Session",
-            "start_date": "2020-01-19",
-            "end_date": "2020-07-11",
+            "start_date": "2021-01-19",
+            "end_date": "2021-06-26",
         },
         {
             "_scraped_name": "2021 1st Special Session",


### PR DESCRIPTION
### Sources

Idaho:
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2022
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2021
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2020
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2019
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2018
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2017
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2015
https://legislature.idaho.gov/sessioninfo/sessiondates/?yr=2014

New Jersey:
https://njpsa.org/update-from-the-nj-statehouse-for-the-week-of-january-10-2022/
https://www.njleg.state.nj.us/legislative-calendar

Oregon:
https://www.oregonlegislature.gov/calendar
https://www.opb.org/article/2021/06/26/oregon-lawmakers-conclude-2021-legislative-session/