### PR TITLE
Corrected end of California 2021-2022 session

### DIFF
--- a/scrapers/ca/__init__.py
+++ b/scrapers/ca/__init__.py
@@ -394,7 +394,7 @@ class California(State):
             "identifier": "20212022",
             "name": "2021-2022 Regular Session",
             "start_date": "2020-12-07",
-            "end_date": "2021-12-31",
+            "end_date": "2022-12-31",
             "active": True,
         },
     ]

--- a/scrapers/ca/__init__.py
+++ b/scrapers/ca/__init__.py
@@ -394,7 +394,7 @@ class California(State):
             "identifier": "20212022",
             "name": "2021-2022 Regular Session",
             "start_date": "2020-12-07",
-            "end_date": "2022-12-31",
+            "end_date": "2022-11-30",
             "active": True,
         },
     ]


### PR DESCRIPTION
Simple change, as per ﻿﻿﻿﻿the [Legislative Calendar](https://www.assembly.ca.gov/legislativedeadlines) the adjournment of the session happens on 2022-11-30 not 2021-12-31.

If there's a technical reason this should remain the same please let me know.