### PR TITLE
fix init-db.sh script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ _data
 cache
 _cache
 pubinfo_*
+openstates-postgres/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
     entrypoint: ["poetry", "run", "os-update"]
     networks:
       - openstates-network
+    depends_on:
+      db:
+        condition: service_healthy
   mysql:
     image: mariadb:10.3
 #    command: mysqld_safe --max_allowed_packet=512M
@@ -70,3 +73,8 @@ services:
       - ./openstates-postgres/:/var/lib/postgresql/data
     networks:
       - openstates-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,5 @@
 version: "3.5"
 
-networks:
-  openstates-network:
-      name: openstates-network
-
 services:
   scrape:
     build: .
@@ -19,8 +15,6 @@ services:
     volumes:
       - .:/opt/openstates/openstates/
     entrypoint: ["poetry", "run", "os-update"]
-    networks:
-      - openstates-network
     depends_on:
       db:
         condition: service_healthy
@@ -32,8 +26,6 @@ services:
     environment:
       - MYSQL_DATABASE=capublic
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-    networks:
-      - openstates-network
   ca-scrape:
     build:
       context: .
@@ -45,8 +37,6 @@ services:
     volumes:
       - .:/opt/openstates/openstates/
     entrypoint: ["poetry", "run", "os-update"]
-    networks:
-    - openstates-network
   ca-download:
     build:
       context: .
@@ -58,8 +48,6 @@ services:
       - .:/opt/openstates/openstates/
     depends_on:
       - mysql
-    networks:
-      - openstates-network
   db:
     image: "mdillon/postgis:11-alpine"
     hostname: "db"
@@ -71,8 +59,6 @@ services:
       POSTGRES_DB: openstatesorg
     volumes:
       - ./openstates-postgres/:/var/lib/postgresql/data
-    networks:
-      - openstates-network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-set -ex
+set -eo pipefail
 unset DATABASE_URL
 
-# stop database and remove volume
-docker-compose down
-docker-compose up -d db
-sleep 3
+if command -v docker-compose > /dev/null 2>&1; then
+    _COMPOSE="docker-compose"
+else
+    _COMPOSE="docker compose"
+fi
 
 # migrate and populate db
-DATABASE_URL=postgis://openstates:openstates@db/openstatesorg docker-compose run --rm --entrypoint "poetry run os-initdb" scrape
+DATABASE_URL=postgis://openstates:openstates@db/openstatesorg ${_COMPOSE} run --rm --entrypoint "poetry run os-initdb" scrape


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

Clean up setup of `init-db.sh` script so it builds correctly and starts services in a way that lets us generate a local DB properly.