### PR TITLE
NH: handle empty version page

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -155,7 +155,11 @@ class NHBillScraper(Scraper):
                         resolution_url, allow_redirects=True
                     ).content.decode("utf-8")
                     page = lxml.html.fromstring(resolution_page)
-                    version_href = page.xpath("//a[2]/@href")[1]
+                    try:
+                        version_href = page.xpath("//a[2]/@href")[1]
+                    except Exception:
+                        self.logger.warning(f"{bill_id} missing version link")
+                        continue
                     true_version = re.search(r"id=(\d+)&", version_href)[1]
                     self.versions_by_lsr[lsr] = true_version
 


### PR DESCRIPTION
Signed-off-by: John Seekins <john@civiceagle.com>

```
14:24:38 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=2317&sy=2022&txtsessionyear=2022'
14:24:38 WARNING openstates: HR16 missing version link
14:24:38 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=2454&sy=2022&txtsessionyear=2022'
14:24:39 WARNING openstates: HR15 missing version link
14:24:39 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=2570&sy=2022&txtsessionyear=2022'
14:24:40 WARNING openstates: HR17 missing version link
14:24:40 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=2692&sy=2022&txtsessionyear=2022'
14:24:41 WARNING openstates: HR18 missing version link
14:24:41 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=3124&sy=2022&txtsessionyear=2022'
14:24:42 WARNING openstates: HR19 missing version link
14:24:42 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=3131&sy=2022&txtsessionyear=2022'
14:24:43 WARNING openstates: HR20 missing version link
14:24:43 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=3132&sy=2022&txtsessionyear=2022'
14:24:44 WARNING openstates: HR21 missing version link
14:24:44 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=3133&sy=2022&txtsessionyear=2022'
14:24:45 WARNING openstates: HR22 missing version link
14:24:45 INFO scrapelib: GET - 'http://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=3134&sy=2022&txtsessionyear=2022'
14:24:46 WARNING openstates: HR23 missing version link
14:24:46 WARNING openstates: bad line: 
```

Not sure if this is the right solution to this problem, but it does fix https://github.com/openstates/issues/issues/771.