### PR TITLE
Add header override for OH

### DIFF
--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -48,7 +48,9 @@ class OHBillScraper(Scraper):
     def scrape(self, session=None, chambers=None):
         # Bills endpoint can sometimes take a very long time to load
         self.timeout = 300
-        self.headers["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36"
+        self.headers[
+            "User-Agent"
+        ] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36"
 
         if int(session) < 128:
             raise AssertionError("No data for period {}".format(session))

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -479,7 +479,6 @@ class OHBillScraper(Scraper):
         legislators = {}
         for chamber in ["House", "Senate"]:
             url = base_url + "chamber/{chamber}/legislators?per_page=100"
-            self.logger.info(f"Downloading from {url} with {self.headers}")
             doc = self.get(
                 url.format(chamber=chamber),
                 verify=False,

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -361,9 +361,7 @@ class OHBillScraper(Scraper):
 
                 if "disapprove" in bill_version:
                     disapprove_url = base_url + bill_version["disapprove"][0]["link"]
-                    disapprove_json = self.get(
-                        disapprove_url
-                    ).json()
+                    disapprove_json = self.get(disapprove_url).json()
                     if len(disapprove_json["items"]) > 0:
                         raise AssertionError(
                             "Whoa, a disapprove! We've never"
@@ -483,7 +481,8 @@ class OHBillScraper(Scraper):
             url = base_url + "chamber/{chamber}/legislators?per_page=100"
             self.logger.info(f"Downloading from {url} with {self.headers}")
             doc = self.get(
-                url.format(chamber=chamber), verify=False,
+                url.format(chamber=chamber),
+                verify=False,
             )
             leg_json = doc.json()
             for leg in leg_json["items"]:
@@ -758,14 +757,10 @@ class OHBillScraper(Scraper):
         doc = lxml.html.fromstring(html)
         for a in doc.xpath('//a[starts-with(@href, "/bills.cfm")]/@href'):
             if a != piece:
-                _get_html_or_pdf_version_old(
-                    self.get(base_url + a).text
-                )
+                _get_html_or_pdf_version_old(self.get(base_url + a).text)
         for a in doc.xpath('//a[starts-with(@href, "/res.cfm")]/@href'):
             if a != piece:
-                _get_html_or_pdf_version_old(
-                    self.get(base_url + a).text
-                )
+                _get_html_or_pdf_version_old(self.get(base_url + a).text)
 
     def scrape_votes_old(self, bill, billname, session):
         vote_url = (

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -48,7 +48,7 @@ class OHBillScraper(Scraper):
     def scrape(self, session=None, chambers=None):
         # Bills endpoint can sometimes take a very long time to load
         self.timeout = 300
-        self.headers["User-Agent"] = "curl/7.82.0"
+        self.headers["User-Agent"] = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36"
 
         if int(session) < 128:
             raise AssertionError("No data for period {}".format(session))


### PR DESCRIPTION
OH websites don't accept scrapelib's `User-Agent` header any more. Changing the header from `scrapelib 2.0.6 python-requests/2.28.1` to `curl/7.82.0` seems to work.