### PR TITLE
OH: People Scraper Fix: Added Independent to Party Dict

### DIFF
--- a/scrapers_next/oh/people.py
+++ b/scrapers_next/oh/people.py
@@ -64,7 +64,7 @@ class House(HtmlListPage):
         # e.g. District 25 | D
         district, party = subtitle.split(" | ")
         district = district.split()[1]
-        party = {"D": "Democratic", "R": "Republican"}[party]
+        party = {"D": "Democrat", "R": "Republican", "I": "Independent"}[party]
 
         return LegDetail(
             LegPartial(

--- a/scrapers_next/oh/people.py
+++ b/scrapers_next/oh/people.py
@@ -33,7 +33,7 @@ class Senate(HtmlListPage):
         # e.g. District 25 | D
         district, party = subtitle.split(" | ")
         district = district.split()[1]
-        party = {"D": "Democratic", "R": "Republican"}[party]
+        party = {"D": "Democratic", "R": "Republican", "I": "Independent"}[party]
 
         return LegDetail(
             LegPartial(
@@ -64,7 +64,7 @@ class House(HtmlListPage):
         # e.g. District 25 | D
         district, party = subtitle.split(" | ")
         district = district.split()[1]
-        party = {"D": "Democrat", "R": "Republican", "I": "Independent"}[party]
+        party = {"D": "Democratic", "R": "Republican", "I": "Independent"}[party]
 
         return LegDetail(
             LegPartial(


### PR DESCRIPTION
The OH People Scraper was failing due to only accounting for Democrats and Republicans in the party dict. I have added an option for Independents to the dict that fixes the error. The scraper was failing on Rep Shayla Davis(I) who is an Independent   https://ohiohouse.gov/members/shayla-l-davis 