### PR TITLE
NC: Bill Scraper Fix

### DIFF
--- a/scrapers/nc/bills.py
+++ b/scrapers/nc/bills.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import json
+
 import lxml.html
 import re
 from openstates.scrape import Bill, Scraper, VoteEvent
@@ -450,14 +452,17 @@ class NCBillScraper(Scraper):
             yield from self.scrape_chamber(chamber, session)
 
     def scrape_chamber(self, chamber, session):
-        chamber = {"lower": "House", "upper": "Senate"}[chamber]
-        url = "https://www3.ncleg.gov/gascripts/SimpleBillInquiry/displaybills.pl"
-        post_data = {"Session": session, "tab": "Chamber", "Chamber": chamber}
+        chamber = {"lower": "H", "upper": "S"}[chamber]
+        print(f"scraping {chamber}")
+        url = f"https://www.ncleg.gov/Legislation/Bills/FiledBillsFeed/{session}/{chamber}"
 
-        data = self.post(url, post_data).text
-        doc = lxml.html.fromstring(data)
-        for row in doc.xpath("//table[@cellpadding=3]/tr")[1:]:
-            bill_id = row.xpath("td[1]/a/text()")[0]
+        data = self.get(url).text
+        print(json.load(data))
+
+        for item in data:
+            print(item)
+            bill_id = item["bill"]
+            print(bill_id)
 
             # Special cases for a page that 404s
             if session == "2009" and bill_id == "H234":

--- a/scrapers/nc/bills.py
+++ b/scrapers/nc/bills.py
@@ -454,9 +454,9 @@ class NCBillScraper(Scraper):
             yield from self.scrape_chamber(chamber, session)
 
     def scrape_chamber(self, chamber, session):
-        chamber = {"lower": "H", "upper": "S"}[chamber]
-        print(f"scraping {chamber}")
-        url = f"https://www.ncleg.gov/Legislation/Bills/FiledBillsFeed/{session}/{chamber}"
+        chamber = {"lower": "House", "upper": "Senate"}[chamber]
+        chamber_abbr = "S" if chamber == "Senate" else "H"
+        url = f"https://www.ncleg.gov/Legislation/Bills/FiledBillsFeed/{session}/{chamber_abbr}"
 
         page = self.get(url).content
         data = lxml.etree.fromstring(page)


### PR DESCRIPTION
The search page we were using to get a list of bills doesn't work how it used to, but there's an [XML page](https://www.ncleg.gov/Legislation/Bills/FiledBillsFeed/2021/H) that gives us partial bill data split by chamber. We're able to pull more important info like id, type, and title from this page more reliably than the bill detail page we are scraping. 

There's also a funky bill (SB 712) that doesn't scrape the same as the others, which is repeated in the same 2021 session as SB 655 so we do get the bill data, but it is the cause of the new try...except blocks.