### PR TITLE
NJ: add null check to legislator emails

### DIFF
--- a/scrapers_next/nj/people.py
+++ b/scrapers_next/nj/people.py
@@ -19,7 +19,7 @@ class LegDetail(JsonPage):
         # response is 3 lists: bio data, addresses, then committee memberships
         bio_data = self.data[0][0]
 
-        p.email = bio_data["ccMailName"]
+        p.email = bio_data["ccMailName"] if bio_data["ccMailName"] is not None else ""
         if pos := bio_data["Legislative_Position"]:
             p.extras["position"] = pos
 


### PR DESCRIPTION
One legislator doesn't have an email listed, added check to see if it exists or should be empty string.