### PR TITLE
TX: drop number of active sessions

### DIFF
--- a/scrapers/tx/__init__.py
+++ b/scrapers/tx/__init__.py
@@ -116,7 +116,7 @@ class Texas(State):
             "identifier": "87",
             "name": "87th Legislature (2021)",
             "start_date": "2021-01-12",
-            "active": True,
+            "active": False,
         },
         {
             "_scraped_name": "87(1) - 2021",
@@ -125,7 +125,7 @@ class Texas(State):
             "identifier": "871",
             "name": "87th Legislature, 1st Called Session (2021)",
             "start_date": "2021-07-08",
-            "active": True,
+            "active": False,
         },
         {
             "_scraped_name": "87(2) - 2021",
@@ -134,7 +134,7 @@ class Texas(State):
             "identifier": "872",
             "name": "87th Legislature, 2nd Called Session (2021)",
             "start_date": "2021-08-07",
-            "active": True,
+            "active": False,
         },
         {
             "_scraped_name": "87(3) - 2021",


### PR DESCRIPTION
Scrapes are timing out, should drop for new 2023 session prep anyway.