### PR TITLE
NC: data validation fix on email attribute collected in process_page

### DIFF
--- a/scrapers_next/nc/people.py
+++ b/scrapers_next/nc/people.py
@@ -25,6 +25,8 @@ class LegDetail(HtmlPage):
             email, legislative_assistant = XPath(
                 "//a[contains(@href, 'mailto')]"
             ).match(self.root)
+            email = email.text_content()
+
         except ValueError:
             try:
                 email = (
@@ -32,6 +34,7 @@ class LegDetail(HtmlPage):
                     .match_one(self.root)
                     .text_content()
                 )
+
             except Exception:
                 email = ""
 


### PR DESCRIPTION
Scraper was failing because process_page had not converted legislator's scraped email address from match object type to string type. Method `.text_content()` was added. Scraper now runs successfully without data validation error.