### PR TITLE
GA: index error fix for collecting staff email

### DIFF
--- a/scrapers_next/ga/people.py
+++ b/scrapers_next/ga/people.py
@@ -8,7 +8,6 @@ class LegDetail(JsonPage):
     def process_page(self):
         p = self.input
         p.add_source(self.source.url, note="Detail page (requires authorization token)")
-
         if self.data["email"]:
             p.email = self.data["email"]
 
@@ -26,7 +25,7 @@ class LegDetail(JsonPage):
             if self.data["capitolAddress"]["fax"]:
                 p.capitol_office.fax = self.data["capitolAddress"]["fax"]
         except TypeError:
-            self.logger.warning("Empty capitol address for {p.name}")
+            self.logger.warning(f"Empty capitol address for {p.name}")
             pass
 
         extras = [
@@ -44,8 +43,12 @@ class LegDetail(JsonPage):
             if info:
                 if type_info == "staff":
                     info = re.split("mailto:|>|<", info)
-                    p.extras["staff"] = info[3]
-                    p.extras["staff email"] = info[2].replace('"', "")
+                    if len(info) > 1:
+                        p.extras["staff"] = info[3]
+                        p.extras["staff email"] = info[2].replace('"', "")
+                    else:
+                        p.extras["staff"] = info[0]
+                        p.extras["staff email"] = ""
                 else:
                     p.extras[type_info] = info
 


### PR DESCRIPTION
People scraper was failing because a legislator's details page did not have their staff member's name hyperlinked with an email address. Consequently, without `href` tags, the list `info` created within `for` loop in `process_page` for that legislator was of length = 1, resulting in `IndexError` when attempting to retrieve a staff name at `info[3]` and a staff email using `info[2]`.

Fix adds conditional statement to check the length of list `info` before retrieving staff name and email, with appropriate indexes given for each situation. Scraper now runs successfully.