### PR TITLE
MI: Fix Primary Sponsor Logic

### DIFF
--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -105,7 +105,7 @@ class MIBillScraper(Scraper):
             if len(sponsors) > 1:
                 classification = (
                     "primary"
-                    if sponsor.tail and "primary" in sponsor.tail
+                    if sponsor.tail and "district" in sponsor.tail
                     else "cosponsor"
                 )
             else:


### PR DESCRIPTION
The source site has been updated so theres one Primary sponsor at the top of the chunk, followed by the cosponsors. This checks for that district string to denote primary or not. [Example source bill](http://legislature.mi.gov/doc.aspx?2021-HB-4412)