### PR TITLE
VT: improving bill action classification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.9
+    python: python3
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0  # Use the ref you want to point at

--- a/scrapers/vt/actions.py
+++ b/scrapers/vt/actions.py
@@ -1,0 +1,59 @@
+import re
+
+# Dictionary matching bill action phrases to classifications. Classifications can be found here:
+# https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
+_actions = {
+    "read first": {"type": "compare", "mappings": ["introduction"]},
+    "read 1st time": {"type": "compare", "mappings": ["introduction"]},
+    "first read": {"type": "compare", "mappings": ["introduction"]},
+    "read second": {"type": "compare", "mappings": ["reading-2"]},
+    "read 2nd": {"type": "compare", "mappings": ["reading-2"]},
+    "second read": {"type": "compare", "mappings": ["reading-2"]},
+    "read third": {"type": "compare", "mappings": ["reading-3"]},
+    "read 3rd": {"type": "compare", "mappings": ["reading-3"]},
+    "third read": {"type": "compare", "mappings": ["reading-3"]},
+    "reported favorably": {
+        "type": "compare",
+        "mappings": ["committee-passage-favorable"],
+    },
+    "rules suspended & messaged to house forthwith": {
+        "type": "compare",
+        "mappings": ["passage"],
+    },
+    "delivered to governor": {"type": "compare", "mappings": ["executive-receipt"]},
+    "signed by governor": {"type": "compare", "mappings": ["executive-signature"]},
+    "vetoed by the governor": {"type": "compare", "mappings": ["executive-veto"]},
+    "vetoed": {"type": "compare", "mappings": ["executive-veto"]},
+    "overrid": {"type": "compare", "mappings": ["veto-override-passage"]},
+    "proposal of amendment": {
+        "type": "compare",
+        "mappings": ["amendment-introduction"],
+    },
+    "become law without signature of governor": {
+        "type": "compare",
+        "mappings": ["became-law", "executive"],
+    },
+    "governor allowed to become law": {"type": "compare", "mappings": ["became-law"]},
+    "allowed to go into effect without the signature of the governor": {
+        "type": "compare",
+        "mappings": ["became-law"],
+    },
+}
+
+
+# Takes in a string description of an action and returns the respective OS classification
+def categorize_actions(action_description):
+    atype = []
+    for action_key, data in _actions.items():
+        # If regex is required to isolate bill action phrase
+        if data["type"] == "regex":
+            if re.search(action_key, action_description.lower()):
+                atype.extend(a for a in data["mappings"])
+
+        # Otherwise, we use basic string comparison
+        else:
+            # If we can detect a phrase that there is an OS action classification for
+            if action_key in action_description.lower():
+                atype.extend(a for a in data["mappings"])
+
+    return atype

--- a/scrapers/vt/actions.py
+++ b/scrapers/vt/actions.py
@@ -31,7 +31,7 @@ _actions = {
     },
     "become law without signature of governor": {
         "type": "compare",
-        "mappings": ["became-law", "executive"],
+        "mappings": ["became-law"],
     },
     "governor allowed to become law": {"type": "compare", "mappings": ["became-law"]},
     "allowed to go into effect without the signature of the governor": {

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -12,34 +12,35 @@ class VTBillScraper(Scraper, LXMLMixin):
 
     # Dictionary matching bill action phrases to classifications
     _actions = {
-        "signed by governor": ["executive-signature"],
-        "become law without signature of governor": ["became-law", "executive"],
-        "vetoed by the governor": ["executive-veto"],
         "read first": ["introduction"],
         "read 1st time": ["introduction"],
         "first read": ["introduction"],
-        "reported favorably": ["committee-passage-favorable"],
         "read second": ["reading-2"],
         "read 2nd": ["reading-2"],
         "second read": ["reading-2"],
         "read third": ["reading-3"],
         "read 3rd": ["reading-3"],
         "third read": ["reading-3"],
+        "reported favorably": ["committee-passage-favorable"],
         "rules suspended & messaged to house forthwith": ["passage"],
-        "overrid": ["veto-override-passage"],
         "delivered to governor": ["executive-receipt"],
+        "signed by governor": ["executive-signature"],
+        "vetoed by the governor": ["executive-veto"],
         "vetoed": ["executive-veto"],
+        "overrid": ["veto-override-passage"],
+        "proposal of amendment": ["amendment-introduction"],
+        "become law without signature of governor": ["became-law", "executive"],
         "governor allowed to become law": ["became-law"],
         "allowed to go into effect without the signature of the governor": [
             "became-law"
         ],
-        "proposal of amendment": ["amendment-introduction"],
     }
 
-    def categorize_actions(self, action_string):
+    # Takes in a string description of an action and returns the respective OS classification
+    def categorize_actions(self, action_description):
         for action_key in list(self._actions):
-            # If we can detect a phrase that we have mapped an action classification for
-            if action_key in action_string:
+            # If we can detect a phrase that there is an OS action classification for
+            if action_key in action_description:
                 return self._actions[action_key]
         return None
 
@@ -243,7 +244,10 @@ class VTBillScraper(Scraper, LXMLMixin):
                     if len(action_classification) > 1:
                         actor = action_classification[1]
 
-                # More action categorization (these were the tricky ones)
+                # More action categorization
+                # These classifications are done separately because they require more rules
+                # in order to correctly classify
+
                 elif actor == "lower" and any(
                     x.lower().startswith("aspassed")
                     for x in action["keywords"].split(";")

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -10,7 +10,8 @@ from utils import LXMLMixin
 
 class VTBillScraper(Scraper, LXMLMixin):
 
-    # Dictionary matching bill action phrases to classifications
+    # Dictionary matching bill action phrases to classifications. Classifications can be found here:
+    # https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
     _actions = {
         "read first": ["introduction"],
         "read 1st time": ["introduction"],

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -38,7 +38,7 @@ class VTBillScraper(Scraper, LXMLMixin):
 
     # Takes in a string description of an action and returns the respective OS classification
     def categorize_actions(self, action_description):
-        for action_key in list(self._actions):
+        for action_key in self._actions.keys():
             # If we can detect a phrase that there is an OS action classification for
             if action_key in action_description:
                 return self._actions[action_key]

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -39,10 +39,10 @@ class VTBillScraper(Scraper, LXMLMixin):
 
     # Takes in a string description of an action and returns the respective OS classification
     def categorize_actions(self, action_description):
-        for action_key in self._actions.keys():
+        for action_key, classification in self._actions.items():
             # If we can detect a phrase that there is an OS action classification for
             if action_key in action_description:
-                return self._actions[action_key]
+                return classification
         return None
 
     def scrape(self, session=None):

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -9,44 +9,6 @@ from utils import LXMLMixin
 
 
 class VTBillScraper(Scraper, LXMLMixin):
-
-    """
-    # Dictionary matching bill action phrases to classifications. Classifications can be found here:
-    # https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
-    _actions = {
-        "read first": ["introduction"],
-        "read 1st time": ["introduction"],
-        "first read": ["introduction"],
-        "read second": ["reading-2"],
-        "read 2nd": ["reading-2"],
-        "second read": ["reading-2"],
-        "read third": ["reading-3"],
-        "read 3rd": ["reading-3"],
-        "third read": ["reading-3"],
-        "reported favorably": ["committee-passage-favorable"],
-        "rules suspended & messaged to house forthwith": ["passage"],
-        "delivered to governor": ["executive-receipt"],
-        "signed by governor": ["executive-signature"],
-        "vetoed by the governor": ["executive-veto"],
-        "vetoed": ["executive-veto"],
-        "overrid": ["veto-override-passage"],
-        "proposal of amendment": ["amendment-introduction"],
-        "become law without signature of governor": ["became-law", "executive"],
-        "governor allowed to become law": ["became-law"],
-        "allowed to go into effect without the signature of the governor": [
-            "became-law"
-        ],
-    }
-
-    # Takes in a string description of an action and returns the respective OS classification
-    def categorize_actions(self, action_description):
-        for action_key, classification in self._actions.items():
-            # If we can detect a phrase that there is an OS action classification for
-            if action_key in action_description:
-                return classification
-        return None
-    """
-
     def scrape(self, session=None):
         HTML_TAGS_RE = r"<.*?>"
 
@@ -242,10 +204,10 @@ class VTBillScraper(Scraper, LXMLMixin):
 
                 # If both an action type and actor were assigned
                 if action_classification:
-                    action_type = action_classification[0]
+                    action_type = action_classification
 
-                    if len(action_classification) > 1:
-                        actor = action_classification[1]
+                    # if len(action_classification) > 1:
+                    # actor = action_classification[1]
 
                 # More action categorization
                 # These classifications are done separately because they require more rules
@@ -276,6 +238,12 @@ class VTBillScraper(Scraper, LXMLMixin):
                     and "passed" not in action["FullStatus"].lower()
                 ):
                     action_type = "amendment-introduction"
+
+                elif (
+                    "become law without signature of governor"
+                    in action["FullStatus"].lower()
+                ):
+                    actor = "executive"
 
                 else:
                     action_type = None

--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -4,12 +4,13 @@ import re
 
 import lxml.etree
 from openstates.scrape import Scraper, Bill, VoteEvent
-
+from . import actions
 from utils import LXMLMixin
 
 
 class VTBillScraper(Scraper, LXMLMixin):
 
+    """
     # Dictionary matching bill action phrases to classifications. Classifications can be found here:
     # https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
     _actions = {
@@ -44,6 +45,7 @@ class VTBillScraper(Scraper, LXMLMixin):
             if action_key in action_description:
                 return classification
         return None
+    """
 
     def scrape(self, session=None):
         HTML_TAGS_RE = r"<.*?>"
@@ -212,16 +214,16 @@ class VTBillScraper(Scraper, LXMLMixin):
 
             # Checks if page actually has json posted
             if "json" in actions_json.headers.get("Content-Type"):
-                actions = json.loads(actions_json.text)["data"]
+                these_actions = json.loads(actions_json.text)["data"]
                 # Checks to see if any data is actually there
-                if actions == "":
+                if these_actions == "":
                     continue
             else:
                 continue
             bill.add_source(actions_url)
 
             chambers_passed = set()
-            for action in actions:
+            for action in these_actions:
                 action = {k: v for k, v in action.items() if v is not None}
 
                 if "Signed by Governor" in action["FullStatus"]:
@@ -234,7 +236,7 @@ class VTBillScraper(Scraper, LXMLMixin):
                     raise AssertionError("Unknown actor for bill action")
 
                 # Categorize action
-                action_classification = self.categorize_actions(
+                action_classification = actions.categorize_actions(
                     action["FullStatus"].lower()
                 )
 


### PR DESCRIPTION
Improvements associated with [OS-783](https://civic-eagle.atlassian.net/browse/OS-783). 

These changes update the VT scraper to:

- match bill action phrases to existing [OS classifications](https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87) at a higher rate than before
- collect bill action phrases and their respective classifications in an organized way
- perform bill action classification in a separate function (outside of the main bill scraping function)