### PR TITLE
Have a cleaner start up for init-db.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,4 +74,4 @@ services:
       test: ["CMD-SHELL", "pg_isready -q -d db -U db"]
       interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,3 +70,8 @@ services:
       - ./openstates-postgres/:/var/lib/postgresql/data
     networks:
       - openstates-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -q -d db -U db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/scripts/init-db.sh
+++ b/scripts/init-db.sh
@@ -4,9 +4,8 @@ set -ex
 unset DATABASE_URL
 
 # stop database and remove volume
-docker-compose down
-docker-compose up -d db
-sleep 3
+docker compose down
+docker compose up --wait db
 
 # migrate and populate db
-DATABASE_URL=postgis://openstates:openstates@db/openstatesorg docker-compose run --rm --entrypoint "poetry run os-initdb" scrape
+DATABASE_URL=postgis://openstates:openstates@db/openstatesorg docker compose run --rm --entrypoint "poetry run os-initdb" scrape


### PR DESCRIPTION
add a health check to the compose db and wait for the db to be healthy before initializing

This also changes to using `docker compose` vs. `docker-compose`. Which means we're relying on the _actual_ docker binaries released by docker (docker desktop on Mac, docker-ce on Linux), where the `compose` plugin is available. Not tested with `podman` (although we probably should).

Signed-off-by: John Seekins <john@civiceagle.com>