### PR TITLE
MS: people scraper fixes

### DIFF
--- a/scrapers_next/ms/people.py
+++ b/scrapers_next/ms/people.py
@@ -157,26 +157,28 @@ class LegDetail(HtmlPage):
 class Legislators(HtmlPage):
     def process_page(self):
         members = self.root.getchildren()
-        count = 0
+        member_links = set()
         for member in members:
-            count += 1
             children = member.getchildren()
             if not children:
                 continue
             elif len(children) == 3:
                 lt_gov = "President of the Senate"
-                pres_pro_temp = "President Pro Tempore"
                 title = children[0].text_content().strip()
-                if title in (lt_gov, pres_pro_temp):
+                if title == lt_gov:
                     continue
 
                 name = children[1].text_content().strip()
 
-                link_id = children[2].text_content().strip()
+                link_id = children[2].text_content().strip().lower()
                 link = "http://billstatus.ls.state.ms.us/members/" + link_id
+                member_links.add(link)
 
                 partial_p = PartialPerson(
-                    name=name, title=title, chamber=self.chamber, source=self.source.url
+                    name=name,
+                    title=title,
+                    chamber=self.chamber,
+                    source=self.source.url,
                 )
 
                 yield LegDetail(partial_p, source=link)
@@ -184,10 +186,14 @@ class Legislators(HtmlPage):
                 for mem in grouper(member, 3):
                     name = mem[0].text_content().strip()
 
-                    link_id = mem[1].text_content().strip()
+                    link_id = mem[1].text_content().strip().lower()
                     if not re.search(r"\.xml", link_id):
                         continue
+
                     link = "http://billstatus.ls.state.ms.us/members/" + link_id
+                    if link in member_links:
+                        continue
+                    member_links.add(link)
 
                     partial_p = PartialPerson(
                         name=name,

--- a/scrapers_next/ms/people.py
+++ b/scrapers_next/ms/people.py
@@ -179,8 +179,8 @@ class Legislators(HtmlPage):
             else:
                 for mem in grouper(member, 3):
                     name = mem[0].text_content().strip()
-                    # Dean Kirby listed twice (already scraped above)
-                    if name == "Dean Kirby":
+
+                    if "vacancy" in name.lower():
                         continue
 
                     link_id = mem[1].text_content().strip()

--- a/scrapers_next/ms/people.py
+++ b/scrapers_next/ms/people.py
@@ -157,19 +157,23 @@ class LegDetail(HtmlPage):
 class Legislators(HtmlPage):
     def process_page(self):
         members = self.root.getchildren()
+        count = 0
         for member in members:
+            count += 1
             children = member.getchildren()
-            if children == []:
+            if not children:
                 continue
             elif len(children) == 3:
+                lt_gov = "President of the Senate"
+                pres_pro_temp = "President Pro Tempore"
                 title = children[0].text_content().strip()
-                name = children[1].text_content().strip()
-                link_id = children[2].text_content().strip()
-                # skip Lt. Gov. Delbert Hosemann
-                if link_id == "http://ltgovhosemann.ms.gov/":
+                if title in (lt_gov, pres_pro_temp):
                     continue
-                else:
-                    link = "http://billstatus.ls.state.ms.us/members/" + link_id
+
+                name = children[1].text_content().strip()
+
+                link_id = children[2].text_content().strip()
+                link = "http://billstatus.ls.state.ms.us/members/" + link_id
 
                 partial_p = PartialPerson(
                     name=name, title=title, chamber=self.chamber, source=self.source.url
@@ -180,10 +184,9 @@ class Legislators(HtmlPage):
                 for mem in grouper(member, 3):
                     name = mem[0].text_content().strip()
 
-                    if "vacancy" in name.lower():
-                        continue
-
                     link_id = mem[1].text_content().strip()
+                    if not re.search(r"\.xml", link_id):
+                        continue
                     link = "http://billstatus.ls.state.ms.us/members/" + link_id
 
                     partial_p = PartialPerson(


### PR DESCRIPTION
This PR was undertaken to fix an issue that was causing the MS people scraper to fail, receiving a 403 error in response to certain requests of member details page URLs.
- This was due to the fact that invalid URLs were being assembled for those requests whenever the scraper encountered a cell in the table of member names that did not contain a link. As of 11/24/22, this happens when vacant seats are encountered on the House members page (i.e. "Vacancy - District 23" instead of a hyperlinked Member name), but would presumably happen whenever hyperlinked text is not present in a cell.
- Solution to this issue in most recent file commit: a cell is skipped whenever there are absent XML page links.

In addition to fixing the above issue, two additional changes were added to improve upon the existing code:
- a `set()` was created to collect member detail XML page URL strings as each member is scraped, including a check to prevent duplicates
  - this is a longer-term solution than the existing code's handling which specifically named an individual ("Dean Kirby") in Senate leadership and instructed a skip of his duplicate listing. The new approach will prevent any duplicates on either house or senate people scrapes, should they occur in the future sessions with different leadership/members.
- cleaner, non-individual-name-specific code was implemented for skipping the "President of the Senate" (a.k.a. the Lieutenant Governor, an executive/non-legislative government official)