### PR TITLE
FL: Add session for 2023 prefiled bills

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -177,11 +177,18 @@ class Florida(State):
             "end_date": "2022-05-30",
             "active": True,
         },
+        {
+            "name": "2023 Regular Session",
+            "identifier": "2023",
+            "classification": "primary",
+            "start_date": "2023-03-07",
+            "end_date": "2023-05-05",
+            "active": True,
+        },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),
         "2022 Org.",
-        "2023",
         "2020 Org.",
         "2019 I",  # Empty, maybe informational session
         "2010",

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -598,6 +598,7 @@ class HouseSearchPage(HtmlListPage):
         # Keep the digits and all following characters in the bill's ID
         bill_number = re.search(r"^\w+\s(\d+\w*)$", self.input.identifier).group(1)
         session_number = {
+            "2023": "99",
             "2022D": "96",
             "2022C": "95",
             "2022": "93",


### PR DESCRIPTION
Prefiled bills are now being introduced for the Florida 2023 session. Added the 2023 Regular Session to the Florida scraper.

Source of the FL 2023 session dates:
https://www.flsenate.gov/Session/Calendar/2023/Session%20Dates%202022-03-17%20080110.PDF