### PR TITLE
[LA, ME, WA]: action classification updates 

### DIFF
--- a/scrapers/la/actions.py
+++ b/scrapers/la/actions.py
@@ -1,0 +1,78 @@
+# Dictionary matching bill action phrases to classifications. Classifications can be found here:
+# https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
+_actions = [
+    {
+        "type": "compare",
+        "value": "vetoed by the governor",
+        "mappings": ["executive-veto"],
+    },
+    {"type": "compare", "value": "becomes Act", "mappings": ["became-law"]},
+    {
+        "type": "compare",
+        "value": "sent to the governor",
+        "mappings": ["executive-receipt"],
+    },
+    {
+        "type": "compare",
+        "value": "signed by the governor",
+        "mappings": ["executive-signature"],
+    },
+    {"type": "compare", "value": "ordered to the senate", "mappings": ["passage"]},
+    {
+        "type": "compare",
+        "value": "ordered returned to the house",
+        "mappings": ["passage"],
+    },
+    {"type": "compare", "value": "sent to the house", "mappings": ["passage"]},
+    {
+        "type": "compare",
+        "value": "referred to the committee",
+        "mappings": ["referral-committee"],
+    },
+    {"type": "compare", "value": "prefiled", "mappings": ["filing"]},
+    {"type": "compare", "value": "passed to 3rd reading", "mappings": ["reading-3"]},
+    {"type": "compare", "value": "inially passed", "mappings": ["passage"]},
+    {"type": "compare", "value": "assed by", "mappings": ["passage"]},
+    {
+        "type": "compare",
+        "value": "sent to the governor",
+        "mappings": ["executive-receipt"],
+    },
+    {
+        "type": "compare",
+        "value": "reported with amendments",
+        "mappings": ["committee-passage-favorable"],
+    },
+    {
+        "type": "compare",
+        "value": "reported favorably",
+        "mappings": ["committee-passage-favorable"],
+    },
+    {"type": "compare", "value": "enrolled", "mappings": ["enrolled"]},
+    {
+        "type": "compare",
+        "value": "read by title and passed to third reading",
+        "mappings": ["reading-3"],
+    },
+    {"type": "compare", "value": "read first time by title", "mappings": ["reading-1"]},
+    {
+        "type": "compare",
+        "value": "read second time by title",
+        "mappings": ["reading-2"],
+    },
+    {
+        "type": "compare",
+        "value": "read second time by title",
+        "mappings": ["reading-2"],
+    },
+    {"type": "compare", "value": "received from", "mappings": ["receipt"]},
+]
+
+
+def categorize_actions(action_description):
+    atype = []
+    for action_dict in _actions:
+        if action_dict["value"] in action_description.lower():
+            atype.extend(a for a in action_dict["mappings"])
+
+    return atype

--- a/scrapers/la/actions.py
+++ b/scrapers/la/actions.py
@@ -1,78 +1,38 @@
-# Dictionary matching bill action phrases to classifications. Classifications can be found here:
-# https://github.com/openstates/openstates-core/blob/5b16776b1882da925e8e8d5c0a07160a7d649c69/openstates/data/common.py#L87
-_actions = [
-    {
-        "type": "compare",
-        "value": "vetoed by the governor",
-        "mappings": ["executive-veto"],
-    },
-    {"type": "compare", "value": "becomes Act", "mappings": ["became-law"]},
-    {
-        "type": "compare",
-        "value": "sent to the governor",
-        "mappings": ["executive-receipt"],
-    },
-    {
-        "type": "compare",
-        "value": "signed by the governor",
-        "mappings": ["executive-signature"],
-    },
-    {"type": "compare", "value": "ordered to the senate", "mappings": ["passage"]},
-    {
-        "type": "compare",
-        "value": "ordered returned to the house",
-        "mappings": ["passage"],
-    },
-    {"type": "compare", "value": "sent to the house", "mappings": ["passage"]},
-    {
-        "type": "compare",
-        "value": "referred to the committee",
-        "mappings": ["referral-committee"],
-    },
-    {"type": "compare", "value": "prefiled", "mappings": ["filing"]},
-    {"type": "compare", "value": "passed to 3rd reading", "mappings": ["reading-3"]},
-    {"type": "compare", "value": "inially passed", "mappings": ["passage"]},
-    {"type": "compare", "value": "assed by", "mappings": ["passage"]},
-    {
-        "type": "compare",
-        "value": "sent to the governor",
-        "mappings": ["executive-receipt"],
-    },
-    {
-        "type": "compare",
-        "value": "reported with amendments",
-        "mappings": ["committee-passage-favorable"],
-    },
-    {
-        "type": "compare",
-        "value": "reported favorably",
-        "mappings": ["committee-passage-favorable"],
-    },
-    {"type": "compare", "value": "enrolled", "mappings": ["enrolled"]},
-    {
-        "type": "compare",
-        "value": "read by title and passed to third reading",
-        "mappings": ["reading-3"],
-    },
-    {"type": "compare", "value": "read first time by title", "mappings": ["reading-1"]},
-    {
-        "type": "compare",
-        "value": "read second time by title",
-        "mappings": ["reading-2"],
-    },
-    {
-        "type": "compare",
-        "value": "read second time by title",
-        "mappings": ["reading-2"],
-    },
-    {"type": "compare", "value": "received from", "mappings": ["receipt"]},
-]
+from utils.actions import Rule, BaseCategorizer
 
 
-def categorize_actions(action_description):
-    atype = []
-    for action_dict in _actions:
-        if action_dict["value"] in action_description.lower():
-            atype.extend(a for a in action_dict["mappings"])
+rules = (
+    Rule(
+        r"Vetoed by the Governor",
+        "executive-veto",
+    ),
+    Rule(r"Becomes Act No", "became-law"),
+    Rule(r"Sent to the Governor", "executive-receipt"),
+    Rule(r"Signed by the Governor", "executive-signature"),
+    Rule(r"ordered to the Senate", "passage"),
+    Rule(r"ordered returned to the House", "passage"),
+    Rule(r"sent to the House", "passage"),
+    Rule(r"referred to the Committee", "referral-committee"),
+    Rule(r"Prefiled", "filing"),
+    Rule(r"passed to 3rd reading", "reading-3"),
+    Rule(r"Finally passed", "passage"),
+    Rule(r"passed by", "passage"),
+    Rule(r"Sent to the Governor", "executive-receipt"),
+    Rule(r"Reported with amendments", "committee-passage-favorable"),
+    Rule(r"Reported favorably", "committee-passage-favorable"),
+    Rule(r"Enrolled", "enrolled"),
+    Rule(r"Read by title and passed to third reading", "reading-3"),
+    Rule(r"Read first time by title", "reading-1"),
+    Rule(r"Read second time by title", "reading-2"),
+    Rule(r"Received from", "receipt"),
+)
 
-    return atype
+
+class Categorizer(BaseCategorizer):
+    rules = rules
+
+    def categorize(self, text):
+        """Wrap categorize"""
+        attrs = BaseCategorizer.categorize(self, text)
+
+        return attrs

--- a/scrapers/la/bills.py
+++ b/scrapers/la/bills.py
@@ -8,10 +8,14 @@ from openstates.scrape import Scraper, Bill, VoteEvent
 from openstates.utils import convert_pdf
 from openstates.exceptions import EmptyScrape
 from utils import LXMLMixin
-from . import actions
+
+# from . import actions
+from .actions import Categorizer
 
 
 class LABillScraper(Scraper, LXMLMixin):
+    categorizer = Categorizer()
+
     _chambers = {"S": "upper", "H": "lower", "J": "legislature"}
 
     _bill_types = {
@@ -332,13 +336,13 @@ class LABillScraper(Scraper, LXMLMixin):
             date = dt.datetime.strptime(date, "%m/%d/%Y")
             chamber = self._chambers[chamber]
 
-            cat = actions.categorize_actions(text.lower())
+            attrs = self.categorizer.categorize(text)
 
             bill.add_action(
                 description=text,
                 date=date.strftime("%Y-%m-%d"),
                 chamber=chamber,
-                classification=cat,
+                classification=attrs["classification"],
             )
 
         yield bill

--- a/scrapers/me/actions.py
+++ b/scrapers/me/actions.py
@@ -46,6 +46,14 @@ rules = (
     Rule(
         r"(?<![Aa]mendment)READ and (PASSED|ADOPTED)(, in concurrence)?\.$", "passage"
     ),
+    Rule(r"ENGROSSED", "reading-3"),
+    Rule(r"Received by the ", "receipt"),
+    Rule(r"(?=.*Committee Amendment)(?=.*ADOPTED)", "committee-passage-favorable"),
+    Rule(r"DEAD", "failure"),
+    Rule(r"(?=.*Committee Amendment)(?=.*FAILED)", "amendment-failure"),
+    Rule(r"Withdraw", "withdrawal"),
+    Rule(r"REFER to the Committee", "referral-committee"),
+    Rule(r"Majority Ought Not to Pass Report was ACCEPTED", "committee-failure"),
 )
 
 

--- a/scrapers/wa/actions.py
+++ b/scrapers/wa/actions.py
@@ -69,7 +69,7 @@ _categorizer_rules = (
     Rule(r"(?i)chapter (((\d+),?)+) \d+ laws.( .+)?", ""),  # XXX: Thom: Code stuff?
     Rule(r"(?i)effective date \d{1,2}/\d{1,2}/\d{4}.*", ""),
     Rule(
-        r"(?i)(?P<committees>\w+) - majority; do pass with amendment\(s\) \
+        r"(?i)(?P<committees>\w+) - [Mm]ajority; do pass with amendment\(s\) \
          (but without amendments\(s\))?.*\.",
         "committee-passage-favorable",
         "committee-passage",
@@ -80,7 +80,7 @@ _categorizer_rules = (
         "",
     ),
     Rule(
-        r"(?i)(?P<committees>\w+) \- Majority; do pass .* \(Majority Report\)",
+        r"(?i)(?P<committees>\w+) \- [Mm]ajority; do pass .* \(Majority Report\)",
         "passage",
     ),
     Rule(r"(?i)Conference committee appointed.", ""),
@@ -107,6 +107,14 @@ _categorizer_rules = (
     Rule(r"(?i)Failed final passage;", "failure"),
     Rule(r"Effective date", "became-law"),
     Rule(r"Chapter .* Laws", "became-law"),
+    Rule(r"Minority; do not pass.", "committee-passage-unfavorable"),
+    Rule(r"Placed on [Ss]econd [Rr]eading", "reading-2"),
+    Rule(r"Placed on [Tt]hird [Rr]eading", "reading-3"),
+    Rule(r"amendment/(s/) adopted", "amendment-passage"),
+    Rule(r"Referred to", "referral-committee"),
+    Rule(r"Majority; do pass.", "committee-passage-favorable"),
+    Rule(r"Minority; without recommendation.", "committee-passage-unfavorable"),
+    Rule(r"Delivered to Governor.", "executive-receipt"),
 )
 
 


### PR DESCRIPTION
PR for action classification updates. These updates aim to increase action classification coverage as well as standardize the classification code so that it utilizes the BaseCategorizer class defined [here](https://github.com/openstates/openstates-scrapers/blob/3e5b5b1eec50f71a7b15b8be1c409a8be483694d/scrapers/utils/actions.py#L62). 


Currently working on:
- [x] Louisiana
- [x] Maine
- [x] Washington