### PR TITLE
HI: Fix Version Parsing

### DIFF
--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -91,6 +91,15 @@ class Hawaii(State):
             "end_date": "2022-04-28",
             "active": True,
         },
+        {
+            "_scraped_name": "2023",
+            "identifier": "2023 Regular Session",
+            "name": "2023 Regular Session",
+            "start_date": "2023-01-18",
+            # TODO: update dates
+            "end_date": "2023-04-28",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "2011",
@@ -111,8 +120,7 @@ class Hawaii(State):
     def get_session_list(self):
         # doesn't include current session, we need to change it
         sessions = url_xpath(
-            "https://capitol.hawaii.gov/archives/main.aspx",
-            "//div[@class='roundedrect gradientgray shadow archiveyears']/a/text()",
+            "https://www.capitol.hawaii.gov/session/archives/main.aspx",
+            "//*[@id='ctl00_MainContent_yearList']/option/text()",
         )
-        sessions.remove("Archives Main")
         return sessions

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -396,6 +396,7 @@ class HIBillScraper(Scraper):
         list_page = lxml.html.fromstring(list_html)
         for bill_url in list_page.xpath("//a[@class='report']"):
             bill_url = bill_url.attrib["href"].replace("www.", "")
+            bill_url = f"{HI_URL_BASE}{bill_url}"
             yield from self.scrape_bill(session, chamber, billtype_map, bill_url)
 
     def scrape(self, chamber=None, session=None):

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -186,22 +186,20 @@ class HIBillScraper(Scraper):
         return name.strip()
 
     def parse_bill_versions_table(self, bill, versions):
-        versions = versions.xpath("./*")
-        if versions == []:
+        if not versions:
             raise Exception("Missing bill versions.")
 
         for version in versions:
-            tds = version.xpath("./td")
-            if "No other versions" in tds[0].text_content():
+            td = version.xpath("./a")[0]
+            if "No other versions" in td.text_content():
                 return
 
-            if version.xpath("./td/a"):
-                http_href = tds[0].xpath("./a")
-                name = http_href[0].text_content().strip()
-                pdf_href = tds[1].xpath("./a")
+            if version.xpath("./a"):
+                http_href = td.attrib["href"]
+                name = td.text_content().strip()
 
-                http_link = http_href[0].attrib["href"].replace("www.", "")
-                pdf_link = pdf_href[0].attrib["href"].replace("www.", "")
+                http_link = f"{HI_URL_BASE}{http_href}"
+                pdf_link = http_link.replace("HTM", "PDF")
 
                 # some bills (and GMs) swap the order or double-link to the same format
                 # so detect the type, and ignore dupes
@@ -270,7 +268,9 @@ class HIBillScraper(Scraper):
 
         qs = dict(urlparse.parse_qsl(urlparse.urlparse(url).query))
         bill_id = "{}{}".format(qs["billtype"], qs["billnumber"])
-        versions = bill_page.xpath("//table[contains(@id, 'GridViewVersions')]")[0]
+        versions = bill_page.xpath(
+            "//*[@id='ctl00_MainContent_UpdatePanel2']/div/div/div"
+        )
 
         metainf_table = bill_page.xpath(
             '//div[contains(@id, "itemPlaceholder")]//table[1]'


### PR DESCRIPTION
Looks like they've updated the site, but most of the common structure still works. The versions have a different selector now, and just pulls the html link & tweaks it for the pdf link since the structure of the second link on the row isn't always definite.