### PR TITLE
TN: Titleless Bills

### DIFF
--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -337,13 +337,14 @@ class TNBillScraper(Scraper):
         title = page.xpath("//span[@id='lblAbstract']")[0].text
         if title is None:
             title = "[No title given by state]"
+            subjects = []
             msg = "%s detail page was missing title info."
             self.logger.warning(msg % bill_id)
-
-        # bill subject
-        subject_pos = title.find("-")
-        subjects = [s.strip() for s in title[: subject_pos - 1].split(",")]
-        subjects = filter(None, subjects)
+        else:
+            # bill subject
+            subject_pos = title.find("-")
+            subjects = [s.strip() for s in title[: subject_pos - 1].split(",")]
+            subjects = filter(None, subjects)
 
         bill = Bill(
             bill_id,

--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -336,9 +336,9 @@ class TNBillScraper(Scraper):
 
         title = page.xpath("//span[@id='lblAbstract']")[0].text
         if title is None:
+            title = "[No title given by state]"
             msg = "%s detail page was missing title info."
             self.logger.warning(msg % bill_id)
-            return
 
         # bill subject
         subject_pos = title.find("-")


### PR DESCRIPTION
We still want to scrape bills that lack a title since they seem to have versions and other data available, this adds the same string we have for [AL bills](https://github.com/openstates/openstates-scrapers/blob/a50f83c37d06f2cd2e9185ccaa20ce32879581ec/scrapers/al/bills.py#L277) lacking a title and skips trying to pull a subject from a non-title.