### PR TITLE
[NH,CT,ID]: action classification updates

### DIFF
--- a/scrapers/ct/actions.py
+++ b/scrapers/ct/actions.py
@@ -1,0 +1,29 @@
+from utils.actions import Rule, BaseCategorizer
+
+_categorizer_rules = (
+    Rule(r"^ADOPTED, (HOUSE|SENATE|SEN\.?)", "passage"),
+    Rule(r"^(HOUSE|SENATE|SEN\.?) PASSED", "passage"),
+    Rule(r"^Joint [Ff]avorable", "committee-passage-favorable"),
+    Rule(r"^Joint [Uu]n?[Ff]avorable", "committee-passage-unfavorable"),
+    Rule(r"SIGNED BY GOVERNOR", "executive-signature"),
+    Rule(r"^LINE ITEM VETOED", "executive-veto-line-item"),
+    Rule(r"VETOED BY GOVERNOR", "executive-veto"),
+    # According to CT leg website, tabled for calendar = second reading
+    Rule(r"TABLED FOR", "reading-2"),
+    Rule(r"^.*ADOPTED.*AMEND.*$", "amendment-passage"),
+    Rule(r"^.*REJECTED.*AMEND.*$", "amendment-failure"),
+    Rule(r"FILED", "filing"),
+    Rule(r"REFERRED TO", "referral"),
+    Rule(r"TRANSMITTED BY SECRETARY OF THE STATE TO GOVERNOR", "executive-receipt"),
+    Rule(r"TAB. FOR CAL.", "reading-2"),
+    Rule(r"^.*REJ.*AMEND.*$", "amendment-failure"),
+    Rule(r"^.*REF.*TO JOINT COMM.*$", "referral-committee"),
+)
+
+
+class Categorizer(BaseCategorizer):
+    rules = _categorizer_rules
+
+    def categorize(self, text):
+        attrs = BaseCategorizer.categorize(self, text)
+        return attrs

--- a/scrapers/id/actions.py
+++ b/scrapers/id/actions.py
@@ -1,0 +1,67 @@
+from utils.actions import Rule, BaseCategorizer
+
+rules = (
+    Rule(r"^Introduced", "introduction"),
+    # reading-1
+    Rule(
+        r"(\w+) intro - (\d)\w+ rdg - to (\w+/?\s?\w+\s?\w+)",
+        ["introduction", "reading-1"],
+    ),
+    # committee actions
+    Rule(r"rpt prt - to\s(\w+/?\s?\w+)", "referral-committee"),
+    # it is difficult to figure out which committee passed/reported out a bill
+    # but i guess we at least know that only committees report out
+    Rule(r"rpt out - rec d/p", "committee-passage-favorable"),
+    Rule(r"^rpt out", "committee-passage"),
+    Rule(r"^rpt out", "committee-passage"),
+    Rule(
+        r"Reported out of Committee with Do Pass Recommendation",
+        "committee-passage-favorable",
+    ),
+    Rule(r"Reported out of Committee without Recommendation", "committee-passage"),
+    Rule(r"^Reported Signed by Governor", "executive-signature"),
+    Rule(r"^Signed by Governor", "executive-signature"),
+    Rule(r"Became law without Governor.s signature", "became-law"),
+    # I dont recall seeing a 2nd rdg by itself
+    Rule(r"^1st rdg - to 2nd rdg", "reading-2"),
+    # second to third will count as a third read if there is no
+    # explicit third reading action
+    Rule(r"2nd rdg - to 3rd rdg", "reading-3"),
+    Rule(r"^3rd rdg$", "reading-3"),
+    Rule(r".*Third Time.*PASSED.*", ["reading-3", "passage"]),
+    # reading-3, passage
+    Rule(r"^3rd rdg as amen - (ADOPTED|PASSED)", ["reading-3", "passage"]),
+    Rule(r"^3rd rdg - (ADOPTED|PASSED)", ["reading-3", "passage"]),
+    Rule(r"^Read Third Time in Full .* (ADOPTED|PASSED).*", ["reading-3", "passage"]),
+    Rule(r"^.*read three times - (ADOPTED|PASSED).*", ["reading-3", "passage"]),
+    Rule(r"^.*Read in full .* (ADOPTED|PASSED).*", ["reading-3", "passage"]),
+    # reading-3, failure
+    Rule(r"^3rd rdg as amen - (FAILED)", ["reading-3", "failure"]),
+    Rule(r"^3rd rdg - (FAILED)", ["reading-3", "failure"]),
+    # rules suspended
+    Rule(r"^Rls susp - ADOPTED", "passage"),
+    Rule(r"^Rls susp - PASSED", "passage"),
+    Rule(r"^Rls susp - FAILED", "failure"),
+    Rule(r"^to governor", "executive-receipt"),
+    Rule(r"^Governor signed", "executive-signature"),
+    Rule(r"^Returned from Governor vetoed", "executive-veto"),
+    Rule(r"Reported out of Committee and referred to", "referral-committee"),
+    Rule(r"Read second time", "reading-2"),
+    Rule(r"Signed by President", "passage"),
+    Rule(r"Signed by Speaker", "passage"),
+    Rule(r"to Governor", "executive-receipt"),
+    Rule(r"Read First Time, Referred to", ["reading-1", "referral-committee"]),
+    Rule(r"Read First Time, Filed for Second Reading", "reading-1"),
+    Rule(r"Read First Time, Filed for Second Reading", "reading-1"),
+    Rule(r"[Ee]nrolling", "enrolled"),
+    Rule(r"Read third time in full – PASSED", "passage"),
+    Rule(r"Read third time in full – FAILED", "failure"),
+)
+
+
+class Categorizer(BaseCategorizer):
+    rules = rules
+
+    def categorize(self, text):
+        attrs = BaseCategorizer.categorize(self, text)
+        return attrs

--- a/scrapers/id/bills.py
+++ b/scrapers/id/bills.py
@@ -220,7 +220,6 @@ class IDBillScraper(Scraper):
             if len(row[2]):
                 action = "".join(row[2].itertext())
             action = action.replace("\xa0", " ").strip()
-            # atype = get_action(actor, action)
             attrs = self.categorizer.categorize(action)
             atype = attrs["classification"]
             if atype and "passage" in atype:

--- a/scrapers/id/bills.py
+++ b/scrapers/id/bills.py
@@ -4,6 +4,8 @@ import re
 import datetime
 from collections import defaultdict
 import lxml.html
+from .actions import Categorizer
+
 
 BILLS_URL = "https://legislature.idaho.gov/sessioninfo/%s/legislation/minidata/"
 BILL_URL = "https://legislature.idaho.gov/sessioninfo/%s/legislation/%s/"
@@ -49,83 +51,6 @@ _COMMITTEES = {
     },
 }
 
-# a full list of the abbreviations and definitions can be found at:
-# http://legislature.idaho.gov/sessioninfo/glossary.htm
-# background on bill to law can be found at:
-# http://legislature.idaho.gov/about/jointrules.htm
-_ACTIONS = (
-    (r"^Introduced", "introduction"),
-    # reading-1
-    (
-        r"(\w+) intro - (\d)\w+ rdg - to (\w+/?\s?\w+\s?\w+)",
-        lambda mch, ch: ["introduction", "reading-1", "referral-committee"]
-        if mch.groups()[2] in _COMMITTEES[ch]
-        else ["introduction", "reading-1"],
-    ),
-    # committee actions
-    (
-        r"rpt prt - to\s(\w+/?\s?\w+)",
-        lambda mch, ch: ["referral-committee"]
-        if mch.groups()[0] in _COMMITTEES[ch]
-        else "other",
-    ),
-    # it is difficult to figure out which committee passed/reported out a bill
-    # but i guess we at least know that only committees report out
-    (r"rpt out - rec d/p", "committee-passage-favorable"),
-    (r"^rpt out", "committee-passage"),
-    (r"^rpt out", "committee-passage"),
-    (
-        r"Reported out of Committee with Do Pass Recommendation",
-        "committee-passage-favorable",
-    ),
-    (r"Reported out of Committee without Recommendation", "committee-passage"),
-    (r"^Reported Signed by Governor", "executive-signature"),
-    (r"^Signed by Governor", "executive-signature"),
-    (r"Became law without Governor.s signature", "became-law"),
-    # I dont recall seeing a 2nd rdg by itself
-    (r"^1st rdg - to 2nd rdg", "reading-2"),
-    # second to third will count as a third read if there is no
-    # explicit third reading action
-    (r"2nd rdg - to 3rd rdg", "reading-3"),
-    (r"^3rd rdg$", "reading-3"),
-    (r".*Third Time.*PASSED.*", ["reading-3", "passage"]),
-    # reading-3, passage
-    (r"^3rd rdg as amen - (ADOPTED|PASSED)", ["reading-3", "passage"]),
-    (r"^3rd rdg - (ADOPTED|PASSED)", ["reading-3", "passage"]),
-    (r"^Read Third Time in Full .* (ADOPTED|PASSED).*", ["reading-3", "passage"]),
-    (r"^.*read three times - (ADOPTED|PASSED).*", ["reading-3", "passage"]),
-    (r"^.*Read in full .* (ADOPTED|PASSED).*", ["reading-3", "passage"]),
-    # reading-3, failure
-    (r"^3rd rdg as amen - (FAILED)", ["reading-3", "failure"]),
-    (r"^3rd rdg - (FAILED)", ["reading-3", "failure"]),
-    # rules suspended
-    (
-        r"^Rls susp - (ADOPTED|PASSED|FAILED)",
-        lambda mch, ch: {
-            "ADOPTED": "passage",
-            "PASSED": "passage",
-            "FAILED": "failure",
-        }[mch.groups()[0]],
-    ),
-    (r"^to governor", "executive-receipt"),
-    (r"^Governor signed", "executive-signature"),
-    (r"^Returned from Governor vetoed", "executive-veto"),
-)
-
-
-def get_action(actor, text):
-    # the biggest issue with actions is that some lines seem to indicate more
-    # than one action
-
-    for pattern, action in _ACTIONS:
-        match = re.match(pattern, text, re.I)
-        if match:
-            if callable(action):
-                return action(match, actor)
-            else:
-                return action
-    return None
-
 
 def get_bill_type(bill_id):
     suffix = bill_id.split(" ")[0]
@@ -136,6 +61,7 @@ def get_bill_type(bill_id):
 
 
 class IDBillScraper(Scraper):
+    categorizer = Categorizer()
 
     # the following are only used for parsing legislation from 2008 and earlier
     vote = None
@@ -294,7 +220,9 @@ class IDBillScraper(Scraper):
             if len(row[2]):
                 action = "".join(row[2].itertext())
             action = action.replace("\xa0", " ").strip()
-            atype = get_action(actor, action)
+            # atype = get_action(actor, action)
+            attrs = self.categorizer.categorize(action)
+            atype = attrs["classification"]
             if atype and "passage" in atype:
                 has_moved_chambers = True
 

--- a/scrapers/nh/actions.py
+++ b/scrapers/nh/actions.py
@@ -1,0 +1,35 @@
+from utils.actions import Rule, BaseCategorizer
+
+# These are regex patterns that map to action categories.
+_categorizer_rules = (
+    Rule(r"Minority Committee Report", None),  # avoid calling these passage
+    Rule(r"Ought to Pass", ["passage"]),
+    Rule(r"Passed by Third Reading", ["reading-3", "passage"]),
+    Rule(r".*Ought to Pass", ["committee-passage-favorable"]),
+    Rule(r".*Introduced(.*) and (R|r)eferred", ["introduction", "referral-committee"]),
+    Rule(r"Proposed(.*) Amendment", "amendment-introduction"),
+    Rule(r"Amendment .* Adopted", "amendment-passage"),
+    Rule(r"Amendment .* Failed", "amendment-failure"),
+    Rule(r"Signed", "executive-signature"),
+    Rule(r"Vetoed", "executive-veto"),
+    Rule(r"^Introduced", "introduction"),
+    Rule(r"Enrolled Adopted", "enrolled"),
+    Rule(r"^Inexpedient", "failure"),
+    Rule(r"Withdraws Floor Amendment", "amendment-withdrawal"),
+    Rule(r"Refer to Interim Study", "referral"),
+    Rule(r"^(?!.*Committee Report).*[Rr]eferred [Tt]o.*$", "referral-committee"),
+    Rule(r"Lay.*on Table.*$", "deferral"),
+    Rule(
+        r"^(?!.*Minority).*Committee Report: Inexpedient to Legislate",
+        "committee-failure",
+    ),
+)
+
+
+class Categorizer(BaseCategorizer):
+    rules = _categorizer_rules
+
+    def categorize(self, text):
+        """Wrap categorize and add boilerplate committees."""
+        attrs = BaseCategorizer.categorize(self, text)
+        return attrs


### PR DESCRIPTION
PR for action classification updates. These updates aim to increase action classification coverage as well as standardize the classification code so that it utilizes the BaseCategorizer class defined [here](https://github.com/openstates/openstates-scrapers/blob/3e5b5b1eec50f71a7b15b8be1c409a8be483694d/scrapers/utils/actions.py#L62).