### PR TITLE
CA: Bills: Skip cert validation when downloading bulk data

### DIFF
--- a/scrapers/ca/download.py
+++ b/scrapers/ca/download.py
@@ -261,7 +261,7 @@ def db_create():
 
 def get_contents():
     resp = {}
-    html = requests.get(BASE_URL).text
+    html = requests.get(BASE_URL, verify=False).text
     doc = lxml.html.fromstring(html)
     # doc.make_links_absolute(BASE_URL)
     rows = doc.xpath("//table/tr")


### PR DESCRIPTION
SSL cert is expired.