### PR TITLE
TN: people, urls fix, try-except add for missing content

### DIFF
--- a/scrapers_next/tn/people.py
+++ b/scrapers_next/tn/people.py
@@ -57,9 +57,14 @@ class LegDetail(HtmlPage):
             p.district_office.fax = ""
             p.district_office.address = ""
 
-        extra_info = XPath(
-            "/html/body/div[1]/div/div/div[2]/div/div[2]/ul[2]/li[1]/ul/li"
-        ).match(self.root)
+        try:
+            extra_info = XPath(
+                "/html/body/div[1]/div/div/div[2]/div/div[2]/ul[2]/li[1]/ul/li"
+            ).match(self.root)
+
+        except SelectorError:
+            extra_info = []
+
         if len(extra_info) > 0:
             p.extras["personal info"] = []
             for line in extra_info:
@@ -182,10 +187,14 @@ class Legislators(HtmlListPage):
 
 
 class Senate(Legislators):
-    source = URL("https://www.capitol.tn.gov/senate/members/")
+    source = URL(
+        "http://wapp.capitol.tn.gov/apps/LegislatorInfo/directory.aspx?chamber=S"
+    )
     chamber = "upper"
 
 
 class House(Legislators):
-    source = URL("https://www.capitol.tn.gov/house/members/")
+    source = URL(
+        "http://wapp.capitol.tn.gov/apps/LegislatorInfo/directory.aspx?chamber=H"
+    )
     chamber = "lower"


### PR DESCRIPTION
The TN people scraper's HtmlListPage object was failing on its top-level SelectorError. This was due to the url for both the Senate and House members having changed. The list page, however, remained unchanged. Correct urls were added, and the scraper was able to begin running through the member list page.

Once HtmlListPage was able to run, it was still failing on one member's page due to missing `extra_content` that an XPath selector was trying to access. After addition of a try-except clause to handle this missing page content, both House and Senate people scrapers were able to run successfully and completely. Data looks good.