### PR TITLE
WA: people RepList CSS selector min+max items adjust

### DIFF
--- a/scrapers_next/wa/people.py
+++ b/scrapers_next/wa/people.py
@@ -107,7 +107,8 @@ class RepList(LegList):
     source = URL(
         "https://app.leg.wa.gov/ContentParts/MemberDirectory/?a=House", timeout=30
     )
-    selector = CSS("#allMembers .memberInformation", min_items=97)
+
+    selector = CSS("#allMembers .memberInformation", min_items=90, max_items=98)
     chamber = "lower"
 
 


### PR DESCRIPTION
WA people scraper was failing on the House because the top-level CSS selector for the list page had `min_items=97` but selector was only getting 93 items. The number of members in the WA House is 98.

The discrepancy was due to five House members being recently removed from the House list because they were all elected to WA Senate seats (Matt Boehnke, Noel Frame, Drew MacEwen, Sharon Shewmake, Javier Valdez).

While the members pages for both chambers will presumably be fully updated when new session starts, this PR brings the `min_items` and `max_items` settings for the House selector into equal proportion with Senate selector counterparts set previously (the Senate is half the size of the house, at 49 members).

Do we feel good about those settings?

(Side note: Should we look at adding min_items and max_items settings for all legislature's people scrapers, to detect irregularities/inconsistencies between what are selectors are encountering and what legislature size should be? Or is not a problem worth worrying about at this point?)