### PR TITLE
IN people: missing phone handling add, BlueSen social fix

### DIFF
--- a/scrapers_next/hi/people.py
+++ b/scrapers_next/hi/people.py
@@ -1,89 +1,102 @@
-import lxml.html
-from spatula import CSS, SelectorError, HtmlListPage
+from spatula import XPath, HtmlListPage
 from openstates.models import ScrapePerson
-
-
-class FormSource:
-    """a WIP generic source for POSTing a form, and getting back results"""
-
-    retries = 3
-
-    def __init__(self, url, form_xpath, button_label):
-        self.url = url
-        self.form_xpath = form_xpath
-        self.button_label = button_label
-
-    def get_response(self, scraper):
-        resp = scraper.get(self.url)
-        root = lxml.html.fromstring(resp.content)
-        form = root.xpath(self.form_xpath)[0]
-        inputs = form.xpath(".//input")
-        # build list of all of the inputs of the form, clicking the button we need to click
-        data = {}
-        for inp in inputs:
-            name = inp.get("name")
-            value = inp.get("value")
-            inptype = inp.get("type")
-            if inptype == "submit":
-                if value == self.button_label:
-                    data[name] = value
-            else:
-                data[name] = value
-
-        # do second request
-        resp = scraper.post(self.url, data)
-        return resp
-
-    def __str__(self):
-        return f"FormSource('{self.url}', '{self.form_xpath}', '{self.button_label}')"
+import re
 
 
 class Legislators(HtmlListPage):
-    source = FormSource(
-        "https://www.capitol.hawaii.gov/members/legislators.aspx", "//form", "Show All"
-    )
-    selector = CSS("#ctl00_ContentPlaceHolderCol1_GridView1 tr")
+    source = "http://www.capitol.hawaii.gov/members/legislators.aspx"
+    selector = XPath(".//div[@class='contact-box center-version active']")
 
-    LABELS = {
-        "first_name": "LabelFirst",
-        "party": "LabelParty",
-        "room": "LabelRoom2",
-        "voice": "LabelPhone2",
-        "fax": "LabelFAX2",
-        "email": "HyperLinkEmail",
-        "chamber": "LabelDis",
-        "district": "LabelDistrict",
-    }
+    multi_commas_regex = re.compile(r",.+,")
+    leader_regex = re.compile(r"(.+),(.+)\s+\(([A-Z]+)\)\s+(.+)")
+    regular_regex = re.compile(r"(.+),(.+)\s+\(([A-Z]+)\)")
 
     def process_item(self, item):
-        try:
-            link = CSS("a").match(item)[1]
-        except SelectorError:
-            self.skip()
-        data = {
-            "last_name": link.text_content(),
-            "url": link.get("href"),
-        }
-        for key, label in self.LABELS.items():
-            data[key] = CSS(f"[id$={label}]").match_one(item).text_content().strip()
+        a_tag = item.xpath("a")[0]
+        member_page = a_tag.get("href")
+        member_photo = a_tag.xpath("img")[0].get("src")
 
-        party = {"(D)": "Democratic", "(R)": "Republican"}[data["party"]]
-        address = "Hawaii State Capitol, Room " + data["room"]
-        chamber = "upper" if data["chamber"] == "S" else "lower"
+        member_text = a_tag.text_content().strip()
+
+        multi_commas = self.multi_commas_regex.search(member_text)
+
+        # Conditional Re-formats member_text in cases with multiple commas
+        #   Ex: Richards\r\n, III, Herbert M. "Tim" (D)
+        if multi_commas:
+            single_line = member_text.replace("\r\n", "")
+            comma_split = [x.strip() for x in single_line.split(",")]
+            member_text = f"{' '.join(comma_split[0:2])}, {comma_split[-1]}"
+
+        leader = self.leader_regex.search(member_text)
+        if leader:
+            name_parts = [x.strip() for x in leader.groups()]
+            # Extract title, only leaders have one listed
+            title = name_parts.pop()
+        else:
+            regular_member = self.regular_regex.search(member_text)
+            name_parts = [x.strip() for x in regular_member.groups()]
+
+        # Extract party abbreviation from list
+        party = name_parts.pop()
+
+        last_name, first_name = name_parts[0], " ".join(name_parts[1:])
+
+        dist_text = item.xpath("div/a")[0].text_content().strip()
+        chamber, district = [x.strip() for x in dist_text.split("District")]
+
+        contact_info = item.xpath("div/address")[0]
+
+        contact_list = []
+        for x in contact_info.text_content().split("\r\n"):
+            if len(x.strip()):
+                contact_list.append(x.strip())
+
+        state_addr_base = "415 S Beretania St, Honolulu, HI 96813"
+        capitol_addr = f"{contact_list[0]}, {state_addr_base}"
+
+        cap_phone = contact_list[1].split(":")[-1].strip()
+        cap_fax = contact_list[2].split(":")[-1].strip()
+
+        # Website does not allow scraping of member emails,
+        #   so a manual check of all member emails confirmed
+        #   accuracy of below solution.
+        chars_to_remove = [
+            " iii",
+            "jr.",
+            " ",
+            "-",
+        ]
+        email_user = last_name.lower()
+        for char in chars_to_remove:
+            if char in email_user:
+                email_user = email_user.replace(char, "")
+        email_start = {"House": "rep", "Senate": "sen"}
+        email = email_start[chamber] + email_user + "@capitol.hawaii.gov"
+
+        # TODO: Add social media handle ingestion
 
         p = ScrapePerson(
-            name=data["first_name"] + " " + data["last_name"],
+            name=f"{first_name} {last_name}",
             state="hi",
-            chamber=chamber,
-            district=data["district"],
-            given_name=data["first_name"],
-            family_name=data["last_name"],
-            party=party,
-            email=data["email"],
+            chamber="lower" if chamber[0] == "H" else "upper",
+            district=district,
+            given_name=first_name,
+            family_name=last_name,
+            party="Democratic" if party == "D" else "Republican",
+            image=member_photo,
+            email=email,
         )
-        p.capitol_office.address = address
-        p.capitol_office.voice = data["voice"]
-        p.capitol_office.fax = data["fax"]
-        p.add_source(data["url"])
-        p.add_link(data["url"])
+
+        if title:
+            p.extras["title"] = title
+
+        p.capitol_office.address = capitol_addr
+        p.capitol_office.voice = cap_phone
+        p.capitol_office.fax = cap_fax
+
+        p.add_source(self.source.url)
+        p.add_link(member_page)
+
+        # TODO: Add Member Detail Page scraper to get any additional data
+
         return p

--- a/scrapers_next/in/people.py
+++ b/scrapers_next/in/people.py
@@ -46,37 +46,30 @@ class BlueSenDetail(HtmlPage):
             .strip()
         )
 
-        social_dict = {
-            "facebook": [],
-            "instagram": [],
-            "twitter": [],
-            "youtube": [],
-        }
+        p.capitol_office.address = addr
 
-        for soc in social_dict.keys():
-            soc_pattern = re.compile(rf"(.+)({soc}\.com/)(.+)")
-            social_dict[soc].append(soc_pattern)
+        socials = ["facebook", "instagram", "twitter", "youtube"]
+        handles = {x: None for x in socials}
+        patterns = {x: re.compile(rf"(.+)({x}\.com/)(.+)") for x in socials}
 
         social_links = CSS("div .fusion-social-links a").match(self.root)
         for link in social_links:
             href = link.get("href").lower()
-            for soc in social_dict.keys():
+            for soc in socials:
                 if soc in href:
-                    pattern = social_dict[soc][0]
+                    pattern = patterns[soc]
                     raw_handle = pattern.search(href).groups()[-1]
                     handle = re.sub("/", "", raw_handle)
-                    social_dict[soc].append(handle)
+                    handles[soc] = handle
 
-        p.capitol_office.address = addr
-
-        if len(social_dict["facebook"]) > 1:
-            p.ids.facebook = social_dict["facebook"][1]
-        if len(social_dict["instagram"]) > 1:
-            p.ids.instagram = social_dict["instagram"][1]
-        if len(social_dict["twitter"]) > 1:
-            p.ids.twitter = social_dict["twitter"][1]
-        if len(social_dict["youtube"]) > 1:
-            p.ids.youtube = social_dict["youtube"][1]
+        if handles["facebook"]:
+            p.ids.facebook = handles["facebook"]
+        if handles["instagram"]:
+            p.ids.instagram = handles["instagram"]
+        if handles["twitter"]:
+            p.ids.twitter = handles["twitter"]
+        if handles["youtube"]:
+            p.ids.youtube = handles["youtube"]
 
         return p
 


### PR DESCRIPTION
Issue that sparked this investigation was fixed by an edit to a member's page on the legislative site.

However, two unrelated `AttributeError: 'NoneType' object has no attribute 'groups'` issues were discovered to be causing failures in running DemocraticSenate.

1. First on `phone1, phone2 = re.search(r"Phone:\s(\d{3}-\d{3}-\d{4})\s\|\s(.+)", phones).groups()`
  - Cause: One or more dem senate members have less than two phone numbers
  - Solution: Restructured how the scraper was ingesting the "Phone" data field and all other information in that section of the page (at this point that also includes "Legislative Assistant", "Email", and "Media Contact"), including addition of a custom exemption to be raised (and named accordingly) when `NewDetailFieldEncountered` because the legislative site has added/modified a data field.
2. Second on `re.search(r"https://(www\.)?facebook\.com/(.+)", fb).groups()[1].rstrip("/")`
  - Cause: Approach of accessing each social media href by indexing as in `fb = CSS("div .fusion-social-links a").match(self.root)[1].get("href")` assumed same order of social media. This failed when one member had an instagram icon/link between icons for twitter and facebook.
  - Solution: Iterate through list of hrefs encountered by CSS selector, using dictionary keys for each potential social media platform, and storing any handles grabbed as values in the dictionary.