### PR TITLE
NM people: skip add for vacant seats

### DIFF
--- a/scrapers_next/nm/people.py
+++ b/scrapers_next/nm/people.py
@@ -55,6 +55,8 @@ class LegList(HtmlListPage):
     def process_item(self, item):
         name_party = CSS("span").match(item)[0].text_content().strip().split(" - ")
         name = name_party[0].strip()
+        if not re.search(r"[a-z]", name) or "vacant" in name.lower():
+            self.skip("vacant")
         party = name_party[1].strip()
         if party == "(D)":
             party = "Democratic"


### PR DESCRIPTION
NM people scraper was failing due to missing page content for vacant member seat.

- Error: `IndexError: list index out of range`
- Problem line: `party = name_party[1].strip()`
- Solution: conditional to skip that seat if alphabetic characters aren't found in the name text, or if name text contains "vacant"