### PR TITLE
Updated ND People Scraper for 2023 Session

### DIFF
--- a/scrapers_next/nd/people.py
+++ b/scrapers_next/nd/people.py
@@ -87,7 +87,7 @@ class LegDetail(HtmlPage):
 
 
 class LegList(HtmlListPage):
-    session = "67-2021"
+    session = "68-2023"
     source = f"https://www.ndlegis.gov/assembly/{session}/regular/members"
     selector = XPath("//div[@class='member-wrapper']")
     next_page_selector = XPath(


### PR DESCRIPTION
The scraper was set to the 2021-2022 session and the 2023-2024 members are now available 