### PR TITLE
SC: Remove .docx Versions

### DIFF
--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -391,8 +391,6 @@ class SCBillScraper(Scraper):
         version_doc = lxml.html.fromstring(version_html)
         version_doc.make_links_absolute(version_url)
         for version in version_doc.xpath('//a[contains(@href, "/prever/")]'):
-            # duplicate versions with same date, use first appearance
-
             bill.add_version_link(
                 note=version.text,  # Description of the version from the state;
                 #  eg, 'As introduced', 'Amended', etc.
@@ -400,13 +398,6 @@ class SCBillScraper(Scraper):
                 on_duplicate="ignore",
                 media_type="text/html",  # Still a MIME type
             )
-            # TODO: remove when docx are posted
-            # bill.add_version_link(
-            #     note=version.text,
-            #     url=version.get("href").replace(".htm", ".docx"),
-            #     on_duplicate="ignore",
-            #     media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            # )
         # for prefiles, the link just points right to the version, not to a versions page
         if "/bills/" in version_url.lower():
             bill.add_version_link(


### PR DESCRIPTION
Got a response from an admin, they're using a new system this year and won't be posting Doc versions any longer so will remove that logic entirely.