### PR TITLE
FL people: fix to skip empty chairs awaiting special election

### DIFF
--- a/scrapers_next/fl/people.py
+++ b/scrapers_next/fl/people.py
@@ -168,7 +168,7 @@ class Representatives(HtmlListPage):
         name = item.xpath("./a/div[@class='team-txt']/h5/text()")[0].strip()
 
         # skips empty chairs due to pending regular/special election
-        if "pending," in name.lower():
+        if "pending, special" or "pending, election" in name.lower():
             self.skip()
 
         party = item.xpath("./a/div[@class='team-txt']/p[1]/text()")[0].split()[0]

--- a/scrapers_next/fl/people.py
+++ b/scrapers_next/fl/people.py
@@ -167,8 +167,8 @@ class Representatives(HtmlListPage):
     def process_item(self, item):
         name = item.xpath("./a/div[@class='team-txt']/h5/text()")[0].strip()
 
-        # hack for empty chairs
-        if name == "Pending, Election":
+        # skips empty chairs due to pending regular/special election
+        if "pending" in name.lower():
             self.skip()
 
         party = item.xpath("./a/div[@class='team-txt']/p[1]/text()")[0].split()[0]

--- a/scrapers_next/fl/people.py
+++ b/scrapers_next/fl/people.py
@@ -168,7 +168,7 @@ class Representatives(HtmlListPage):
         name = item.xpath("./a/div[@class='team-txt']/h5/text()")[0].strip()
 
         # skips empty chairs due to pending regular/special election
-        if "pending" in name.lower():
+        if "pending," in name.lower():
             self.skip()
 
         party = item.xpath("./a/div[@class='team-txt']/p[1]/text()")[0].split()[0]


### PR DESCRIPTION
Scraper was failing with data validation error for `ScrapePerson` object when encountering an empty seat that is awaiting special election to be filled.
- Cause: scraper was only skipping if seat was labelled with "Pending, Election" and not in cases when label was "Pending, Special Election"
- Solution: conditional statement that initiates `self.skip()` executes simply if "pending" is in lowercase name label.

*Note* - additional commits were made to handle unlikely but possible cases when a hypothetical member's last name could contain the string "pending" at its end (i.e. "Spending, Marsha P.). The conditional now handles when either "pending, special" or "pending, election" are in the lowercase name label.