### PR TITLE
Updated Hardcoded Session Values for AK and KS

### DIFF
--- a/scrapers_next/ak/people.py
+++ b/scrapers_next/ak/people.py
@@ -131,7 +131,7 @@ class LegDetail(HtmlPage):
 
 
 class LegList(HtmlListPage):
-    session_num = "32"
+    session_num = "33"
     source = f"https://www.akleg.gov/basis/mbr_info.asp?session={session_num}"
     selector = XPath("//html/body/div[2]/div/div/table//tr[position()>1]/td[1]/nobr/a")
 

--- a/scrapers_next/ks/people.py
+++ b/scrapers_next/ks/people.py
@@ -47,7 +47,7 @@ class MembersDetail(JsonPage):
             ]
         )
 
-        leg_url = f"http://www.kslegislature.org/li/b2021_22/members/{content['KPID']}/"
+        leg_url = f"http://www.kslegislature.org/li/b2023_24/members/{content['KPID']}/"
         image_url = (
             f"http://www.kslegislature.org/li/m/images/pics/{content['KPID']}.jpg"
         )


### PR DESCRIPTION
Updated the session values for KS and AK. The AK value is correct but AK has not finished updating the page. Currently the page only includes Senators. They are still adding House of Representatives, there is missing data on one Senator, looks like they are making updates now. We may need to open a Jira ticket for AK if there are fixes needed in the scraper.