### PR TITLE
RI people: regex sub fixes for bad member bio urls

### DIFF
--- a/scrapers_next/ri/people.py
+++ b/scrapers_next/ri/people.py
@@ -1,6 +1,13 @@
 from spatula import HtmlListPage, CSS, XPath, HtmlPage, Page, URL
 from openstates.models import ScrapePerson
 import xlrd
+import re
+
+# Regex patterns to fix specific bad urls provided for new member bio pages
+#  TODO: Check at future point in 2023 session if these urls still bad,
+#   or if regex string substitution fix can be removed from LegList
+alex_finkelman_re = re.compile("finkelman/")
+linda_ujifusa_re = re.compile("ujifusa/")
 
 EXCEL_URL = URL(
     "http://www.rilegislature.gov/SiteAssets/MailingLists/Representatives.xls",
@@ -77,6 +84,10 @@ class LegList(HtmlListPage):
             p.district_office.voice = phone
 
         bio = CSS("td center a").match_one(item).get("href")
+
+        # Fixes bio page bad urls for Rep. Alex Finkelman, Sen. Linda Ujifusa
+        bio = alex_finkelman_re.sub("finkelmana/", bio)
+        bio = linda_ujifusa_re.sub("ujifusal/", bio)
 
         p.email = email
         p.add_link(bio)


### PR DESCRIPTION
Scraper was failing with 404 error when retrieving bio page urls for one senator and one assemblyman (both newly elected).

**Issue**
- the bad urls posted on the respective mailing list pages ([Senate](http://webserver.rilin.state.ri.us/Email/SenEmailListDistrict.asp) and [Assembly](http://webserver.rilin.state.ri.us/Email/RepEmailListDistrict.asp)) for these two members had only the last name (i.e. "ujifusa" for Senator Linda Ujifusa, and "finkelman" for Representative Alex Finkelman) while the good url path needed their first initial appended at the end of that substring (i.e. "ujifusal" and "finkelmana", respectively).

**Solution**
- given that there is not a consistent pattern to the good urls, this commit used ad hoc regex substitutions for those two members
- a `TODO` comment was added to check if urls are fixed in the future so these ad hoc checks can eventually be removed from the file
