### PR TITLE
MA people: list_url request verify=False add to avoid SSLError

### DIFF
--- a/scrapers_next/ma/people.py
+++ b/scrapers_next/ma/people.py
@@ -29,7 +29,7 @@ class LegDetail(JsonPage):
             district=self.data["District"],
             chamber=chamber,
             image=image,
-            email=self.data["EmailAddress"],
+            email=self.data["EmailAddress"] or "",
         )
 
         room_num = self.data["RoomNumber"]
@@ -76,7 +76,7 @@ class LegDetail(JsonPage):
 
 class LegList(JsonListPage):
 
-    source = URL(list_url(), timeout=30)
+    source = URL(list_url(), timeout=30, verify=False)
     selector = XPath("//LegislativeMemberSummary/Details")
 
     def process_item(self, item):


### PR DESCRIPTION
Scraper was failing with SSLError on HTTPS request of member list url.

Error:
- `SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))`

Solution:
- `verify=False` added to `URL` object for `list_url()`

Additional change to storing member email:
- Scraper was still failing with data validation error on `email` attribute of `ScrapePerson` object
- Solution: added `or ""` to store empty string when `self.data["EmailAddress"]` is none-type when processing member detail data.