### PR TITLE
PA: 2023 First Special

### DIFF
--- a/scrapers/pa/__init__.py
+++ b/scrapers/pa/__init__.py
@@ -85,6 +85,15 @@ class Pennsylvania(State):
             "name": "2023-2024 Regular Session",
             "start_date": "2023-01-03",
             "end_date": "2024-11-30",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2023-2024 Special Session #1 (Victims of Sexual Abuse)",
+            "classification": "primary",
+            "identifier": "2023-2024S1",
+            "name": "2023-2024 Special Session #1",
+            "start_date": "2023-01-09",
+            "end_date": "2023-01-13",
             "active": True,
         },
     ]

--- a/scrapers/pa/__init__.py
+++ b/scrapers/pa/__init__.py
@@ -85,7 +85,7 @@ class Pennsylvania(State):
             "name": "2023-2024 Regular Session",
             "start_date": "2023-01-03",
             "end_date": "2024-11-30",
-            "active": False,
+            "active": True,
         },
         {
             "_scraped_name": "2023-2024 Special Session #1 (Victims of Sexual Abuse)",

--- a/scrapers/pa/bills.py
+++ b/scrapers/pa/bills.py
@@ -18,7 +18,7 @@ class PABillScraper(Scraper):
     def scrape(self, chamber=None, session=None):
         chambers = [chamber] if chamber is not None else ["upper", "lower"]
 
-        match = re.search(r"#(\d+)", session)
+        match = re.search(r"[S#](\d+)", session)
         for chamber in chambers:
             if match:
                 yield from self.scrape_session(chamber, session, int(match.group(1)))


### PR DESCRIPTION
First special of the biennium!

I changed the code here to allow specials to be named "yearS1" in addition to "year#1" because I'm not confident that there's nowhere on os.org that we're not passing around session identifiers in the URL where a hash symbol could wreak havoc.