### PR TITLE
AR people: selector error fix for missing detail page data

### DIFF
--- a/scrapers_next/ar/people.py
+++ b/scrapers_next/ar/people.py
@@ -11,7 +11,10 @@ class PartialMember:
 
 
 class LegDetail(HtmlPage):
-    example_source = "https://www.arkleg.state.ar.us/Legislators/Detail?member=B.+Ballinger&ddBienniumSession=2023%2F2023R"
+    example_source = (
+        "https://www.arkleg.state.ar.us/Legislators/Detail?"
+        "member=B.+Ballinger&ddBienniumSession=2023%2F2023R"
+    )
 
     def process_page(self):
 
@@ -80,26 +83,29 @@ class LegDetail(HtmlPage):
             elif table[key] != "":
                 # remove the colon at the end
                 p.extras[key[:-1].lower()] = table[key]
-
-        address = CSS(".col-md-12 p b").match_one(self.root).text_content()
-        full_address = address[:-5] + "AR " + address[-5:]
+        try:
+            address = CSS(".col-md-12 p b").match_one(self.root).text_content()
+            full_address = address[:-5] + "AR " + address[-5:]
+            p.district_office.address = full_address
+        except SelectorError:
+            pass
 
         p.add_source(self.source.url)
         p.add_source(self.input.url)
-        p.district_office.address = full_address
 
         return p
 
 
 class LegList(HtmlListPage):
-    source = "https://www.arkleg.state.ar.us/Legislators/List?sort=Type&by=desc&ddBienniumSession=2023%2F2023R#SearchResults"
-    selector = XPath(
-        "//div[@role='grid']//div[contains(@class, 'row')]//div[@class='col-md-6']"
+    source = (
+        "https://www.arkleg.state.ar.us/Legislators/List?"
+        "sort=Type&by=desc&ddBienniumSession=2023%2F2023R#SearchResults"
     )
-    # contains(@class, 'measure-tab')
-    # selector = XPath("//div[@class='row tableRow']")
-    # selector = CSS("row tableRow")
-    # selector = XPath('//div[@class="row tableRow"]')
+    selector = XPath(
+        "//div[@role='grid']"
+        "//div[contains(@class, 'row')]"
+        "//div[@class='col-md-6']"
+    )
 
     def process_item(self, item):
         chamber_name = (
@@ -113,7 +119,7 @@ class LegList(HtmlListPage):
         chamber = chamber_name[0]
 
         name = chamber_name[1].replace("  ", " ")
-        if "(Resigned)" in name:
+        if "resigned" in name.lower():
             self.skip()
 
         if chamber == "Senator":


### PR DESCRIPTION
Scraper was initial failing with `SelectorError` due to some new members' photos not being updated, but AR site resolved that issue itself.

However, scraper still failed with `SelectorError` on some detail pages due to absence of `<p>` for member's district address.
- resolved, for now, with an exception for those pages

A few minor changes were made elsewhere, a couple to achieve PEP8 line length, and the other to make a conditional check of a string's contents [more inclusive of case variations](https://github.com/openstates/openstates-scrapers/pull/4345/files#diff-5dd67280e0d5c1364f841b983d2f2865cc4d55fe4e52020ef4fed0c78fe70cfdL116-R122).