### PR TITLE
CO people: reduce min_items for member list selector

### DIFF
--- a/scrapers_next/co/people.py
+++ b/scrapers_next/co/people.py
@@ -51,7 +51,7 @@ class LegDetail(HtmlPage):
 
 class LegList(HtmlListPage):
     source = "http://leg.colorado.gov/legislators"
-    selector = CSS("tbody tr", min_items=101)
+    selector = CSS("tbody tr", min_items=100)
 
     def process_item(self, item):
         title = CSS("td").match(item)[0].text_content().strip()


### PR DESCRIPTION
Scraper was failing because CSS selector for `LegList` had its `min_items` attribute set one number too high.

This commit reduces `min_items` from 101 to 100 (as there are 100 total members of CO legislature, with 35 Senators and 65 Representatives).