### PR TITLE
OR people: fixes 'email' validation and one bad member url

### DIFF
--- a/scrapers_next/or/people.py
+++ b/scrapers_next/or/people.py
@@ -104,10 +104,13 @@ class LegList(JsonPage):
             if title not in ["Senator", "Representative"]:
                 p.extras["title"] = title
 
-            email = leg["EmailAddress"].strip()
-            p.email = email
+            email = leg["EmailAddress"]
+            p.email = email.strip() if email else ""
 
             website = leg["WebSiteUrl"]
+            # Fixes bad url in the JSON data for Sen. Elizabeth Steiner
+            website = website.replace("steinerhayward", "steiner")
+
             p.add_link(website, note="homepage")
             p.add_source(website)
 


### PR DESCRIPTION
Scraper was failing with `AttributeError` when attempting to strip whitespace from member emails that were stored as `None` in the source JSON data.
- Solution: `p.email = email.strip() if email else ""`

Additionally, one request of member detail page was resulting in 404 error.
- Cause: bad url from JSON data
- Solution: replaced with correct string