### PR TITLE
SC: add docx version to Filed bills

### DIFF
--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -406,6 +406,12 @@ class SCBillScraper(Scraper):
                 on_duplicate="ignore",
                 media_type="text/html",  # Still a MIME type
             )
+            bill.add_version_link(
+                note="Filed",
+                url=version_url.replace(".htm", ".docx"),
+                on_duplicate="ignore",
+                media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
 
         # actions
         for row in bill_div.xpath("table/tr"):


### PR DESCRIPTION
They added back docx versions to Filed bills but not all bill versions, so adding it as an option