### PR TITLE
CO comm: selector change to handle task force w/o members

### DIFF
--- a/scrapers_next/co/committees.py
+++ b/scrapers_next/co/committees.py
@@ -1,5 +1,6 @@
 from spatula import HtmlPage, HtmlListPage, CSS, SelectorError, URL
 from openstates.models import ScrapeCommittee
+import logging
 
 
 class CommitteeDetails(HtmlPage):
@@ -17,7 +18,9 @@ class CommitteeDetails(HtmlPage):
         else:
             chamber = "legislature"
         com = ScrapeCommittee(name=self.input, chamber=chamber)
-        members = CSS(".member ").match(self.root)
+        members = self.root.xpath(".//div[@class='member']")
+        if not members:
+            logging.warning(f"No membership data for {com.name}")
         for member in members:
             try:
                 member_name = CSS("h4 a").match_one(member).text_content()


### PR DESCRIPTION
Committee scraper was failing with `SelectorError` on `CSS(.member)`.
- This was happening for just one committee that lacked membership: the "Task Force for the Consideration of Facial Recognition Services"

This PR solves this by changing to a standard `xpath` selector, and logging a `logging.warning` when a committee does not have a `<div>` with `class='member'`.