### PR TITLE
AK comm: adjusted num_items down on CSS selector

### DIFF
--- a/scrapers_next/ak/committees.py
+++ b/scrapers_next/ak/committees.py
@@ -42,7 +42,7 @@ class CommiteeDetail(HtmlPage):
 
 class CommitteeList(HtmlListPage):
     source = URL("https://www.akleg.gov/basis/Committee/List/33")
-    selector = CSS("div.area-frame ul.list li", num_items=112)
+    selector = CSS("div.area-frame ul.list li", num_items=110)
 
     def process_item(self, item):
         comm_name = (


### PR DESCRIPTION
Committee scraper was failing with error `spatula.selectors.SelectorError: CSS(div.area-frame ul.list li) on <html> @ line 3 got 110 results, expected 112`

This PR simply adjusts `num_items` attribute of the CSS selector down to match the number of items actually appearing on the page.