### PR TITLE
MA: Bills: Better handling of changing bill ids

### DIFF
--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -71,11 +71,9 @@ class MABillScraper(Scraper):
                 single_bill_chamber = "upper"
 
             for bill_meta in self.bill_list[single_bill_chamber]:
-                if (
-                    bill_no == bill_meta["DocketNumber"]
-                    or bill_no == bill_meta["BillNumber"]
-                ):
+                if bill_no in [bill_meta["DocketNumber"], bill_meta["BillNumber"]]:
                     yield from self.scrape_bill(session, bill_meta, single_bill_chamber)
+                    self.info("Finished bill scrape, exiting.")
                     return
 
         if not chamber:

--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -70,7 +70,7 @@ class MABillScraper(Scraper):
             else:
                 single_bill_chamber = "upper"
 
-            for bill_meta in self.bill_list:
+            for bill_meta in self.bill_list[single_bill_chamber]:
                 if (
                     bill_no == bill_meta["DocketNumber"]
                     or bill_no == bill_meta["BillNumber"]


### PR DESCRIPTION
@NewAgeAirbender @johnseekins @jessemortenson  -- Flagging y'all while this is still a WIP to get your feedback.

MA has a system where they file a bill with one number "docket number", "HD123", then once it hits committee they list it under a normal bill number, unrelated to the docket number. "H345". 

Traditionally Openstates has just duped them, so the docket version stops updating after intro and we have a ton of dupes under the different bill numbers.

I've updated the scraper to do two things:

1. Now when we pull an intro-d bill, we add the docket version as a companion, using the "replaces" relationship. This is in the database but I don't think it's ever been used.
2. I updated the scraper to use the API for the bill list, instead of a big, slow paginated search. I think someone on your team evaluated the API last year and determined that it wasn't reliable for prime time, but in my tests this one endpoint seems ok, and saves us a TON of requests while also providing the docket/into mapping we need.

I have no clue if openstates-core does any replacement or matching if you import a bill with a replaces relationship, so that's an exercise left to the reader.

If you wanna test this without it taking forever:

```python
poetry run os-update ma bills session=193rd bill_no=H49 --scrape
```

Will give you one that's been introduced.

Curious on your thoughts on this approach, it would be nice to get this settled before they get too many bill numbers swapped out.