### PR TITLE
MS: continue instead of return in case of no title

### DIFF
--- a/scrapers/ms/bills.py
+++ b/scrapers/ms/bills.py
@@ -94,11 +94,8 @@ class MSBillScraper(Scraper):
 
             details_root = lxml.etree.fromstring(page)
             title = details_root.xpath("string(//SHORTTITLE)")
+            title = "[No title given by state]" if title == "" else title
             longtitle = details_root.xpath("string(//LONGTITLE)")
-
-            if title == "":
-                self.warning(f"No title yet for {bill_id}, skipping")
-                continue
 
             bill = Bill(
                 bill_id,

--- a/scrapers/ms/bills.py
+++ b/scrapers/ms/bills.py
@@ -98,7 +98,7 @@ class MSBillScraper(Scraper):
 
             if title == "":
                 self.warning(f"No title yet for {bill_id}, skipping")
-                return
+                continue
 
             bill = Bill(
                 bill_id,


### PR DESCRIPTION
We've been missing ~86 senate bills & resolutions for a few days because the scrape returned instead of continuing on if there wasn't a title. There'll probably be one posted eventually, but following the example from [TN](https://github.com/openstates/openstates-scrapers/blob/c4762c1ea89267343abb6b7c219ae19d6531d700/scrapers/tn/bills.py#L338) where we just set the title to something noticeable for us & users