### PR TITLE
MN bills: fix gets bill versions for resolutions

### DIFF
--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -61,6 +61,14 @@ SITE_IDS = {
     "2023-2024": "0932023",
 }
 
+version_re = re.compile(r".+,\s+(.+):.+Session.+\)\s+Posted on\s+(.+)")
+
+
+def format_version_url(url):
+    if "http" not in url:
+        url = "https://www.senate.mn" + url
+    return url
+
 
 class MNBillScraper(Scraper, LXMLMixin):
     # For testing purposes, this will do a lite version of things.  If
@@ -268,6 +276,7 @@ class MNBillScraper(Scraper, LXMLMixin):
         bill_type = {"F": "bill", "R": "resolution", "C": "concurrent resolution"}[
             bill_id[1].upper()
         ]
+
         bill = Bill(
             bill_id,
             legislative_session=session,
@@ -535,7 +544,74 @@ class MNBillScraper(Scraper, LXMLMixin):
 
     def extract_versions(self, bill, doc):
         # Get all versions of the bill.
-        for row in doc.xpath("//div[@id='versions']/table/tr[td]"):
+        version_rows = doc.xpath("//div[@id='versions']/table/tr[td]")
+
+        # If there is NOT a 'Version List' expander to show versions table,
+        #  this gets versions from link on page that follows the label
+        #  "Current bill text:"
+        if not version_rows:
+            current = doc.xpath("//div[contains(text(), 'Current bill text')]/a[1]")[0]
+
+            current_html_url = current.xpath("@href")[0]
+            current_response = requests.get(current_html_url)
+            current_content = lxml.html.fromstring(current_response.content)
+
+            pdf_xpath = ".//a[contains(text(), 'Authors and Status')]/../following-sibling::td/a"
+
+            current_pdf_url = current_content.xpath(pdf_xpath)[0].xpath("@href")[0]
+            current_pdf_url = format_version_url(current_pdf_url)
+
+            vers_list = [
+                x
+                for x in current_content.xpath(".//b")
+                if "Posted on" in x.getparent().text_content()
+            ]
+
+            for vers in vers_list:
+                vers_descriptor = vers.getparent().text_content().strip()
+                title_date_match = version_re.search(vers_descriptor)
+                if not title_date_match:
+                    continue
+                raw_title, raw_date = title_date_match.groups()
+                vers_title = (
+                    "Introduction" if "introduced" in raw_title.lower() else raw_title
+                )
+                vers_day = datetime.datetime.strptime(raw_date, "%B %d, %Y").date()
+
+                href = vers.getparent().xpath("@href")
+                # If parent element has href, that means it is a link
+                # to an additional version, and the below conditional block
+                # gets the html and pdf urls for that version
+                if href:
+                    vers_html_url = href[0]
+                    vers_html_url = format_version_url(vers_html_url)
+                    vers_response = requests.get(vers_html_url)
+                    vers_content = lxml.html.fromstring(vers_response.content)
+                    vers_pdf_url = vers_content.xpath(pdf_xpath)[0].xpath("@href")[0]
+                    vers_pdf_url = format_version_url(vers_pdf_url)
+
+                # If parent element does not have href, it is current version
+                else:
+                    vers_html_url = current_html_url
+                    vers_pdf_url = current_pdf_url
+
+                bill.add_version_link(
+                    vers_title,
+                    vers_html_url,
+                    date=vers_day,
+                    media_type="text/html",
+                    on_duplicate="ignore",
+                )
+                bill.add_version_link(
+                    vers_title,
+                    vers_pdf_url,
+                    date=vers_day,
+                    media_type="application/pdf",
+                    on_duplicate="ignore",
+                )
+
+        # Otherwise if there IS a 'Version List' to show versions table
+        for row in version_rows:
             html_link = row.xpath("td[1]/a")[0]
             version_title = html_link.text_content().strip().replace("  ", " ")
             version_day = row.xpath("td[3]/text()")[0].strip()
@@ -558,6 +634,7 @@ class MNBillScraper(Scraper, LXMLMixin):
                     media_type="application/pdf",
                     on_duplicate="ignore",
                 )
+
         return bill
 
     # def extract_vote_from_action(self, bill, action, chamber, action_row):


### PR DESCRIPTION
This PR fixes a gap in data ingestion, wherein versions were only being retrieved for bills and not for resolutions (normal or concurrent).

Cause
- The formatting on resolution detail pages do not have the "Version List" table we were targeting for this data.

Solution
- This PR added a backup target in the case when the versions table isn't found.
- A request is made for the html page containing the "Current Bill Text", on which is found:
   - the html text of the that version
   - a link to the pdf page for that version
   - a list of links to the html pages of any other versions that may exist
      - in the case that those version links do exist, additional requests are made of each link's href in order to retrieve the pdf page urls for each version

MN resolutions and concurrent resolutions are now getting all versions.