### PR TITLE
FL: minor fix to House scraping

### DIFF
--- a/scrapers_next/fl/people.py
+++ b/scrapers_next/fl/people.py
@@ -168,7 +168,8 @@ class Representatives(HtmlListPage):
         name = item.xpath("./a/div[@class='team-txt']/h5/text()")[0].strip()
 
         # skips empty chairs due to pending regular/special election
-        if "pending, special" in name.lower() or "pending, election" in name.lower():
+        # if "pending, special" in name.lower() or "pending, election" in name.lower():
+        if any(s in name.lower() for s in ["pending, special", "pending, election"]):
             self.skip()
 
         party = item.xpath("./a/div[@class='team-txt']/p[1]/text()")[0].split()[0]

--- a/scrapers_next/fl/people.py
+++ b/scrapers_next/fl/people.py
@@ -168,7 +168,7 @@ class Representatives(HtmlListPage):
         name = item.xpath("./a/div[@class='team-txt']/h5/text()")[0].strip()
 
         # skips empty chairs due to pending regular/special election
-        if "pending, special" or "pending, election" in name.lower():
+        if "pending, special" in name.lower() or "pending, election" in name.lower():
             self.skip()
 
         party = item.xpath("./a/div[@class='team-txt']/p[1]/text()")[0].split()[0]


### PR DESCRIPTION
Since (non-empty) strings are always resolved as "true" in Python, there was an `if` statement that was always being entered, causing a bug. Made a minor change to the `if` statement so that this does not happen. Pertains to [OS-1009](https://civic-eagle.atlassian.net/browse/OS-1009). 