### PR TITLE
MS: ignore 2022 Extraordinary Session

### DIFF
--- a/scrapers/ms/__init__.py
+++ b/scrapers/ms/__init__.py
@@ -244,6 +244,7 @@ class Mississippi(State):
         },
     ]
     ignored_scraped_sessions = [
+        "2022 Extraordinary Session",
         "2008 First Extraordinary Session",
         "2007 Regular Session",
         "2007 First Extraordinary Session",


### PR DESCRIPTION
So MS removed the 'First' from the 2022 First Extraordinary Session just on the [session list page](http://billstatus.ls.state.ms.us/sessions.htm), but the [interior pages](http://billstatus.ls.state.ms.us/20221E/pdf/mainmenu.htm) of that session still say the full '2022 First Extraordinary Session'. The links to the bill versions also all still work ([HB1](https://openstates.org/ms/bills/20221E/HB1/) for example), so opting to just add it to the ignore list rather than changing the metadata for that session. cc: @chrisyamas 