### PR TITLE
Comm add_link updates

### DIFF
--- a/scrapers_next/az/committees.py
+++ b/scrapers_next/az/committees.py
@@ -64,6 +64,13 @@ class CommitteeList(JsonListPage):
         com.extras["Committee Short Name"] = item["CommitteeShortName"]
         com.extras["Committee Type"] = item["TypeName"]
 
-        com.add_source(self.source.url)
+        com.add_source(self.source.url, "API with all committee details")
+
+        # User-friendly HTML page to access data on each committee
+        coms_link = (
+            f"https://apps.azleg.gov/BillStatus/"
+            f"CommitteeOverView?SessionID={self.session_id}"
+        )
+        com.add_link(coms_link, note="homepage")
 
         return com

--- a/scrapers_next/ca/committees.py
+++ b/scrapers_next/ca/committees.py
@@ -148,6 +148,7 @@ class SenateCommitteeList(HtmlListPage):
 
         com.add_source(self.source.url, note="Committee List Page")
         com.add_source(comm_url, note="Committee Detail Page")
+        com.add_link(comm_url, note="homepage")
 
         return CommDetails(com, source=URL(comm_url))
 
@@ -189,5 +190,6 @@ class AssemblyCommitteeList(HtmlListPage):
 
         com.add_source(self.source.url, note="Committee List Page")
         com.add_source(comm_url, note="Committee Detail Page")
+        com.add_link(comm_url, note="homepage")
 
         return CommDetails(com, source=URL(comm_url))

--- a/scrapers_next/ct/committees.py
+++ b/scrapers_next/ct/committees.py
@@ -62,6 +62,7 @@ class CommitteeMemberPage(HtmlPage):
     def process_page(self):
         com = self.input.get("com")
         com.add_source(self.source.url, note="Committee details page")
+        com.add_link(self.source.url, note="homepage")
 
         # Member names and rows are stored within a table
         row_selector = XPath("//table[@summary='Committee member list']/tbody/tr")

--- a/scrapers_next/fl/committees.py
+++ b/scrapers_next/fl/committees.py
@@ -62,7 +62,8 @@ class HouseComDetail(HtmlPage):
             name = self.clean_name(cm.text_content())
             self.input.add_member(name)
 
-        self.input.add_source(self.source.url)
+        self.input.add_source(self.source.url, note="Committee Details Page")
+        self.input.add_link(self.source.url, note="homepage")
 
         yield self.input
 
@@ -111,6 +112,7 @@ class SenComDetail(HtmlPage):
             member = self.clean_name(ul.text_content())
             comm.add_member(member)
 
-        comm.add_source(self.source.url)
+        comm.add_source(self.source.url, note="Committee Details Page")
+        comm.add_link(self.source.url, note="homepage")
 
         return comm

--- a/scrapers_next/in/committees.py
+++ b/scrapers_next/in/committees.py
@@ -85,6 +85,12 @@ class CommitteeList(HtmlListPage):
                     note="Committee List API from current beta version of Indiana gov site",
                 )
 
+                # TODO: update with better HTML link once Indiana has launched
+                #   their new legislative site. Currently, the "homepage" link
+                #   for each comm will point to list of all standing committees
+                coms_link = "https://iga.in.gov/legislative/2023/committees/"
+                com.add_link(coms_link, note="homepage")
+
                 yield CommitteeDetail(
                     com, source=URL(mem_source, timeout=30, headers=self.source.headers)
                 )

--- a/scrapers_next/ks/committees.py
+++ b/scrapers_next/ks/committees.py
@@ -111,7 +111,7 @@ class CommitteeList(HtmlListPage):
         )
         detail_link = com_link.get("href")
         com.add_source(detail_link)
-        com.add_link(detail_link, "homepage")
+        com.add_link(detail_link, note="homepage")
         return CommitteeDetail(com, source=detail_link)
 
 

--- a/scrapers_next/ky/committees.py
+++ b/scrapers_next/ky/committees.py
@@ -63,6 +63,7 @@ class CommitteeDetail(HtmlPage):
         parent_committee = self.input.get("parent")
         com = get_committee_info(title, parent_committee)
         com.add_source(self.source.url, note="committee details page")
+        com.add_link(self.source.url, note="homepage")
 
         # Make the scraper more fragile by doing an extra check to
         # make sure expected chamber and detected chamber are the same

--- a/scrapers_next/ma/committees.py
+++ b/scrapers_next/ma/committees.py
@@ -19,6 +19,7 @@ class CommitteeDetail(HtmlPage):
             self.source.url,
             note="Committee Details Page",
         )
+        com.add_link(self.source.url, note="homepage")
         try:
             member_blocks = XPath('//*[contains(@class, "committeeMemberList")]').match(
                 self.root

--- a/scrapers_next/me/committees.py
+++ b/scrapers_next/me/committees.py
@@ -61,9 +61,12 @@ class SenateCommitteeList(HtmlPage):
                         classification="committee",  # No senate subcommittees as of 2023-01-25
                     )
                 )
-                committees[-1].add_source(
-                    self.source.url, note="Senate committee and member listing"
+                appended_comm = committees[-1]
+                appended_comm.add_source(
+                    self.source.url,
+                    note="Committee details page",
                 )
+                appended_comm.add_link(self.source.url, note="homepage")
             except SelectorError:
                 # This <p> only contains text and is a committee member name
                 member_title = p.text_content()
@@ -162,6 +165,8 @@ class HouseOrJointCommitteeMemberList(HtmlPage):
                         break
                 if matched_committee:
                     com = matched_committee
+                    com.add_source(self.source.url, note="Committee details page")
+                    com.add_link(self.source.url, note="homepage")
                 else:
                     raise UnexpectedCommitteeName(com.name)
 

--- a/scrapers_next/ms/committees.py
+++ b/scrapers_next/ms/committees.py
@@ -33,6 +33,7 @@ class Committees(HtmlPage):
                 comm.add_member(member, "Member")
 
             comm.add_source(self.source.url, note="Committees List Page")
+            comm.add_link(self.source.url, note="homepage")
 
             yield comm
 

--- a/scrapers_next/ne/committees.py
+++ b/scrapers_next/ne/committees.py
@@ -59,6 +59,7 @@ class StandingCommList(HtmlListPage):
         comm.add_source(self.source.url, note="Standing Committees List Page")
         comm_url = item.get("href")
         comm.add_source(comm_url, note="Committee Details Page")
+        comm.add_link(comm_url, note="homepage")
 
         return StandingCommMembership(comm, source=comm_url)
 
@@ -86,5 +87,8 @@ class SelectCommList(HtmlPage):
             for member in members:
                 name, role = get_name_role(member)
                 comm.add_member(name, role)
+
+            comm.add_source(self.source.url, note="Committees list page")
+            comm.add_link(self.source.url, note="homepage")
 
             yield comm

--- a/scrapers_next/nh/committees.py
+++ b/scrapers_next/nh/committees.py
@@ -96,9 +96,10 @@ class SenateCommittee(HtmlListPage):
         com = ScrapeCommittee(
             name=name, classification="committee", chamber=self.chamber
         )
+        com.add_source(self.source.url, note="Committees list page")
         detail_link = com_link.get("href")
-        com.add_source(detail_link)
-        com.add_link(detail_link, "homepage")
+        com.add_source(detail_link, note="Committee details page")
+        com.add_link(detail_link, note="homepage")
         return SenateCommitteeDetail(com, source=URL(detail_link, timeout=30))
 
 
@@ -113,9 +114,10 @@ class HouseCommittee(HtmlListPage):
         com = ScrapeCommittee(
             name=name, classification="committee", chamber=self.chamber
         )
+        com.add_source(self.source.url, note="Committees list page")
         detail_link = com_link.get("href")
-        com.add_source(detail_link)
-        com.add_link(detail_link, "homepage")
+        com.add_source(detail_link, note="Committee details page")
+        com.add_link(detail_link, note="homepage")
         return HouseCommitteeDetail(com, source=URL(detail_link, timeout=30))
 
 

--- a/scrapers_next/oh/committees.py
+++ b/scrapers_next/oh/committees.py
@@ -30,7 +30,8 @@ class JointCommittee(HtmlPage):
             classification="committee",
         )
 
-        com.add_source(self.source.url, note="Committee member listing page")
+        com.add_source(self.source.url, note="Committee details page")
+        com.add_link(self.source.url, note="homepage")
 
         for (name, role) in self.get_members():
             com.add_member(name=remove_title_prefix(name), role=role)
@@ -345,7 +346,8 @@ class SenateCommitteeDetail(HtmlPage):
             chamber="upper",
             classification="committee",  # No subcommittes as of 2023-01-27
         )
-        com.add_source(self.source.url, note="Committee member listing page")
+        com.add_source(self.source.url, note="Committee details page")
+        com.add_link(self.source.url, note="homepage")
         build_house_or_senate_membership(com, self.root)
         return com
 
@@ -360,7 +362,8 @@ class HouseCommitteeDetail(HtmlPage):
             chamber="lower",
             classification="committee",  # No subcommittes as of 2023-01-27
         )
-        com.add_source(self.source.url, note="Committee member listing page")
+        com.add_source(self.source.url, note="Committee details page")
+        com.add_link(self.source.url, note="homepage")
         build_house_or_senate_membership(com, self.root)
         return com
 

--- a/scrapers_next/vt/committees.py
+++ b/scrapers_next/vt/committees.py
@@ -7,8 +7,9 @@ from openstates.models import ScrapeCommittee
 
 
 class CommitteeList(JsonListPage):
+    session_year = "2024"
     source = URL(
-        "https://legislature.vermont.gov/committee/loadList/2024/",
+        f"https://legislature.vermont.gov/committee/loadList/{session_year}/",
         timeout=10,
     )
 
@@ -91,4 +92,14 @@ class CommitteeList(JsonListPage):
                 self.source.url,
                 note="Committee JSON from legislature.vermont.gov site",
             )
+
+            # TODO: determine more consistent way to add each committee's HTML
+            #   page link, given not present for many committees in JSON data.
+            #   Below link is to HTML committee list page (not ideal).
+            coms_link = (
+                f"https://legislature.vermont.gov/committee/list/"
+                f"{self.session_year}/"
+            )
+            com.add_link(coms_link, note="homepage")
+
             yield com

--- a/scrapers_next/wi/committees.py
+++ b/scrapers_next/wi/committees.py
@@ -40,8 +40,8 @@ class CommitteeList(HtmlListPage):
             chamber=self.chamber,
         )
         detail_link = item.get("href")
-        com.add_source(detail_link)
-        com.add_link(detail_link, "homepage")
+        com.add_source(detail_link, note="Committee details page")
+        com.add_link(detail_link, note="homepage")
         return CommitteeDetails(com, source=detail_link)
 
 


### PR DESCRIPTION
This updates the committees scrapers of the following jurisdictions to ensure they all utilize required `add_link()` method for each committee scraped, with the method including a `note="homepage"` argument. *Note: ME also had its committee scraper file renamed due to a typo --> `committies.py` became `committees.py`.*

Jurisdictions updated:
- MA
- FL
- AZ
- CA
- CT
- IN
- KS
- KY
- ME
- MS
- NE
- NH
- OH
- VT
- WI