### PR TITLE
MT: other_names fix

### DIFF
--- a/scrapers_next/mt/committees.py
+++ b/scrapers_next/mt/committees.py
@@ -100,8 +100,8 @@ class HouseSenateJointCommList(HtmlListPage):
         if "Appropriations" in com.name:
             if chamber == "legislature" and classification == "committee":
                 house_and_senate_names = [
-                    "House Appropriations",
-                    "Senate Finance and Claims",
+                    {"name": "House Appropriations"},
+                    {"name": "Senate Finance and Claims"},
                 ]
                 com.other_names.append(house_and_senate_names)
 


### PR DESCRIPTION
Need to set other names as a listed dictionary of `OtherName` based on the model [here](https://github.com/openstates/openstates-core/blob/f086a88b9e5cf861e9d4d674da30bce22bc99f7a/openstates/models/common.py#L108) FYI @chrisyamas 