### PR TITLE
IA comm: detail page link add for lower, upper

### DIFF
--- a/scrapers_next/ia/committees.py
+++ b/scrapers_next/ia/committees.py
@@ -106,6 +106,8 @@ class CommitteeDetails(HtmlPage):
         )
         com.add_source(self.source.url)
         com.add_source("https://www.legis.iowa.gov/committees", "Committee list page")
+        com.add_link(self.source.url, note="homepage")
+
         # Get list of members contained in nested grid_12
         # Translation hack in case they switch to all-caps
         try:


### PR DESCRIPTION
Committees in upper and lower chamber were missing the `add_link()` method, and this showed up during imports. This PR updates accordingly.