### PR TITLE
TN: empty action description check

### DIFF
--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -19,6 +19,10 @@ def actions_from_table(bill, actions_table):
     for ar in action_rows[1:]:
         tds = ar.xpath("td")
         action_taken = tds[0].text
+        # sometimes there's an empty action ex:
+        # https://wapp.capitol.tn.gov/apps/BillInfo/Default.aspx?BillNumber=HB0243&GA=113
+        if action_taken == "":
+            return
         strptime = datetime.datetime.strptime
         action_date = strptime(tds[1].text.strip(), "%m/%d/%Y").date()
         action_types, attrs = categorize_action(action_taken)


### PR DESCRIPTION
Scrapers failing cuz of a lack of action text on [HB 243](https://wapp.capitol.tn.gov/apps/BillInfo/Default.aspx?BillNumber=HB0243&GA=113) so just adds a check