### PR TITLE
WA: fixing inaccurate action classification Rule

### DIFF
--- a/scrapers/wa/actions.py
+++ b/scrapers/wa/actions.py
@@ -80,7 +80,7 @@ _categorizer_rules = (
         "",
     ),
     Rule(
-        r"(?i)(?P<committees>\w+) \- [Mm]ajority; do pass .* \(Majority Report\)",
+        r"^(?!HOUS)(?i)(?P<committees>\w+) \- [Mm]ajority; do pass .* \(Majority Report\)",
         "passage",
     ),
     Rule(r"(?i)Conference committee appointed.", ""),

--- a/scrapers/wa/actions.py
+++ b/scrapers/wa/actions.py
@@ -80,8 +80,8 @@ _categorizer_rules = (
         "",
     ),
     Rule(
-        r"^(?!HOUS)(?i)(?P<committees>\w+) \- [Mm]ajority; do pass .* \(Majority Report\)",
-        "passage",
+        r"(?i)(?P<committees>\w+) \- [Mm]ajority; do pass .* \(Majority Report\)",
+        "committee-passage-favorable",
     ),
     Rule(r"(?i)Conference committee appointed.", ""),
     Rule(r"(?i)Conference committee report;", ""),


### PR DESCRIPTION
Fixing classification for a rule from "passage" to "committee passage favorable". Relates to [DATA-2444](https://civic-eagle.atlassian.net/browse/DATA-2444). 