### PR TITLE
IA: updating people scraper to grab capitol addresses and phone numbers

### DIFF
--- a/scrapers_next/ia/people.py
+++ b/scrapers_next/ia/people.py
@@ -79,16 +79,20 @@ class LegDetail(HtmlPage):
                         "service began",
                         "home address",
                         "other phone",
-                        "business address",
                         "cell phone",
                     }
 
                     if field_name == "legislative email":
                         p.email = field_text.lower()
-                    elif field_name == "capitol phone":
+                    elif (
+                        field_name == "capitol phone"
+                        or field_name == "capitol office phone"
+                    ):
                         p.capitol_office.voice = field_text
                     elif field_name == "office phone":
                         p.district_office.voice = field_text
+                    elif field_name == "business address":
+                        p.capitol_office.address = field_text
                     elif field_name in extra_fields:
                         p.extras[field_name] = field_text
                     else:


### PR DESCRIPTION
Capitol office addresses are listed as "business address"es on legislators' pages. We were scraping this as an extra_field and I changed it to map back to capitol office address. Also accounted for inconsistencies in the way "capitol phone number" is written on legislators' pages. ~~Why won't they standardize~~

Relates to [OS-1123](https://civic-eagle.atlassian.net/browse/OS-1123)