### PR TITLE
Bugfix for ND events

### DIFF
--- a/scrapers/nd/events.py
+++ b/scrapers/nd/events.py
@@ -2,7 +2,6 @@ import re
 import pytz
 import logging
 import dateutil.parser
-import datetime
 import requests
 import lxml.html
 from spatula import HtmlPage
@@ -32,6 +31,7 @@ class EventConsolidator(object):
             local_date = dateutil.parser.parse(date_time)
 
             item_date, item_time = str(local_date).split()
+            agenda_time = item["agenda_time"]
             bill_name = item["bill_name"]
             item_id = f"{item_time}+{bill_name}"
 
@@ -54,6 +54,7 @@ class EventConsolidator(object):
             agenda_item_details = {
                 "description": item["description"],
                 "bill_name": item["bill_name"],
+                "agenda_time": agenda_time,
                 "sub_com": item["sub_com"],
             }
             self.events[event_key][item_id] = []
@@ -88,10 +89,8 @@ class EventConsolidator(object):
                 agenda = self.events[event][item_key]
                 for item in agenda:
                     print(item)
-                    time = datetime.datetime.strptime(
-                        item_key.split("+")[0], "%H:%M:%S"
-                    ).strftime("%I:%M %p")
-                    descr_with_time = f"[{time}]: {item['description']}"
+                    agenda_time = item["agenda_time"]
+                    descr_with_time = f"[{agenda_time}]: {item['description']}"
                     item_descr = event_obj.add_agenda_item(descr_with_time)
                     if item["bill_name"]:
                         item_descr.add_bill(item["bill_name"])
@@ -167,6 +166,7 @@ class EventsTable(HtmlPage):
             agenda_item = {
                 "bill_name": bill_name,
                 "date_time": date_time,
+                "agenda_time": agenda_time,
                 "committee": com,
                 "sub_com": sub_com,
                 "location": loc,

--- a/scrapers/nd/events.py
+++ b/scrapers/nd/events.py
@@ -57,8 +57,7 @@ class EventConsolidator(object):
                 "agenda_time": agenda_time,
                 "sub_com": item["sub_com"],
             }
-            self.events[event_key][item_id] = []
-            self.events[event_key][item_id].append(agenda_item_details)
+            self.events[event_key][item_id] = agenda_item_details
 
         yield from self.create_events()
 
@@ -86,16 +85,14 @@ class EventConsolidator(object):
             event_obj.dedupe_key = event_name
 
             for item_key in self.events[event]["item_keys"]:
-                agenda = self.events[event][item_key]
-                for item in agenda:
-                    print(item)
-                    agenda_time = item["agenda_time"]
-                    descr_with_time = f"[{agenda_time}]: {item['description']}"
-                    item_descr = event_obj.add_agenda_item(descr_with_time)
-                    if item["bill_name"]:
-                        item_descr.add_bill(item["bill_name"])
-                    if item["sub_com"]:
-                        item_descr["extras"]["sub_committee"] = item["sub_com"]
+                item = self.events[event][item_key]
+                agenda_time = item["agenda_time"]
+                descr_with_time = f"[{agenda_time}]: {item['description']}"
+                item_descr = event_obj.add_agenda_item(descr_with_time)
+                if item["bill_name"]:
+                    item_descr.add_bill(item["bill_name"])
+                if item["sub_com"]:
+                    item_descr["extras"]["sub_committee"] = item["sub_com"]
 
             event_obj.add_source(self.url)
 

--- a/scrapers/nd/events.py
+++ b/scrapers/nd/events.py
@@ -32,6 +32,8 @@ class EventConsolidator(object):
             local_date = dateutil.parser.parse(date_time)
 
             item_date, item_time = str(local_date).split()
+            bill_name = item["bill_name"]
+            item_id = f"{item_time}+{bill_name}"
 
             committee = item["committee"]
             location = item["location"]
@@ -47,15 +49,15 @@ class EventConsolidator(object):
                 if time_is_earlier(item_time, current_start):
                     self.events[event_key]["event_start_time"] = item_time
 
-            self.events[event_key]["item_keys"].add(item_time)
+            self.events[event_key]["item_keys"].add(item_id)
 
             agenda_item_details = {
                 "description": item["description"],
                 "bill_name": item["bill_name"],
                 "sub_com": item["sub_com"],
             }
-            self.events[event_key][item_time] = []
-            self.events[event_key][item_time].append(agenda_item_details)
+            self.events[event_key][item_id] = []
+            self.events[event_key][item_id].append(agenda_item_details)
 
         yield from self.create_events()
 
@@ -85,9 +87,10 @@ class EventConsolidator(object):
             for item_key in self.events[event]["item_keys"]:
                 agenda = self.events[event][item_key]
                 for item in agenda:
-                    time = datetime.datetime.strptime(item_key, "%H:%M:%S").strftime(
-                        "%I:%M %p"
-                    )
+                    print(item)
+                    time = datetime.datetime.strptime(
+                        item_key.split("+")[0], "%H:%M:%S"
+                    ).strftime("%I:%M %p")
                     descr_with_time = f"[{time}]: {item['description']}"
                     item_descr = event_obj.add_agenda_item(descr_with_time)
                     if item["bill_name"]:


### PR DESCRIPTION
Only one bill was being added per event. This was caused by using the event time as the item_key for each bill. Bills were stored in a set so duplicate keys caused previous bills to be deleted.

I fixed this by adding the bill name to the key.

I also updated bill description to use the agenda time instead of the meeting start time since I was changing that area of the code. If this isn't correct I can change it back.