### PR TITLE
GA events: increase acceptable variance of bill ids

### DIFF
--- a/scrapers/ga/events.py
+++ b/scrapers/ga/events.py
@@ -71,7 +71,6 @@ class GAEventScraper(Scraper):
                 # Scrape bill ids from agenda pdf
                 for bill_id in Agenda(source=URL(row["agendaUri"])).do_scrape():
                     event.add_bill(bill_id)
-                    print(bill_id)
 
             if row["livestreamUrl"] is not None:
                 event.add_media_link(

--- a/scrapers/ga/events.py
+++ b/scrapers/ga/events.py
@@ -71,6 +71,7 @@ class GAEventScraper(Scraper):
                 # Scrape bill ids from agenda pdf
                 for bill_id in Agenda(source=URL(row["agendaUri"])).do_scrape():
                     event.add_bill(bill_id)
+                    print(bill_id)
 
             if row["livestreamUrl"] is not None:
                 event.add_media_link(
@@ -86,10 +87,21 @@ class GAEventScraper(Scraper):
 
 
 class Agenda(PdfPage):
+    non_formatted_re = re.compile(r"(H|S).+(B|R).+\s+(\d+)")
+
     def process_page(self):
         matches = re.findall(
-            r"((SB|HB|SR|HR)\s\d+)",
+            r"((SB|HB|SR|HR|House Bill|Senate Bill|House Resolution"
+            r"|Senate Resolution|H\.B\.|S\.B\.|H\.R\.|S\.R\.)\s+\d+)",
             self.text,
         )
         for m, _ in matches:
-            yield m
+            yield self.format_match(m)
+
+    def format_match(self, match):
+        needs_formatting = self.non_formatted_re.search(match)
+        if not needs_formatting:
+            return match
+        else:
+            chamber, bill_type, num = needs_formatting.groups()
+            return f"{chamber}{bill_type} {num}"


### PR DESCRIPTION
The event scraper bug fix in this most recent prior PR did not allow for additional variance in formatting of bill references on committee agendas. The below code block includes such variance into the regex:
```
matches = re.findall(
            r"((SB|HB|SR|HR|House Bill|Senate Bill|House Resolution"
            r"|Senate Resolution|H\.B\.|S\.B\.|H\.R\.|S\.R\.)\s+\d+)",
            self.text,
        )
```

Additional formatting method `format_match()` was added to `Agenda()` class to ensure bill_id is yielding in format that will allow for bill association.