### PR TITLE
VA: people scraper update

### DIFF
--- a/scrapers_next/va/people.py
+++ b/scrapers_next/va/people.py
@@ -110,29 +110,31 @@ class MemberDetail(HtmlPage):
         return p
 
     def get_offices(self, person):
-        for ul in self.root.xpath('//ul[@class="linkNon" and normalize-space()]'):
-            address = []
-            phone = None
-            email = None
-            for li in ul.getchildren():
-                text = li.text_content()
-                if re.match(r"\(\d{3}\)", text):
-                    phone = text.strip()
-                elif text.startswith("email:"):
-                    email = text.strip("email: ").strip()
-                else:
-                    address.append(text.strip())
+        for i in range(1, 3):
+            for ul in self.root.xpath(f"/html/body/div/div[2]/div[2]/div[{i}]/ul"):
+                address = []
+                phone = None
+                email = None
+                for li in ul.getchildren():
+                    text = li.text_content()
+                    if re.match(r"\(\d{3}\)", text):
+                        phone = text.strip()
+                    elif text.startswith("email:"):
+                        email = text.strip("email: ").strip()
+                    else:
+                        address.append(text.strip())
 
-                if "Capitol Square" in address:
-                    office_obj = person.capitol_office
-                else:
-                    office_obj = person.district_office
+                    if i == 1:
+                        office_obj = person.capitol_office
 
-            office_obj.address = "; ".join(address)
-            if phone:
-                office_obj.voice = phone
-            if email:
-                person.email = email
+                    else:
+                        office_obj = person.district_office
+
+                office_obj.address = "; ".join(address)
+                if phone:
+                    office_obj.voice = phone
+                if email:
+                    person.email = email
 
 
 class SenateDetail(MemberDetail):

--- a/scrapers_next/va/people.py
+++ b/scrapers_next/va/people.py
@@ -110,6 +110,7 @@ class MemberDetail(HtmlPage):
         return p
 
     def get_offices(self, person):
+        # div[1] and div[2] is where contacted info is located
         for i in range(1, 3):
             for ul in self.root.xpath(f"/html/body/div/div[2]/div[2]/div[{i}]/ul"):
                 address = []
@@ -124,6 +125,7 @@ class MemberDetail(HtmlPage):
                     else:
                         address.append(text.strip())
 
+                    # the first contact block is capital
                     if i == 1:
                         office_obj = person.capitol_office
 
@@ -132,7 +134,12 @@ class MemberDetail(HtmlPage):
 
                 office_obj.address = "; ".join(address)
                 if phone:
-                    office_obj.voice = phone
+                    # making sure we don't add the same phone number for district and capitol offices
+                    if i != 1:
+                        office_obj.voice = phone
+                    else:
+                        if phone == person.capitol_office.voice:
+                            office_obj.voice = ""
                 if email:
                     person.email = email
 


### PR DESCRIPTION
People scraper updates to scrape address and contact info more thoroughly. Relates to [DATA-2348](https://civic-eagle.atlassian.net/browse/DATA-2348).

New additions to scraper:
- scraping both blocks of contact information (capital and district)
- better identification for which information belongs to capital and which to district
- sanity check to make sure we aren't adding the same phone number to both capital and district offices 