### PR TITLE
NJ: update 2022-2023 end date

### DIFF
--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -68,7 +68,7 @@ class NewJersey(State):
             "identifier": "220",
             "name": "2022-2023 Regular Session",
             "start_date": "2022-01-11",
-            "end_date": "2022-12-31",
+            "end_date": "2023-12-31",
             "active": True,
         },
     ]


### PR DESCRIPTION
Bumping up the end date so it's a little more accurate cc: @chrisyamas