### PR TITLE
MA: check abstract for empty value

### DIFF
--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -167,8 +167,8 @@ class MABillScraper(Scraper):
 
         bill_summary = None
         if page.xpath('//p[@id="pinslip"]/text()'):
-            bill_summary = page.xpath('//p[@id="pinslip"]/text()')[0]
-        if bill_summary:
+            bill_summary = page.xpath('//p[@id="pinslip"]/text()')[0].strip()
+        if bill_summary and bill_summary != "":
             bill.add_abstract(bill_summary, "summary")
 
         if bill_meta["BillNumber"] and bill_meta["DocketNumber"]:


### PR DESCRIPTION
[HD 4162](https://malegislature.gov/Bills/193/HD4162) was causing [issues on import](https://bobsled.openstates.org/run/bc2dadecf20342eca0951d9711b19d6e#bottom) since the Abstract was an empty string, so adds a check for that.