### PR TITLE
NY: add check for extra non-vote text

### DIFF
--- a/scrapers/ny/bills.py
+++ b/scrapers/ny/bills.py
@@ -442,11 +442,12 @@ class NYBillScraper(Scraper):
 
                 for vote_pair in votes:
                     name, vote_val = vote_pair
-                    vote.vote(vote_dictionary[vote_val], name)
-                    if vote_val == "AB":
-                        absent_count += 1
-                    elif vote_val == "ER":
-                        excused_count += 1
+                    if "participated via videoconferencing" not in name:
+                        vote.vote(vote_dictionary[vote_val], name)
+                        if vote_val == "AB":
+                            absent_count += 1
+                        elif vote_val == "ER":
+                            excused_count += 1
 
                 vote.set_count("absent", absent_count)
                 vote.set_count("excused", excused_count)


### PR DESCRIPTION
[This vote](https://nyassembly.gov/leg/?default_fld=&leg_video=&bn=S00823&term=2023&Floor%26nbspVotes=Y) was causing issues on the scraper since there's text at the bottom that was getting flagged as a vote. The members' votes are recorded as usual, but they wanted to note who was voting but not physically present.
![Screenshot 2023-03-15 at 5 30 43 PM](https://user-images.githubusercontent.com/34139325/225457996-fe6447f4-8186-44c2-850e-a102c06a54bf.png)
