### PR TITLE
IA: fix chamber assignments & H/SSB classification

### DIFF
--- a/scrapers/ia/bills.py
+++ b/scrapers/ia/bills.py
@@ -20,7 +20,6 @@ class IABillScraper(Scraper):
         # yield from self.scrape_prefiles(session)
 
         session_id = self.get_session_id(session)
-        """
         url = f"https://www.legis.iowa.gov/legislation/findLegislation/allbills?ga={session_id}"
         page = lxml.html.fromstring(req_session.get(url).text)
 
@@ -35,7 +34,7 @@ class IABillScraper(Scraper):
             yield self.scrape_bill(
                 chamber, session, session_id, bill_id, bill_url, title, sponsors
             )
-        """
+
         # scrapes dropdown options on 'Bill Book' page
         #  to get bill types not found on 'All Bills' page
         bill_book_url = (


### PR DESCRIPTION
Chamber was not getting set correctly for Study bills so this fixes it. Also adds the bill type as proposed bill to Study bills since they get renumbered & reintroduced as HF or SF bills.