### PR TITLE
NC events: bill id reformatting

### DIFF
--- a/scrapers/nc/events.py
+++ b/scrapers/nc/events.py
@@ -3,15 +3,28 @@ from dateutil.parser import ParserError
 import datetime
 import pytz
 import re
+import requests
+import lxml.html
 from openstates.scrape import Scraper, Event
 from utils import LXMLMixin
 from utils.events import match_coordinates
 from openstates.exceptions import EmptyScrape
 
 
+class UnknownBillIdFormatError(BaseException):
+    def __init__(self, raw_bill_id):
+        super().__init__(f"Unexpected format: '{raw_bill_id}'")
+
+
+class UnknownBillIdPrefixError(BaseException):
+    def __init__(self, prefix):
+        super().__init__(f"Unexpected prefix: '{prefix}'")
+
+
 class NCEventScraper(Scraper, LXMLMixin):
     verify = False
     _tz = pytz.timezone("US/Eastern")
+    bill_id_re = re.compile(r"([A-Z]\w+\s)*([A-Z]\w+\s)([A-Z]\w+\s)(\d+)")
 
     def scrape(self):
         url = "https://www.ncleg.gov/LegislativeCalendar/"
@@ -106,9 +119,21 @@ class NCEventScraper(Scraper, LXMLMixin):
                         agenda = event.add_agenda_item(agenda_text)
 
                         for bill_row in agenda_row.xpath(
-                            './/a[contains(@href,"BillLookUp")]/text()'
+                            './/a[contains(@href,"BillLookUp")]'
                         ):
-                            agenda.add_bill(bill_row.split(":")[0])
+                            # Make request to BillLookUp page to scrape proper
+                            #  bill_id, because event list page only lists
+                            #  bills/resolutions in format 'S123' or 'H456',
+                            #  but proper prefixes are one of the following:
+                            #  {'SJR', 'HB', 'HR', 'SB', 'HJR', 'SR'}
+                            bill_url = bill_row.get("href")
+                            bill_resp = requests.get(bill_url)
+                            bill_page = lxml.html.fromstring(bill_resp.content)
+                            raw_bill_id = bill_page.xpath(
+                                ".//div[@class='col-12 col-sm-6 h2 text-center order-sm-2']/text()"
+                            )[0]
+                            bill_id = self.clean_bill_id(raw_bill_id)
+                            agenda.add_bill(bill_id)
 
                 if row.xpath(".//a[@title='Stream meeting']"):
                     media_url = row.xpath(".//a[@title='Stream meeting']/@href")[0]
@@ -131,3 +156,16 @@ class NCEventScraper(Scraper, LXMLMixin):
 
     def clean_name(self, name):
         return re.sub(r"[\-\-\s*]+(UPDATED|CANCELLED)", "", name).strip()
+
+    def clean_bill_id(self, raw_bill_id):
+        expected_prefixes = {"SJR", "HB", "HR", "SB", "HJR", "SR"}
+        bill_id_match = self.bill_id_re.search(raw_bill_id)
+        if bill_id_match:
+            bill_id_full_list = [x for x in bill_id_match.groups() if x]
+            prefix = "".join(x[0] for x in bill_id_full_list[:-1])
+            if prefix not in expected_prefixes:
+                raise UnknownBillIdPrefixError(prefix)
+            bill_id = f"{prefix} {bill_id_full_list[-1]}"
+            return bill_id
+        else:
+            raise UnknownBillIdFormatError(raw_bill_id)


### PR DESCRIPTION
Bills were not being added to an event's agenda with a proper bill id. This PR fixes the formatting, and provides custom errors to encounter unexpected values / changes to page in future scrapes.

**Further detail**
- Proper bill ids for NC have prefixes included in this set: `{'SJR', 'HB', 'HR', 'SB', 'HJR', 'SR'}`
- Example in tested output:
   - bills that were being added to event agenda as 'H250', 'S54', 'H175', and 'S100' are now being added with proper prefix and formatting to be, respectively, 'HB 250', 'SJR 54', 'HJR 175', and 'SB 100'