### PR TITLE
NJ events: skip full chamber events

### DIFF
--- a/scrapers/nj/events.py
+++ b/scrapers/nj/events.py
@@ -89,6 +89,10 @@ class NJEventScraper(Scraper, MDBMixin):
 
             description = "Meeting of the {}".format(hr_name)
 
+            # Skips full-chamber events, helps limit scope to committee events
+            if "on the Whole" in description:
+                continue
+
             location = (
                 record["Location"]
                 or "New Jersey Statehouse, 125 W State St, Trenton, NJ 08608"


### PR DESCRIPTION
PR adds conditional statement to skip full-chamber events (Meeting of the Senate or House "on the Whole") to help limit the scope of the scraper only to committee events on the calendar.