### PR TITLE
AL: check for sponsor existing

### DIFF
--- a/scrapers/al/bills.py
+++ b/scrapers/al/bills.py
@@ -67,9 +67,13 @@ class ALBillScraper(Scraper):
                     chamber=chamber,
                     classification=self.bill_types[row["InstrumentType"]],
                 )
+                sponsor = row["InstrumentSponsor"]
+                if sponsor == "":
+                    self.warning("No sponsors")
+                    continue
 
                 bill.add_sponsorship(
-                    name=row["InstrumentSponsor"],
+                    name=sponsor,
                     entity_type="person",
                     classification="primary",
                     primary=True,


### PR DESCRIPTION
There's one bill (HB142) that's added as a duplicate but without most of the important information (including sponsor), so adding a check to sponsorship & returning if it doesn't exist.