### PR TITLE
NV bills: shortener for too long bill title

### DIFF
--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -265,6 +265,7 @@ class BillTabDetail(HtmlPage):
                 )
                 return
 
+        # Only known case where bill title is over 300 characters
         if self.input.identifier == "SJR7-2021" and self.input.session == "82":
             short_title = shorten_bill_title(short_title)
 

--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -9,7 +9,6 @@ from openstates.scrape import Scraper, Bill
 from .common import session_slugs
 from spatula import HtmlListPage, HtmlPage, CSS, XPath, SelectorError
 
-
 TZ = pytz.timezone("PST8PDT")
 ACTION_CLASSIFIERS = (
     ("Approved by the Governor", "executive-signature"),
@@ -66,10 +65,24 @@ def extract_bdr(title):
     the number is in the title but it's useful as a structured extra
     """
     bdr = False
-    bdr_regex = re.search(r"\(BDR (\w+\-\w+)\)", title)
+    bdr_regex = re.search(r"\(BDR (\w+-\w+)\)", title)
     if bdr_regex:
         bdr = bdr_regex.group(1)
     return bdr
+
+
+def shorten_bill_title(title):
+    """
+    Used in cases where the bill title exceeds the
+    300-character limit that we have on this attribute.
+    """
+    title_bdr_re = re.compile(r"(.+)(\(BDR \w+-\w+\))")
+    title_bdr_match = title_bdr_re.search(title)
+    bdr_full = ""
+    if title_bdr_match:
+        title, bdr_full = title_bdr_match.groups()
+    title = f"{title[:280]}... + {bdr_full}"
+    return title
 
 
 @dataclass

--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -85,6 +85,15 @@ def shorten_bill_title(title):
     return title
 
 
+class BillTitleLengthError(BaseException):
+    def __init__(self, bill_id, title):
+        super().__init__(
+            f"Title of {bill_id} exceeds 30 characters:"
+            f"\n title -> '{title}'"
+            f"\n character length -> {len(title)}"
+        )
+
+
 @dataclass
 class BillStub:
     source_url: str
@@ -268,6 +277,9 @@ class BillTabDetail(HtmlPage):
         # Only known case where bill title is over 300 characters
         if self.input.identifier == "SJR7-2021" and self.input.session == "82":
             short_title = shorten_bill_title(short_title)
+        # If additional case arises in future
+        elif len(short_title) > 300:
+            raise BillTitleLengthError(self.input.identifier, short_title)
 
         bill = Bill(
             identifier=self.input.identifier,

--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -265,6 +265,9 @@ class BillTabDetail(HtmlPage):
                 )
                 return
 
+        if self.input.identifier == "SJR7-2021" and self.input.session == "82":
+            short_title = shorten_bill_title(short_title)
+
         bill = Bill(
             identifier=self.input.identifier,
             legislative_session=self.input.session,


### PR DESCRIPTION
Function created to shorten bill title in case when it's length is longer than the acceptable 300 characters.

Only known case in with SJR7-2021, where bill title from source is:
- "Proposes to amend the Nevada Constitution to remove the constitutional provisions governing the election and duties of the Board of Regents of the State University and to authorize the Legislature to provide by statute for the governance of the State University and for the auditing of public institutions of higher education in this State. (BDR C-944)"
- this solution shortens it to:
   - "Proposes to amend the Nevada Constitution to remove the constitutional provisions governing the election and duties of the Board of Regents of the State University and to authorize the Legislature to provide by statute for the governance of the State University and for the auditing... (BDR C-944)"