### PR TITLE
AL bills: prevent duplicate bills

### DIFF
--- a/scrapers/al/bills.py
+++ b/scrapers/al/bills.py
@@ -16,6 +16,7 @@ class ALBillScraper(Scraper):
     gql_url = "https://gql.api.alison.legislature.state.al.us/graphql"
     session_year = ""
     session_type = ""
+    bill_ids = set()
 
     gql_headers = {
         "Accept": "*/*",
@@ -60,8 +61,15 @@ class ALBillScraper(Scraper):
                 if title == "":
                     title = row["Subject"]
 
+                # prevent duplicates
+                bill_id = row["InstrumentNbr"]
+                if bill_id in self.bill_ids:
+                    continue
+                else:
+                    self.bill_ids.add(bill_id)
+
                 bill = Bill(
-                    identifier=row["InstrumentNbr"],
+                    identifier=bill_id,
                     legislative_session=session,
                     title=title,
                     chamber=chamber,


### PR DESCRIPTION
This PR implements a conditional check for duplicate bills, and skips cases where they are encountered. Duplicates were resulting from being listed multiple times on the [source site](https://alison.legislature.state.al.us/bill-search).

The duplicates that are being prevented:
- SB123
- SB124
- SB125
- SB126
- SB127
- HB142 (although this was already prevented by [a different check](https://github.com/openstates/openstates-scrapers/pull/4569) added by @NewAgeAirbender earlier this week)