### PR TITLE
LA: set extraordinary session to false

### DIFF
--- a/scrapers/la/__init__.py
+++ b/scrapers/la/__init__.py
@@ -238,7 +238,7 @@ class Louisiana(State):
             "name": "2023 First Extraordinary Session",
             "start_date": "2023-01-30",
             "end_date": "2023-02-05",
-            "active": True,
+            "active": False,
         },
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
Adjournment of special session was Friday, 2/3/23 according to [source site](https://legis.la.gov/legis/home.aspx).