### PR TITLE
CT events: agenda url verify set to false

### DIFF
--- a/scrapers/ct/events.py
+++ b/scrapers/ct/events.py
@@ -94,7 +94,7 @@ class CTEventScraper(Scraper):
             agenda_url = info["url"]
             if agenda_url:
                 full_url = f"https://www.cga.ct.gov{agenda_url}"
-                for bill in Agenda(source=URL(full_url)).do_scrape():
+                for bill in Agenda(source=URL(full_url, verify=False)).do_scrape():
                     event.add_bill(bill)
 
             yield event


### PR DESCRIPTION
Simple fix for error that was resulting:
`requests.exceptions.SSLError: HTTPSConnectionPool(host='www.cga.ct.gov', port=443): Max retries exceeded with url: /2023/AGEdata/ca/pdf/2023ca-00124-R001230AGE-ca.pdf (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))`

Solution adds `verify=False` argument to `URL()` object for `Agenda()` scrapes.