### PR TITLE
RI events: dedupe key add

### DIFF
--- a/scrapers/ri/events.py
+++ b/scrapers/ri/events.py
@@ -99,6 +99,7 @@ class RIEventScraper(Scraper, LXMLMixin):
 
         event.add_document("Agenda", url, media_type="text/html", on_duplicate="ignore")
         event.add_source(url)
+        event.dedupe_key = event_desc
 
         # aight. Let's get us some bills!
         bills = page.xpath("//b/a")


### PR DESCRIPTION
Adds the event `name` as `dedupe_key` to prevent `DuplicateItemError` during import.