### PR TITLE
SC: setting scrapelib_rpm to 30

### DIFF
--- a/scrapers/sc/__init__.py
+++ b/scrapers/sc/__init__.py
@@ -4,6 +4,8 @@ from openstates.scrape import State
 import requests
 import lxml.html
 
+settings = {"SCRAPELIB_RPM": 30}
+
 
 class SouthCarolina(State):
     scrapers = {


### PR DESCRIPTION
The SC events scraper has been failing with `requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))` which typically indicates that we're scraping their site too fast so it cuts us off. 

This PR replicates what has been done in other jurisdictions and adds `settings = {"SCRAPELIB_RPM": 30}` to the `__init__.py` for SC. The solution works after several local tests

Just wanted to confirm that this RPM is agreeable, as it might slow down the SC bill scrapes, given that it is in the `scrapers/sc/__init__.py` file. However, that is also where this setting is made for every other jurisdiction where `SCRAPELIB_RPM` is set.