### PR TITLE
feat(scrapers_next.la): Add miscellaneous committee scraper

### DIFF
--- a/scrapers_next/la/committees.py
+++ b/scrapers_next/la/committees.py
@@ -1,17 +1,12 @@
-from spatula import HtmlPage, HtmlListPage, XPath, URL, SkipItem
+import re
+
+import requests
+from lxml.html import Element, fromstring
 from openstates.models import ScrapeCommittee
+from spatula import URL, HtmlListPage, HtmlPage, SkipItem, XPath
 
-
-def extract_info(name_list):
-    """
-    Helper function called in `CommitteeDetail()` class,
-    extracts full name and role of each member.
-    """
-    last_name, *first_name = name_list[0].split(", ")
-    first_name = ", ".join(first_name)
-    role = name_list[1].split("|")[0]
-
-    return last_name, first_name, role
+from utils import (_identify_member_role, _manually_fix_broken_links,
+                   remove_title_reorder_name, select_chamber)
 
 
 class CommitteeList(HtmlListPage):
@@ -46,15 +41,12 @@ class CommitteeDetail(HtmlPage):
 
         members = self.root.xpath("//div[@class='card-R22']/a[@class='memlink22']")
         for member in members:
-            name_and_title = [
-                x.strip() for x in member.text_content().split("\r\n") if len(x.strip())
-            ]
-            last_name, first_name, role = extract_info(name_and_title)
-            name = first_name + " " + last_name
-            if ", " in name:
-                name_parts = name.split(", ")
-                name = ", ".join([name_parts[1], name_parts[0]])
-            com.add_member(name, role)
+            name, role, *_ = member.xpath(".//span/text()")
+            clean_name = remove_title_reorder_name(name)
+            if not clean_name.strip():
+                continue
+            role = _identify_member_role(role)
+            com.add_member(clean_name, role)
 
         com.add_source(self.source.url, note="Committee Detail Page")
         com.add_link(self.source.url, note="homepage")
@@ -62,6 +54,138 @@ class CommitteeDetail(HtmlPage):
         if not com.members:
             raise SkipItem("empty committee")
 
+        return com
+
+
+class MiscellaneousCommitteeList(HtmlListPage):
+
+    def process_page(self):
+        """Process page - find and scrape committees
+
+        This was setup to handle the regular misc committees and the
+        subcommittees of the joint budget committee
+
+        :return: committee data
+        """
+        for link in self.root.xpath(
+            "//div[@id='ctl00_ctl00_PageBody_PageContent_PanelMiscellaneous']//a"
+        ):
+            link = _manually_fix_broken_links(link)
+            self.classification = "committee"
+            self.parent = None
+            yield self.process_item(link)
+
+        # Manually download and identify subcommittees
+        response = requests.get("https://jlcb.legis.la.gov", timeout=30)
+        subcommittees = fromstring(response.content).xpath(
+            '//li/a[contains(text(),"Sub Committees")]/../ul/li/a'
+        )
+
+        # Process budget subcommittees
+        for link in subcommittees:
+            link.set("href", f"https://jlcb.legis.la.gov{link.get('href')}")
+            self.parent = "Joint Legislative Committee on the Budget"
+            self.classification = "subcommittee"
+            yield self.process_item(link)
+
+    def process_item(self, item: Element) -> HtmlPage:
+        """Process committee data
+
+        :param item: Page to process
+        :return: Committee Detail data
+        """
+        comm_name, comm_url = item.text_content(), item.get("href")
+        self.chamber = select_chamber(comm_url, comm_name)
+
+        com = ScrapeCommittee(
+            name=comm_name.strip(),
+            chamber=self.chamber,
+            classification=self.classification,
+            parent=self.parent,
+        )
+        com.add_source(self.source.url, note="Committees List Page")
+        return MiscellaneousCommitteeDetail(com, source=URL(comm_url, timeout=30))
+
+
+class MiscellaneousCommitteeDetail(HtmlPage):
+    def process_page(self) -> CommitteeDetail:
+        """Process miscellaneous committee pages
+
+        Because of the various types of pages exhibited in Louisiana
+        The simplest method across them all was to identify language found
+        inside tables and then to reverse engineer the table data and extract
+        In once case the page did not contain tables
+
+        return: committee details
+        """
+        com = self.input
+
+        tables = self.root.xpath(
+            "//table[.//*["
+            'contains(text(),"Chairman") or '
+            'contains(text(),"Vice") or '
+            'contains(text(),"Ex-O") or '
+            'contains(text(),"Senator")'
+            "]][1]"
+        )
+        divs = self.root.xpath(
+            "//div[.//*["
+            'contains(text(),"Chairman") or '
+            'contains(text(),"Vice")'
+            ']][1]'
+        )
+
+        if tables:
+            if com.name in [
+                "Joint Legislative Committee on the Budget",
+                "Litigation Sub",
+            ]:
+                tables = [tables[1], tables[3]]
+            else:
+                tables = [tables[-1]]
+
+            for table in tables:
+                rows = table.xpath(".//tr")
+                for row in rows:
+                    c = row.xpath(".//td/text()")
+                    if not c:
+                        continue
+                    opt = row.xpath(".//td")
+                    name, _ = opt[0].text_content(), opt[-1].text_content()
+                    clean_name = remove_title_reorder_name(name)
+                    if not clean_name.strip():
+                        continue
+                    role = _identify_member_role(
+                        " ".join([x.text_content() for x in opt])
+                    )
+                    com.add_member(clean_name, role)
+        elif divs:
+            if divs:
+                rows = divs[-1].xpath(".//span")
+                members = set()
+                for row in rows:
+                    members.update(row.text_content().split("\n"))
+                for member in members:
+                    row_text = re.sub(r"\s+", " ", member.strip()).strip()
+                    clean_name = remove_title_reorder_name(row_text)
+                    if not clean_name:
+                        continue
+                    role = _identify_member_role(row_text)
+                    com.add_member(clean_name, role)
+        else:
+            rows = self.root.xpath('.//div[@id="links"]/text()')
+            for row in rows:
+                row_text = re.sub("\s+", " ", row).strip()
+                if not row_text:
+                    continue
+                clean_name = remove_title_reorder_name(row_text)
+                com.add_member(clean_name, "member")
+
+        com.add_source(self.source.url, note="Committee Detail Page")
+        com.add_link(self.source.url, note="homepage")
+
+        if not com.members:
+            raise SkipItem("Empty committee")
         return com
 
 
@@ -78,11 +202,8 @@ class House(CommitteeList):
     chamber = "lower"
 
 
-# TODO - complete Miscellaneous class
-# class Miscellaneous(CommitteeList):
-#     source = URL(
-#         "https://www.legis.la.gov/legis/Committees.aspx?c=M",
-#         timeout=30,
-#     )
-#     selector = XPath("//div[@id='ctl00_ctl00_PageBody_PageContent_PanelMiscellaneous']//a")
-#     chamber = "legislature"
+class Miscellaneous(MiscellaneousCommitteeList):
+    source = URL(
+        "https://www.legis.la.gov/legis/Committees.aspx?c=M",
+        timeout=30,
+    )

--- a/scrapers_next/la/utils.py
+++ b/scrapers_next/la/utils.py
@@ -1,0 +1,91 @@
+import re
+from lxml.html import Element
+
+def extract_info(name_and_title: list[str]) -> tuple[str, str, str]:
+    """Extract and correct name
+
+    Helper function called in `CommitteeDetail()` class,
+    extracts full name and role of each member.
+
+    :param name_and_title: Name and title data
+    :return: Tuple containing Last, First and Role
+    """
+    last_name, *first_name = name_and_title[0].split(", ")
+    first_name = ", ".join(first_name)
+    role = name_and_title[1].split("|")[0]
+
+    return last_name, first_name, role
+
+
+def remove_title_reorder_name(person_name: str) -> str:
+    """Remove titles from text
+
+    :param person_name: Person text
+    """
+    name = re.sub(
+        r"Treasurer|(Chairman-)|(Lieutenant)? ?Governor|Attorney General|Secretary of State|Senate President|House Speaker|Senator|Representative|Commissioner",
+        "",
+        person_name,
+    )
+    name = re.sub(r"( - .*)|(, (Vice)? ?Chairman)", "", name)
+    name = re.sub("\(?Sen\.\)?|\(?Rep\.\)?", "", name)
+    name = re.sub("Representative|Senator", "", name)
+    name = re.sub(r", [A-Z]{3,}.*", "", name)
+    name = re.sub(r"\"\w+\"", "", name)
+    name = name.strip()
+    if re.match("\w+, \w+", name):
+        m = re.match(r"Sr\.|Jr\.|III?|IV|V", name.split()[-1])
+        if m:
+            a, b = name.split(",", 1)
+            b = b.replace(m.group(), "")
+            name = f"{b.strip()} {a.strip()}, {m.group()}"
+        else:
+            a, b = name.split(",", 1)
+            name = f"{b.strip()} {a.strip()}"
+    clean_name = name.strip()
+    return clean_name
+
+
+def select_chamber(comm_url: str, comm_name: str) -> str:
+    """Identify chamber in miscellaneous cases.
+
+    This gets us roughly where we want to be. Not all Misc committees are
+    legislative though so we need to do some cleanup here.
+
+    :param comm_url: The committee website url
+    :param comm_name: The committee name
+    :return: committee chamber type
+    """
+    if "cid=h" in comm_url.lower():
+        return "lower"
+    elif "Sen_Committees" in comm_url or "Senate" in comm_name:
+        return "upper"
+    return "legislature"
+
+
+def _identify_member_role(row_content: str) -> str:
+    """Normalize member role information
+
+    :param row_content: Row content that contains role type
+    :return: normalized role type
+    """
+    for opt in ["Ex Officio", "Co-Chairmain", "Chairman", "Vice Chair"]:
+        if opt in row_content:
+            return opt.lower()
+    if "Interim Member" in row_content:
+        return "interim"
+    elif "Ex-O" in row_content:
+        return "ex officio"
+    return "member"
+
+def _manually_fix_broken_links(link: Element) -> Element:
+    """Fix a couple broken or incorrect links
+
+    :param link: Link html element
+    :return: Link element
+    """
+    if link.get('href') == "http://www.doa.la.gov/Pages/IEB/index.aspx":
+        link.set("href", "https://www.doa.la.gov/state-employees/interim-emergency-board/board-info/board-members/")
+    elif link.get('href') == "http://jlcb.legis.la.gov/":
+        link.set("href", "https://jlcb.legis.la.gov/default_Members")
+    return link


### PR DESCRIPTION
This PR addresses issue started by @chrisyamas and elegantly created by @kdmonroe in [Issue](https://github.com/openstates/issues/issues/911) 

Adds support for miscellaneous committees in the state of Louisiana.  Uses Spatula and creates a new file for
utils.py to handle some helper methods. 

I wanted to contribute to your project, and I saw that the LA misc. committee scraper was incomplete.
I took a stab at adding to the misc. committee scraper. 
