### PR TITLE
DE: Events: Skip cert verify

### DIFF
--- a/scrapers/de/events.py
+++ b/scrapers/de/events.py
@@ -42,7 +42,7 @@ class DEEventScraper(Scraper, LXMLMixin):
 
         page_data = []
         try:
-            page_data = self.post(page_url).json()["Data"]
+            page_data = self.post(page_url, verify=False).json()["Data"]
         except json.decoder.JSONDecodeError:
             # No agenda items
             self.info(f"POST returned nothing on {page_url}")
@@ -62,7 +62,7 @@ class DEEventScraper(Scraper, LXMLMixin):
 
     def scrape(self):
         url = "https://legis.delaware.gov/json/CommitteeMeetings/GetUpcomingCommitteeMeetings"
-        resp = self.post(url)
+        resp = self.post(url, verify=False)
 
         if resp.text == "":
             raise EmptyScrape


### PR DESCRIPTION
Removes the need for the machine on our end to download the correct intermediate certificate