### PR TITLE
AL bills: strip title whitespace, validation fix

### DIFF
--- a/scrapers/al/bills.py
+++ b/scrapers/al/bills.py
@@ -55,7 +55,7 @@ class ALBillScraper(Scraper):
 
             for row in page["data"]["allInstrumentOverviews"]:
                 chamber = self.chamber_map[row["Body"]]
-                title = row["ShortTitle"]
+                title = row["ShortTitle"].strip()
 
                 # some recently filed bills have no title, but a good subject which is close
                 if title == "":


### PR DESCRIPTION
AL bills scraper was failing when validating a bill, due to one of the bills having its title value set to multiple whitespace string `"   "` in the JSON data. There is a conditional in the code for handling when titles are just an empty string (which triggers a different value assignment), but not when there is whitespace contained.

By stripping whitespace from `title` value that is initially extracted from the JSON data, the conditional can be triggered for all appropriate cases, thereby ensuring reassignment of `title` to a valid string value, such that every bill object now passes validation with this fix in place.