### PR TITLE
MT bills: increase max retry attempts + wait time

### DIFF
--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -72,6 +72,10 @@ class MTBillScraper(Scraper, LXMLMixin):
         )
 
     def scrape(self, chamber=None, session=None):
+        # adjust scrapelib settings to prevent ConnectionError
+        self.retry_attempts = 10
+        self.retry_wait_seconds = 30
+
         # set default parameters
         chambers = [chamber] if chamber else ["upper", "lower"]
 


### PR DESCRIPTION
Montana bills scraper has been failing, likely due to `ConnectionError` which could be rectified by increasing the maximum allowed setting values for the attributes of `Scraper` object corresponding to `scrapelib` settings: `retry_attempts` and `retry_wait_seconds`.

This PR increases each of those respective attribute values by a factor of (approximately) three. If scraper runs are successful after this, we can try adjusting the setting back down slightly to lower the overall runtime.