### PR TITLE
SC events: event time fix, dedupe key add

### DIFF
--- a/scrapers/sc/events.py
+++ b/scrapers/sc/events.py
@@ -80,6 +80,8 @@ class SCEventScraper(Scraper):
 
     prior_event_time_string = None
 
+    event_keys = set()
+
     def get_page_from_url(self, url):
         """
         Get page from the provided url and change to string
@@ -207,6 +209,13 @@ class SCEventScraper(Scraper):
                 else:
                     classification = "other-meeting"
 
+                event_key = f"{description}#{location}#{date_time}"
+
+                if event_key in self.event_keys:
+                    continue
+                else:
+                    self.event_keys.add(event_key)
+
                 event = Event(
                     name=description,  # Event Name
                     start_date=date_time,  # When the event will take place
@@ -214,6 +223,8 @@ class SCEventScraper(Scraper):
                     classification=classification,
                     status=status,
                 )
+
+                event.dedupe_key = event_key
 
                 if "committee" in description.lower():
                     event.add_participant(description, type="committee", note="host")

--- a/scrapers/sc/events.py
+++ b/scrapers/sc/events.py
@@ -78,6 +78,8 @@ class SCEventScraper(Scraper):
     jurisdiction = "sc"
     _tz = pytz.timezone("US/Eastern")
 
+    prior_event_time_string = None
+
     def get_page_from_url(self, url):
         """
         Get page from the provided url and change to string
@@ -153,7 +155,7 @@ class SCEventScraper(Scraper):
             else:
                 continue
 
-            # If a event is in the next calendar year, the date_string
+            # If an event is in the next calendar year, the date_string
             # will have a year in it
             if date_string.count(",") == 2:
                 event_year = date_string[-4:]
@@ -172,6 +174,15 @@ class SCEventScraper(Scraper):
                 ):
                     status = "cancelled"
 
+                # For cases when time string is listed as a reference to prior
+                #  event's start time:
+                #   i.e. "Immediately after EOC full committee"
+                if "after" in time_string:
+                    time_string = self.prior_event_time_string
+
+                # Set attribute to be used for following event, as above case
+                self.prior_event_time_string = time_string
+
                 time_string = normalize_time(time_string)
                 date_time = datetime.datetime.strptime(
                     f"{event_year} {date_string} {time_string}",
@@ -179,6 +190,7 @@ class SCEventScraper(Scraper):
                 )
 
                 date_time = self._tz.localize(date_time)
+
                 try:
                     meeting_info = meeting.xpath("br[1]/preceding-sibling::node()")[1]
                     location, description = re.search(


### PR DESCRIPTION
This PR addresses two issues: one with event times, the other with duplication.

Event times
------------
South Carolina events scraper was failing on a `ValueError` when a string like `"Immediately after EOC Full Committee"` was being passed to `datetime.strptime()` method instead of a time string like `"1:00 pm"`.

This would occur in cases when the time for an event is determined by the start or end time of a prior event. This solution stores a reference to the immediately-prior-event's start time, and has the aforementioned dependent cases simply default to the prior event's start time (as that is the best estimate that can be provided, and we do not want to provide a time that could be later than the dependent event's actual start time).

Duplication
-----------
Dedupe key added to event, with an `event_keys` set to prevent actual duplicates.