### PR TITLE
MT bills: (temporary) disable ~all~ vote processing

### DIFF
--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -121,21 +121,26 @@ class MTBillScraper(Scraper, LXMLMixin):
                 bills.append({"url": bill_url, "sponsor": sponsor})
 
         for bill_info in bills:
-            bill, votes = self.parse_bill(
-                bill_info["url"], bill_info["sponsor"], session
-            )
+            bill = self.parse_bill(bill_info["url"], bill_info["sponsor"], session)
+            # bill, votes = self.parse_bill(
+            #     bill_info["url"], bill_info["sponsor"], session
+            # )
             yield bill
-            for vote in votes:
-                if vote.dedupe_key not in self._seen_vote_ids:
-                    self._seen_vote_ids.add(vote.dedupe_key)
-                    yield vote
+            # TODO: reincorporate vote processing
+            #  (this is only being removed / commented out temporarily)
+            # for vote in votes:
+            #     if vote.dedupe_key not in self._seen_vote_ids:
+            #         self._seen_vote_ids.add(vote.dedupe_key)
+            #         yield vote
 
     def parse_bill(self, bill_url, list_sponsor, session):
         # list_sponsor passed to support proposed bills (aka "unintroduced") which have "LC XXXX" bill numbers
         bill = None
         doc = self.lxmlize(bill_url)
 
-        bill, votes = self.parse_bill_status_page(bill_url, doc, list_sponsor, session)
+        # TODO: add votes back in
+        # bill, votes = self.parse_bill_status_page(bill_url, doc, list_sponsor, session)
+        bill = self.parse_bill_status_page(bill_url, doc, list_sponsor, session)
 
         # Get versions on the detail page.
         versions = [
@@ -168,7 +173,9 @@ class MTBillScraper(Scraper, LXMLMixin):
         # Add bill url as a source.
         bill.add_source(bill_url)
 
-        return bill, votes
+        # TODO: add votes back in
+        # return bill, votes
+        return bill
 
     def scrape_new_site_versions(self, bill, url):
         page = self.lxmlize(url)
@@ -264,7 +271,8 @@ class MTBillScraper(Scraper, LXMLMixin):
         )
 
         self.add_actions(bill, page)
-        votes = self.add_votes(bill, page, url)
+        # TODO: add votes back in
+        # votes = self.add_votes(bill, page, url)
 
         tabledata = self._get_tabledata(page)
 
@@ -347,7 +355,9 @@ class MTBillScraper(Scraper, LXMLMixin):
 
         self.add_fiscal_notes(page, bill)
 
-        return bill, list(votes)
+        # TODO: add votes back in
+        # return bill, list(votes)
+        return bill
 
     def add_actions(self, bill, status_page):
         for idx, action in enumerate(


### PR DESCRIPTION
This PR comments out all calls for vote scraping and parsing in the Montana bills scraper, and refactors the scraper to run without those lines (only getting bills and actions).

*Note: Vote functionality will be added back in soon. This PR is simply meant to get MT bills scraper successfully running again for now.*