### PR TITLE
AL: event and bill vote deduplication adds

### DIFF
--- a/scrapers/al/events.py
+++ b/scrapers/al/events.py
@@ -63,6 +63,8 @@ class ALEventScraper(Scraper, LXMLMixin):
             if event_key in event_keys:
                 continue
 
+            event_keys.add(event_key)
+
             event = Event(
                 start_date=event_date,
                 name=event_title,

--- a/scrapers/al/events.py
+++ b/scrapers/al/events.py
@@ -46,6 +46,8 @@ class ALEventScraper(Scraper, LXMLMixin):
         if len(page["data"]["hearingsMeetings"]) == 0:
             raise EmptyScrape
 
+        event_keys = set()
+
         for row in page["data"]["hearingsMeetings"]:
             event_date = self._TZ.localize(dateutil.parser.parse(row["SortTime"]))
             event_title = row["EventTitle"]
@@ -56,6 +58,11 @@ class ALEventScraper(Scraper, LXMLMixin):
                 )
             event_desc = row["EventDesc"]
 
+            event_key = f"{event_title}#{event_location}#{event_date}"
+
+            if event_key in event_keys:
+                continue
+
             event = Event(
                 start_date=event_date,
                 name=event_title,
@@ -63,8 +70,7 @@ class ALEventScraper(Scraper, LXMLMixin):
                 description=event_desc,
             )
 
-            event_name = f"{event_title}#{event_location}#{event_date}"
-            event.dedupe_key = event_name
+            event.dedupe_key = event_key
 
             # TODO: When they add committees, agendas, and video streams
 


### PR DESCRIPTION
The PR modifies both Alabama's events and bills scrapers for duplication/deduplication adds:
- Events: completes [earlier implemented](https://github.com/openstates/openstates-scrapers/commit/ff201fd13994c745dfdee41e4fe1d4418dd2b526#diff-606b539e25ba4c7bd78bde8129df17b5a3e6f94076ebced16333f4a6547aa5e1R66-R67) deduplication by adding a `set()` for unique event keys, along with a conditional check, to prevent actual duplicates.
- Bills (specifically votes): adds `VoteEvent` dedupe key with `set()` for duplicate checks and prevention.