### PR TITLE
Fix image scrape for Rep. Charlie Conrad in OR

### DIFF
--- a/scrapers_next/or/people.py
+++ b/scrapers_next/or/people.py
@@ -16,6 +16,8 @@ class LegDetail(HtmlPage):
             img = "https://www.oregonlegislature.gov/wagner/PublishingImages/member_photo.jpg"
         elif p.name == "Kathleen Taylor":
             img = "https://www.oregonlegislature.gov/taylor/PublishingImages/member_photo.jpg"
+        elif p.name == "Charlie Conrad":
+            img = "https://www.oregonlegislature.gov/conrad/PublishingImages/Pages/news/Rep%20Conrad%202023_Small2.jpg"
         else:
             img = CSS("h1 img").match_one(self.root).get("src")
         p.image = img


### PR DESCRIPTION
Representative Charlie Conrad's [page](https://www.oregonlegislature.gov/conrad) does not have the representative's image in the selector specified in the scraper. 

This commit manually specifies his image.