### PR TITLE
AR bills: fix yield statements in refactoring

### DIFF
--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -15,11 +15,6 @@ TIMEZONE = pytz.timezone("US/Central")
 
 
 class ARBillScraper(Scraper):
-    """
-    The challenge here is that I need to comment out all
-
-    """
-
     ftp_user = ""
     ftp_pass = ""
     bills = {}

--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -93,7 +93,7 @@ class ARBillScraper(Scraper):
                     primary=True,
                 )
 
-            # need year before if its a fiscal or special session beyond first
+            # need year before if it's a fiscal or special session beyond first
             year = session[0:4]
             if len(session) > 4 and session[-1] != "1":
                 year = int(year) - 1
@@ -326,6 +326,8 @@ class ARBillScraper(Scraper):
                 media_type="application/pdf",
             )
 
+        yield bill
+
         # TODO: reincorporate below code block for vote processing
         #  (commented out due to scraper having vote event processing issue)
         # for link in page.xpath(
@@ -426,7 +428,7 @@ class ARBillScraper(Scraper):
     def get_utf_16_ftp_content(self, url):
         # hacky code alert:
         # inserting the credentials inline plays nice with urllib.urlretrieve
-        # when other methods dont
+        # when other methods do not
         url = url.replace("ftp://", f"ftp://{self.ftp_user}:{self.ftp_pass}@")
         local_file, headers = urllib.request.urlretrieve(url)
         raw = open(local_file, "rb")

--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -15,14 +15,19 @@ TIMEZONE = pytz.timezone("US/Central")
 
 
 class ARBillScraper(Scraper):
+    """
+    The challenge here is that I need to comment out all
+
+    """
+
     ftp_user = ""
     ftp_pass = ""
     bills = {}
 
     def scrape(self, chamber=None, session=None):
 
-        self.ftp_user = os.environ.get("AR_FTP_USER", None)
-        self.ftp_pass = os.environ.get("AR_FTP_PASSWORD", None)
+        self.ftp_user = os.environ.get("AR_FTP_USER", "arklegview")
+        self.ftp_pass = os.environ.get("AR_FTP_PASSWORD", "V1ew0nly!")
 
         if not self.ftp_user or not self.ftp_pass:
             self.error("AR_FTP_USER and AR_FTP_PASSWORD env variables are required.")
@@ -38,10 +43,13 @@ class ARBillScraper(Scraper):
         leg_chambers = [chamber] if chamber else ["upper", "lower"]
 
         for leg_chamber in leg_chambers:
-            yield from self.scrape_bill(leg_chamber, session)
+            self.scrape_bill(leg_chamber, session)
+
         self.scrape_actions()
+
         if not self.bills:
             raise EmptyScrape
+
         for bill_id, bill in self.bills.items():
             yield bill
 
@@ -107,7 +115,7 @@ class ARBillScraper(Scraper):
                 version_url = f"https://www.arkleg.state.ar.us/assembly/{year}/{self.slug}/Bills/{bill_url}.pdf"
             bill.add_version_link(bill_id, version_url, media_type="application/pdf")
 
-            yield from self.scrape_bill_page(bill)
+            self.scrape_bill_page(bill)
 
             self.bills[bill_id] = bill
 
@@ -325,8 +333,6 @@ class ARBillScraper(Scraper):
                 date=date,
                 media_type="application/pdf",
             )
-
-        yield bill
 
         # TODO: reincorporate below code block for vote processing
         #  (commented out due to scraper having vote event processing issue)

--- a/scrapers/ar/bills.py
+++ b/scrapers/ar/bills.py
@@ -26,8 +26,8 @@ class ARBillScraper(Scraper):
 
     def scrape(self, chamber=None, session=None):
 
-        self.ftp_user = os.environ.get("AR_FTP_USER", "arklegview")
-        self.ftp_pass = os.environ.get("AR_FTP_PASSWORD", "V1ew0nly!")
+        self.ftp_user = os.environ.get("AR_FTP_USER", None)
+        self.ftp_pass = os.environ.get("AR_FTP_PASSWORD", None)
 
         if not self.ftp_user or not self.ftp_pass:
             self.error("AR_FTP_USER and AR_FTP_PASSWORD env variables are required.")


### PR DESCRIPTION
Adds `yield bill` command that was missing from `scrape_bill_page()` method, and necessary for scraper to run successfully.