### PR TITLE
CA: break up subjects

### DIFF
--- a/scrapers/ca/bills.py
+++ b/scrapers/ca/bills.py
@@ -392,7 +392,16 @@ class CABillScraper(Scraper, LXMLMixin):
                     tags.append("tax levy")
 
                 if version.subject:
-                    subject = clean_title(version.subject)
+                    cleaned_subjects = clean_title(version.subject)
+                    # one has a super long subject, trims last few characters so still makes sense
+                    if bill_id.strip() == "SB867" and session == "20232024":
+                        subject = cleaned_subjects[0:250]
+                    # another has a colon at the end instead of a period & verify flags an empty string list item later
+                    elif bill_id.strip() == "SB889" and session == "20232024":
+                        subject = cleaned_subjects[0:-1].split(":")
+                    # break up subject to actually be a list of them instead of one long string
+                    else:
+                        subject = cleaned_subjects.replace(".", "").split(":")
 
             if not title:
                 self.warning("Couldn't find title for %s, skipping" % bill_id)
@@ -402,7 +411,7 @@ class CABillScraper(Scraper, LXMLMixin):
             if summary:
                 fsbill.add_abstract(summary, note="summary")
             fsbill.classification = type_
-            fsbill.subject = [subject] if subject else []
+            fsbill.subject = subject if subject else []
             fsbill.extras["impact_clause"] = impact_clause
             fsbill.extras["tags"] = tags
 


### PR DESCRIPTION
Subjects are listed separated by colons on the source, so this breaks them up in a way that makes that clear. There are 2 special cases, one has a super long one so gets trimmed a bit and the other has a colon at the end instead of a period so fixes for those cases.