### PR TITLE
SC bills: updates for summary and abstract selection

### DIFF
--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -352,16 +352,24 @@ class SCBillScraper(Scraper):
             raise ValueError("unknown bill type: %s" % bill_type)
 
         # this is fragile, but less fragile than it was
-        b = bill_div.xpath('./b[text()="Summary:"]')[0]
-        bill_summary = b.getnext().tail.strip()
+        # b = bill_div.xpath('./b[text()="Summary:"]')[0]
+        # bill_summary = b.getnext().tail.strip()
+
+        # Short "Summary" will be the bill title,
+        #  while the longer summary will be added as an abstract
+        summ_and_abst = [x.strip() for x in bill_div.xpath("./text()")]
+        summary, abstract = [x for x in summ_and_abst if len(x)][-2:]
 
         bill = Bill(
             bill_id,
             legislative_session=session,  # session name metadata's `legislative_sessions`
             chamber=chamber,  # 'upper' or 'lower'
-            title=bill_summary,
+            title=summary,
             classification=bill_type,
         )
+
+        # This stores the more lengthy 'summary' description as an abstract
+        bill.add_abstract(note="description", abstract=abstract)
 
         subjects = list(self._subjects[bill_id])
 

--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -351,11 +351,7 @@ class SCBillScraper(Scraper):
         else:
             raise ValueError("unknown bill type: %s" % bill_type)
 
-        # this is fragile, but less fragile than it was
-        # b = bill_div.xpath('./b[text()="Summary:"]')[0]
-        # bill_summary = b.getnext().tail.strip()
-
-        # Short "Summary" will be the bill title,
+        # Short "Summary" will be added as the bill title,
         #  while the longer summary will be added as an abstract
         summ_and_abst = [x.strip() for x in bill_div.xpath("./text()")]
         summary, abstract = [x for x in summ_and_abst if len(x)][-2:]


### PR DESCRIPTION
The PR updates the South Carolina bill scraper to get the shorter version of the Summary for the bill title, and adds the longer version (which was previously being stored as the bill title) as an abstract.

This was undertaken to prevent overly-long bill titles.