### PR TITLE
MO: update to more reliable session list src

### DIFF
--- a/scrapers/mo/__init__.py
+++ b/scrapers/mo/__init__.py
@@ -140,8 +140,8 @@ class Missouri(State):
     def get_session_list(self):
         http.client.parse_headers = parse_headers_override
         return url_xpath(
-            "https://www.house.mo.gov/billcentral.aspx?year=2019&code=S1&q=&id=",
-            '//select[@id="SearchSession"]/option/text()',
+            "https://www.house.mo.gov/Session.aspx",
+            '//*[@id="sessions"]/option/text()',
         )
 
 


### PR DESCRIPTION
This PR updates the URL and xpath used to get the list of sessions from the Missouri legislature. This was done because there were frequent failures with the prior URL used.