### PR TITLE
Scrapers Utils: url_xpath exception add

### DIFF
--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -9,7 +9,7 @@ def url_xpath(url, path, verify=True, user_agent=None):
     try:
         doc = lxml.html.fromstring(res.text)
     except Exception as e:
-        logging.warning(
+        logging.error(
             f"Failed to retrieve xpath from {url} :: returned:\n"
             f"CONTENT: {res.content} \n"
             f"RETURN CODE: {res.status_code}"

--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -8,7 +8,11 @@ def url_xpath(url, path, verify=True, user_agent=None):
     try:
         doc = lxml.html.fromstring(res.text)
     except Exception as e:
-        print(f"Failed to retrieve xpath from {url} :: {res.content} returned")
+        print(
+            f"Failed to retrieve xpath from {url} :: returned:\n"
+            f"CONTENT: {res.content} \n"
+            f"RETURN CODE: {res.status_code}"
+        )
         raise Exception(e)
     return doc.xpath(path)
 

--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -4,7 +4,12 @@ import lxml.html
 
 def url_xpath(url, path, verify=True, user_agent=None):
     headers = {"user-agent": user_agent} if user_agent else None
-    doc = lxml.html.fromstring(requests.get(url, verify=verify, headers=headers).text)
+    res = requests.get(url, verify=verify, headers=headers)
+    try:
+        doc = lxml.html.fromstring(res.text)
+    except Exception as e:
+        print(f"Failed to retrieve xpath from {url} :: {res.content} returned")
+        raise Exception(e)
     return doc.xpath(path)
 
 

--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -1,5 +1,6 @@
 import requests
 import lxml.html
+import logging
 
 
 def url_xpath(url, path, verify=True, user_agent=None):
@@ -8,7 +9,7 @@ def url_xpath(url, path, verify=True, user_agent=None):
     try:
         doc = lxml.html.fromstring(res.text)
     except Exception as e:
-        print(
+        logging.warning(
             f"Failed to retrieve xpath from {url} :: returned:\n"
             f"CONTENT: {res.content} \n"
             f"RETURN CODE: {res.status_code}"


### PR DESCRIPTION
This PR adds an exception clause to the `url_xpath()` method in `scrapers/utils/lxmlize.py`. The purpose is to provide more detailed and useful logging, particularly to debug errors that occur with this method when a scraper is run virtually but do not occur when it is run locally (i.e. s in AWS but not on developer's local machine).