### PR TITLE
Scraper Utils: event key hash add

### DIFF
--- a/scrapers/utils/__init__.py
+++ b/scrapers/utils/__init__.py
@@ -2,6 +2,23 @@ import re
 
 from .lxmlize import LXMLMixin  # noqa
 from .lxmlize import url_xpath  # noqa
+import hashlib
+import uuid
+
+
+def hash_key(key_str):
+    """
+    Used to shorten identifier strings while maintaining uniqueness.
+    :param key_str: type str - identifier of variable length
+    :return: type str - unique hash of identifier
+    """
+    hash_val = hashlib.md5()
+    hash_val.update(key_str.encode("utf-8"))
+    hex_encoded_hash = hash_val.hexdigest()
+    uuid_hex = uuid.UUID(hex_encoded_hash)
+    unique_event_hash_str = str(uuid_hex)
+    return unique_event_hash_str
+
 
 _phone_pattern = re.compile(r"\(?\d{3}\)?\s?-?\d{3}-?\d{4}")
 _email_pattern = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\." r"[a-zA-Z]{2,}\b")

--- a/scrapers/utils/events.py
+++ b/scrapers/utils/events.py
@@ -1,3 +1,21 @@
+import hashlib
+import uuid
+
+
+def hash_event_key(event_key_str):
+    """
+    Used to shorten event identifier strings while maintaining uniqueness.
+    :param event_key_str: type str - event identifier of variable length
+    :return: type str - unique hash of event identifier
+    """
+    hash_val = hashlib.md5()
+    hash_val.update(event_key_str.encode("utf-8"))
+    hex_encoded_hash = hash_val.hexdigest()
+    uuid_hex = uuid.UUID(hex_encoded_hash)
+    unique_event_hash_str = str(uuid_hex)
+    return unique_event_hash_str
+
+
 # the current function to set coordinates requires a
 # valid URL and Note, which we often don't have.
 # so this will add just coordinates

--- a/scrapers/utils/events.py
+++ b/scrapers/utils/events.py
@@ -1,21 +1,3 @@
-import hashlib
-import uuid
-
-
-def hash_event_key(event_key_str):
-    """
-    Used to shorten event identifier strings while maintaining uniqueness.
-    :param event_key_str: type str - event identifier of variable length
-    :return: type str - unique hash of event identifier
-    """
-    hash_val = hashlib.md5()
-    hash_val.update(event_key_str.encode("utf-8"))
-    hex_encoded_hash = hash_val.hexdigest()
-    uuid_hex = uuid.UUID(hex_encoded_hash)
-    unique_event_hash_str = str(uuid_hex)
-    return unique_event_hash_str
-
-
 # the current function to set coordinates requires a
 # valid URL and Note, which we often don't have.
 # so this will add just coordinates


### PR DESCRIPTION
This PR creates a new utility function that can be utilized in event scrapers to create a unique hashed identifier for the event's `dedupe_key`, to help facilitate duplication prevention which also eliminates risk of a `dedupe_key` exceeding allowable length.

The modification made in this PR was undertaken based on [this code suggestion](https://github.com/openstates/openstates-scrapers/pull/4639#discussion_r1201294079) from @johnseekins.