### PR TITLE
UT: 1st special session enddate add

### DIFF
--- a/scrapers/ut/__init__.py
+++ b/scrapers/ut/__init__.py
@@ -325,9 +325,8 @@ class Utah(State):
             "classification": "special",
             "identifier": "2023S1",
             "name": "2023 1st Special Session",
-            # TODO: update end date
             "start_date": "2023-05-17",
-            "end_date": "2023-06-01",
+            "end_date": "2023-05-18",
             "active": True,
         },
     ]


### PR DESCRIPTION
This PR updates the end date of UT’s First Special Session to be 5/18/23.

The session began on 5/17/23 and [ended that same day](https://le.utah.gov/asp/schedule/journal.asp?Session=2023S1).