### PR TITLE
NV: 2023 Second Special

### DIFF
--- a/scrapers/nv/__init__.py
+++ b/scrapers/nv/__init__.py
@@ -150,6 +150,16 @@ class Nevada(State):
             "end_date": "2023-06-06",
             "active": True,
         },
+        {
+            "_scraped_name": "35th (2023) Special Session",
+            "classification": "special",
+            "identifier": "2023Special35",
+            "name": "35th (2023) Special Session",
+            "start_date": "2023-06-07",
+            # TODO: change end_date
+            "end_date": "2023-06-30",
+            "active": True,
+        },
     ]
     ignored_scraped_sessions = [
         "25th (2008) Special Session",


### PR DESCRIPTION
The [35th (2023) Special Session](https://www.leg.state.nv.us/Session/35th2023Special/) of the Nevada Legislature began on June 07, 2023, at 8:00 AM.

This PR adds it to NV's `__init__` file.