### PR TITLE
SC: temporary changes to scrape past 2 sessions

### DIFF
--- a/scrapers/sc/__init__.py
+++ b/scrapers/sc/__init__.py
@@ -52,6 +52,8 @@ class SouthCarolina(State):
             "name": "2019-2020 Regular Session",
             "start_date": "2019-01-08",
             "end_date": "2020-06-25",
+            # TODO: Remove below line after successful past-session scrapes
+            "active": True,
         },
         {
             "_scraped_name": "124 - (2021-2022)",
@@ -60,7 +62,8 @@ class SouthCarolina(State):
             "name": "2021-2022 Regular Session",
             "start_date": "2021-01-12",
             "end_date": "2022-05-12",
-            "active": False,
+            # TODO: Revert below value to False after successful past-session scrapes
+            "active": True,
         },
         {
             "_scraped_name": "125 - (2023-2024)",

--- a/scrapers/sc/__init__.py
+++ b/scrapers/sc/__init__.py
@@ -52,8 +52,6 @@ class SouthCarolina(State):
             "name": "2019-2020 Regular Session",
             "start_date": "2019-01-08",
             "end_date": "2020-06-25",
-            # TODO: Remove below line after successful past-session scrapes
-            "active": True,
         },
         {
             "_scraped_name": "124 - (2021-2022)",
@@ -62,8 +60,7 @@ class SouthCarolina(State):
             "name": "2021-2022 Regular Session",
             "start_date": "2021-01-12",
             "end_date": "2022-05-12",
-            # TODO: Revert below value to False after successful past-session scrapes
-            "active": True,
+            "active": False,
         },
         {
             "_scraped_name": "125 - (2023-2024)",

--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -105,15 +105,11 @@ class SCBillScraper(Scraper):
     urls = {
         "lower": {
             "daily-bill-index": "https://www.scstatehouse.gov/sessphp/hintros.php",
-            "2021-2022-DBI": "https://web.archive.org/web/20221110101038/https://www.scstatehouse.gov/sessphp/hintros.php",
-            "2019-2020-DBI": "https://web.archive.org/web/20201101155143/https://www.scstatehouse.gov/sessphp/hintros.php",
             "prefile-index": "https://www.scstatehouse.gov/sessphp/prefil"
             "{last_two_digits_of_session_year}.php",
         },
         "upper": {
             "daily-bill-index": "https://www.scstatehouse.gov/sessphp/sintros.php",
-            "2021-2022-DBI": "https://web.archive.org/web/20221110101352/https://www.scstatehouse.gov/sessphp/sintros.php",
-            "2019-2020-DBI": "https://web.archive.org/web/20201101152857/https://www.scstatehouse.gov/sessphp/sintros.php",
             "prefile-index": "https://www.scstatehouse.gov/sessphp/prefil"
             "{last_two_digits_of_session_year}.php",
         },

--- a/scrapers/sc/bills.py
+++ b/scrapers/sc/bills.py
@@ -113,18 +113,11 @@ def get_index_url(session, chamber, chamber_letter):
         "2019-2020-upper": "20201101152857",
         "2021-2022-lower": "20221110101038",
         "2021-2022-upper": "20221110101352",
-        # TODO: Add archive id values during transition between sessions (i.e. Dec 2024).
-        "2023-2024-lower": None,
-        "2023-2024-upper": None,
-        "2025-2026-lower": None,
-        "2025-2026-upper": None,
-        "2027-2028-lower": None,
-        "2027-2028-upper": None,
-        "2029-2030-lower": None,
-        "2029-2030-upper": None,
+        # TODO: Add archive id values for both chambers for outgoing session
+        #  during transition between sessions (Upcoming: Nov or Dec 2024).
     }
 
-    web_archive_id = web_archive_ids[f"{session}-{chamber}"]
+    web_archive_id = web_archive_ids.get(f"{session}-{chamber}", None)
 
     # Web Archive IDs should only be in collection for past sessions
     if web_archive_id:
@@ -137,7 +130,7 @@ def get_index_url(session, chamber, chamber_letter):
 
 class SCBillScraper(Scraper):
     """
-    Bill scraper that pulls down all legislatition on from sc website.
+    Bill scraper that pulls down all legislation on from SC website.
     Used to pull in information regarding Legislation, and basic associated metadata,
     using x-path to find and obtain the information
     """
@@ -146,19 +139,6 @@ class SCBillScraper(Scraper):
         super().__init__(*args, **kwargs)
         self.raise_errors = False
         self.retry_attempts = 5
-
-    urls = {
-        "lower": {
-            "daily-bill-index": "https://www.scstatehouse.gov/sessphp/hintros.php",
-            "prefile-index": "https://www.scstatehouse.gov/sessphp/prefil"
-            "{last_two_digits_of_session_year}.php",
-        },
-        "upper": {
-            "daily-bill-index": "https://www.scstatehouse.gov/sessphp/sintros.php",
-            "prefile-index": "https://www.scstatehouse.gov/sessphp/prefil"
-            "{last_two_digits_of_session_year}.php",
-        },
-    }
 
     _subjects = defaultdict(set)
 
@@ -174,7 +154,7 @@ class SCBillScraper(Scraper):
         """
         Obtain bill subjects, which will be saved onto _subjects global,
         to be added on to bill later on in process.
-        :param session_code:
+        :param session:
 
         """
         # only need to do it once


### PR DESCRIPTION
Adds functionality to scraper to ingest past session bill data.

This was undertaken to update Open States database after improvements were made to `name` and `abstract` collection for SC bills in [previous PR](https://github.com/openstates/openstates-scrapers/pull/4629).

Note: web archived pages were used to get the past session bill index pages, which allows for this past-session ingestion with minimal changes to the scraper. `TODO` comments have been included in the code as reminders to maintainers that an archive id will need to be manually added in the lead up to every new session start (i.e. every two years) to ensure full past-session-scrape functionality.