### PR TITLE
IL: temp disable votes

### DIFF
--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -505,7 +505,7 @@ class IlBillScraper(Scraper):
         sponsor_list = build_sponsor_list(doc.xpath('//a[contains(@class, "content")]'))
         # don't add just yet; we can make them better using action data
 
-        committee_actors = {}
+        # committee_actors = {}
 
         # actions
         action_tds = doc.xpath('//a[@name="actions"]/following-sibling::table[1]/td')
@@ -560,8 +560,9 @@ class IlBillScraper(Scraper):
         self.scrape_documents(bill, version_url)
         yield bill
 
-        votes_url = doc.xpath('//a[text()="Votes"]/@href')[0]
-        yield from self.scrape_votes(session, bill, votes_url, committee_actors)
+        # temporarily remove vote processing due to pdf issues
+        # votes_url = doc.xpath('//a[text()="Votes"]/@href')[0]
+        # yield from self.scrape_votes(session, bill, votes_url, committee_actors)
 
     def scrape_documents(self, bill, version_url):
         html = self.get(version_url).text


### PR DESCRIPTION
Having some issues with pdf processing of votes, the session is over so disabling for now until we can get a solution in place.