### PR TITLE
NC: Dedupe VoteEvent by Roll Call Number

### DIFF
--- a/scrapers/nc/bills.py
+++ b/scrapers/nc/bills.py
@@ -234,7 +234,6 @@ class NCBillScraper(Scraper):
             date = date.isoformat()
 
             ve = VoteEvent(
-                identifier=f"Roll Call Number: {rcs}",
                 chamber=chamber,
                 start_date=date,
                 motion_text=subject,
@@ -242,6 +241,7 @@ class NCBillScraper(Scraper):
                 bill=bill,
                 classification="passage",  # TODO: classify votes
             )
+            ve.dedupe_key = rcs
             ve.set_count("yes", int(aye))
             ve.set_count("no", int(no))
             ve.set_count("not voting", int(nv))

--- a/scrapers/nc/bills.py
+++ b/scrapers/nc/bills.py
@@ -234,6 +234,7 @@ class NCBillScraper(Scraper):
             date = date.isoformat()
 
             ve = VoteEvent(
+                identifier=f"Roll Call Number: {rcs}",
                 chamber=chamber,
                 start_date=date,
                 motion_text=subject,


### PR DESCRIPTION
Running into validation issues with some vote events, we already capture the roll call number to check the chamber voting, so just adds it as the `dedupe_key`