### PR TITLE
FL: add 2024 session with estimated dates

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -203,6 +203,16 @@ class Florida(State):
             "end_date": "2023-02-10",
             "active": False,
         },
+        {
+            "name": "2024 Regular Session",
+            "identifier": "2024",
+            "classification": "primary",
+            # TODO: Update with accurate start/end dates as below dates are
+            #  estimates based on days of week of 2022 session start/end
+            "start_date": "2024-01-09",
+            "end_date": "2024-03-11",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),


### PR DESCRIPTION
Adds 2024 session to `legislative_sessions` list in the `init` file, in response to the Florida legislature adding it to their site.

Start and end dates are estimates using 2022 as basis for prediction, with comment to update later when that information is announced.