### PR TITLE
Indiana: Unpaginate actions

### DIFF
--- a/scrapers/in/bills.py
+++ b/scrapers/in/bills.py
@@ -375,7 +375,14 @@ class INBillScraper(Scraper):
         client = ApiClient(self)
         r = client.get("bills", session=session)
         all_pages = client.unpaginate(r)
+
+        # if you need to test a single bill:
+        # all_pages = [
+        #     {"billName": "SB0001", "displayName": "SB 1", "link": "/2023/bills/sb0001/"}
+        # ]
+
         for b in all_pages:
+            # print(b)
             bill_id = b["billName"]
             disp_bill_id = b["displayName"]
 
@@ -436,11 +443,12 @@ class INBillScraper(Scraper):
                 actions = client.get(
                     "bill_actions", session=session, bill_id=bill_id.lower()
                 )
+                actions = client.unpaginate(actions)
             except scrapelib.HTTPError:
                 self.logger.warning("Could not find bill actions page")
                 actions = {"items": []}
 
-            for a in actions["items"]:
+            for a in actions:
                 action_desc = a["description"]
                 if "governor" in action_desc.lower():
                     action_chamber = "executive"

--- a/scrapers/in/bills.py
+++ b/scrapers/in/bills.py
@@ -382,7 +382,6 @@ class INBillScraper(Scraper):
         # ]
 
         for b in all_pages:
-            # print(b)
             bill_id = b["billName"]
             disp_bill_id = b["displayName"]
 


### PR DESCRIPTION
We're missing actions on indiana bills with > 50 actions, because they were maxing out and paginating.