### PR TITLE
WA: update end date, add empty to events, skip subjects

### DIFF
--- a/scrapers/wa/__init__.py
+++ b/scrapers/wa/__init__.py
@@ -68,8 +68,7 @@ class Washington(State):
             "identifier": "2023-2024",
             "name": "2023-2024 Regular Session",
             "start_date": "2023-01-09",
-            # TODO: update end date
-            "end_date": "2023-04-25",
+            "end_date": "2023-04-23",
             "active": True,
         },
     ]

--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -249,7 +249,7 @@ class WABillScraper(Scraper, LXMLMixin):
         current = int(datetime.date.today().year)
         max_year = year if current < year + 1 else year + 1
         for y in (year, max_year):
-            self.build_subject_mapping(y)
+            # self.build_subject_mapping(y)
             url = "%s/GetLegislationByYear?year=%s" % (self._base_url, y)
 
             try:

--- a/scrapers/wa/events.py
+++ b/scrapers/wa/events.py
@@ -6,6 +6,7 @@ import pytz
 import lxml
 
 from openstates.scrape import Scraper, Event
+from openstates.exceptions import EmptyScrape
 from .utils import xpath
 
 
@@ -45,6 +46,8 @@ class WAEventScraper(Scraper, LXMLMixin):
     def get_xml(self, start, end):
         if self.meetings is not None:
             return self.meetings
+        else:
+            raise EmptyScrape
 
         event_url = (
             "http://wslwebservices.leg.wa.gov/CommitteeMeetingService.asmx"


### PR DESCRIPTION
WA doesn't have the subject page anymore, temporarily disabling while we find another solution before the next session starts. Also adds `EmptyScrape` to the event scraper