### PR TITLE
add CITATION.cff, top 10 contributors to start

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: Open States Scrapers
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: James
+    family-names: Turk
+    orcid: 'https://orcid.org/0000-0003-1762-1420'
+  - given-names: Michael
+    family-names: Stephens
+  - given-names: Tim
+    family-names: Showers
+  - given-names: Thom
+    family-names: Neale
+  - given-names: Miles
+    family-names: Watkins
+  - given-names: Paul
+    family-names: Tagliamonte
+  - given-names: Rylie
+    family-names: Johnson
+  - given-names: Rachel
+    family-names: Shorey
+  - given-names: Dan
+    family-names: Schneiderman
+  - given-names: Josh
+    family-names: Carp
+repository-code: 'https://openstates.org'
+abstract: >-
+  Python web scrapers for all 50 state legislatures, DC, and
+  Puerto Rico.
+license: GPL-3.0


### PR DESCRIPTION
Recently became aware of CFF files (see:
https://github.blog/2021-08-19-enhanced-support-citations-github/) which, similar to LICENSE, adds a helpful citation-helper to the GitHub UI.  I've been told this repo has been used/cited in papers in an ad hoc way before, so this could prove useful.

This adds a very simple software citation & I started with the top 10 contributors, glad to add others if they'd like & if anyone has an orcid & contributes they should be welcome to add to this!

