### PR TITLE
FL: ignore 2023C for now

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -203,18 +203,26 @@ class Florida(State):
             "end_date": "2023-02-10",
             "active": False,
         },
+        # {
+        #     "name": "2023 Special Session C",
+        #     "identifier": "2023C",
+        #     "classification": "special",
+        #     "start_date": "2023-11-06",
+        #     "end_date": "2023-11-09",
+        #     "active": True,
+        # },
         {
             "name": "2024 Regular Session",
             "identifier": "2024",
             "classification": "primary",
-            # TODO: Update End Date
             "start_date": "2024-01-09",
-            "end_date": "2024-03-11",
+            "end_date": "2024-03-08",
             "active": True,
         },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),
+        "2023C",
         "2022 Org.",
         "2020 Org.",
         "2019 I",  # Empty, maybe informational session


### PR DESCRIPTION
Bills aren't posted yet but should be soon, session starts [Nov. 6th](https://www.flgov.com/wp-content/uploads/2023/10/Joint-Proclamation-Special-Session-C.pdf)