### PR TITLE
NH: 2024 Prefiles

### DIFF
--- a/scrapers/nh/__init__.py
+++ b/scrapers/nh/__init__.py
@@ -92,6 +92,14 @@ class NewHampshire(State):
             "name": "2023 Regular Session",
             "start_date": "2023-01-04",
             "end_date": "2023-06-30",
+            "active": False,
+        },
+        {
+            "identifier": "2024",
+            "classification": "primary",
+            "name": "2024 Regular Session",
+            "start_date": "2024-01-03",
+            "end_date": "2024-06-28",
             "active": True,
         },
     ]


### PR DESCRIPTION
Looks like the bills at the scraped pages are for 2024 now. Got through ~20 bills before they closed the connection doing a test run, but looks okay.