### PR TITLE
MO: comment out subjects temporarily

### DIFF
--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -684,7 +684,8 @@ class MOBillScraper(Scraper, LXMLMixin):
             )
 
     def scrape(self, chamber=None, session=None):
-        self._scrape_subjects(session)
+        # TODO: add back OR get subjects on detail page, depending on email back from their developers
+        # self._scrape_subjects(session)
 
         # special sessions and other year manipulation messes up the session variable
         # but we need it for correct output


### PR DESCRIPTION
We're getting 403 errors hitting the [House Bill Subject](https://house.mo.gov/LegislationSP.aspx?code=R&category=subjectindex&year=2024) page with either Bobsled or Airflow so this temporarily skips it so that we can at least get most of the bill data in for prefiles. I have a contact with the team of House Developers, so I sent an email asking if they'll have that information available on the Bill Detail XML page & will update the scraper based on his information.