### PR TITLE
PA: Events: Fix related bill names

### DIFF
--- a/scrapers/pa/events.py
+++ b/scrapers/pa/events.py
@@ -86,8 +86,9 @@ class PAEventScraper(Scraper):
                     for bill in bills:
                         parsed = urllib.parse.urlparse(bill.get("href"))
                         qs = urllib.parse.parse_qs(parsed.query)
+                        print(qs)
                         item.add_bill(
-                            "{}{} {}".format(qs["body"], qs["type"], qs["bn"])
+                            "{}{} {}".format(qs["body"][0], qs["type"][0], qs["bn"][0])
                         )
                     for committee in committees:
                         parsed = urllib.parse.urlparse(committee.get("href"))


### PR DESCRIPTION
Related bills were adding python list items instead of proper strings, this fixes the bill names.