### PR TITLE
RI: Better logging, disable subjects for now

### DIFF
--- a/scrapers/ri/bills.py
+++ b/scrapers/ri/bills.py
@@ -113,7 +113,7 @@ class RIBillScraper(Scraper):
             lines = [(n.text_content().strip(), n) for n in node]
             if "No Bills Met this Criteria" in [x[0] for x in lines]:
                 self.info("No results. Skipping block")
-                # return []
+                return []
 
             for line in lines:
                 line, node = line
@@ -158,6 +158,7 @@ class RIBillScraper(Scraper):
             default_headers["ctl00$rilinContent$cbCategory"] = subjects[subject]
             default_headers["ctl00$rilinContent$cbYear"] = session
 
+            self.info(f"Fetching bills subject mapping for {subject}")
             blocks = self.parse_results_page(
                 self.post(SEARCH_URL, data=default_headers).text
             )
@@ -220,6 +221,9 @@ class RIBillScraper(Scraper):
         for idex in idexes:
             blocks = "FOO"  # Ugh.
             while len(blocks) > 0:
+                self.info(
+                    f"Searching for bills in {chamber} in range {idex} to {idex + MAXQUERY}"
+                )
                 default_headers = get_default_headers(SEARCH_URL)
                 default_headers[FROM] = idex
                 default_headers[TO] = idex + MAXQUERY
@@ -291,7 +295,12 @@ class RIBillScraper(Scraper):
     def scrape(self, chamber=None, session=None):
         chambers = [chamber] if chamber is not None else ["upper", "lower"]
 
-        subjects = self.get_subject_bill_dict(session)
+        # NOTE: disabled by showerst 2024-01-04
+        # this is making 350 POST requests because there are almost no subjects
+        # assigned yet, but the 2023 subjects are still posted.
+        # possibly restore this later.
+        # subjects = self.get_subject_bill_dict(session)
+        subjects = {}
 
         for chamber in chambers:
             yield from self.scrape_bills(chamber, session, subjects)


### PR DESCRIPTION
This scraper is doing a POST request for every 2023 subject, despite none of them being assigned. I'm disabling subjects for now which speeds it way up.

Once there's data here, we will want to restore them. FYI @jessemortenson @NewAgeAirbender 

Also if anyone needs to train a newbie, this scraper has some gnarly old code that could benefit from a rewrite.