### PR TITLE
ME: change session 131 to end in 2024 so events match current bills

### DIFF
--- a/scrapers/me/__init__.py
+++ b/scrapers/me/__init__.py
@@ -86,7 +86,7 @@ class Maine(State):
             "identifier": "131",
             "name": "131st Legislature (2023-2024)",
             "start_date": "2022-12-07",
-            "end_date": "2023-06-12",
+            "end_date": "2024-04-17",
             "active": True,
         },
     ]


### PR DESCRIPTION
Date from https://legislature.maine.gov/

Currently, no ME event related entities (specifically related bills) are matching to actual bill entities, because the `resolve_bill()` logic [only looks for bills that are in a session with dates that bracket around the event's date](https://github.com/openstates/openstates-core/blob/db7af4d314fa5dd6b5ce3864627c38799d46db78/openstates/importers/base.py#L171). Since ME's session 131 was coded as ending in 2023, none of the bill entities are being resolved on event related entity records.