### PR TITLE
NJ: add 2024-2025 metadata

### DIFF
--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -69,6 +69,14 @@ class NewJersey(State):
             "name": "2022-2023 Regular Session",
             "start_date": "2022-01-11",
             "end_date": "2023-12-31",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2024-2025 Session",
+            "identifier": "221",
+            "name": "2024-2025 Regular Session",
+            "start_date": "2024-01-09",
+            "end_date": "2025-12-31",
             "active": True,
         },
     ]

--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -69,7 +69,7 @@ class NewJersey(State):
             "name": "2022-2023 Regular Session",
             "start_date": "2022-01-11",
             "end_date": "2023-12-31",
-            "active": False,
+            "active": True,
         },
         {
             "_scraped_name": "2024-2025 Session",
@@ -77,7 +77,7 @@ class NewJersey(State):
             "name": "2024-2025 Regular Session",
             "start_date": "2024-01-09",
             "end_date": "2025-12-31",
-            "active": True,
+            "active": False,
         },
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
Only merge when bills can be scraped successfully