### PR TITLE
LA: Bills: Fix for assumed year in action dates

### DIFF
--- a/scrapers/la/bills.py
+++ b/scrapers/la/bills.py
@@ -49,6 +49,8 @@ class LABillScraper(Scraper, LXMLMixin):
         "2024s2": "242ES",
     }
 
+    _start_year = ""
+
     def pdf_to_lxml(self, filename, type="html"):
         text = convert_pdf(filename, type)
         return lxml.html.fromstring(text)
@@ -122,6 +124,12 @@ class LABillScraper(Scraper, LXMLMixin):
             return []
 
     def scrape(self, chamber=None, session=None):
+        # LA doesn't provide the year in action dates,
+        # so assume it's the year of the active session
+        for i in self.jurisdiction.legislative_sessions:
+            if i["identifier"] == session:
+                self.start_year = i["start_date"][0:4]
+
         chambers = [chamber] if chamber else ["upper", "lower"]
         session_id = self._session_ids[session]
         # Scan bill abbreviation list if necessary.
@@ -335,10 +343,9 @@ class LABillScraper(Scraper, LXMLMixin):
 
         for action in these_actions:
             date, chamber, page, text = [x.text for x in action.xpath(".//td")]
-            session_year = self.jurisdiction.legislative_sessions[-1]["start_date"][0:4]
             # Session is April -> June. Prefiles look like they're in
             # January at earliest.
-            date += "/{}".format(session_year)
+            date += "/{}".format(self.start_year)
             date = dt.datetime.strptime(date, "%m/%d/%Y")
             chamber = self._chambers[chamber]
 


### PR DESCRIPTION
LA doesn't provide the year in action dates. The scraper was previously assuming actions happened in the year of the most recent session, but right now we're scraping 2023 while the most recent session is an upcoming 2024, so all action dates are wrong.

This fixes it.
