### PR TITLE
NY: fix events API call

### DIFF
--- a/scrapers/ny/apiclient.py
+++ b/scrapers/ny/apiclient.py
@@ -64,7 +64,7 @@ class OpenLegislationAPIClient(object):
             "committees/{session_year}/{chamber}/{committee_name}/history"
             "?limit={limit}&offset={offset}&full={full}&order={sort_order}"
         ),
-        meetings=("agendas/meetings/{start}/{end}?"),
+        meetings=("agendas/meetings/{start}/{end}?limit=1000"),
         meeting=("agendas/{year}/{agenda_id}/{committee}?"),
         members=(
             "members/{session_year}?limit={limit}&offset={offset}&full={full}"


### PR DESCRIPTION
/agendas/meetings/ now seems to require an undocumented 'limit' query parameter, or else it throws a bad input error