### PR TITLE
HI: disable SSL verify, update for some site HTML changes, add 2024

### DIFF
--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -1,4 +1,5 @@
-from utils import url_xpath
+import lxml.html
+import requests
 from openstates.scrape import State
 from .events import HIEventScraper
 from .bills import HIBillScraper
@@ -97,6 +98,14 @@ class Hawaii(State):
             "name": "2023 Regular Session",
             "start_date": "2023-01-18",
             "end_date": "2023-05-04",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2024",
+            "identifier": "2024",
+            "name": "2024 Regular Session",
+            "start_date": "2024-01-17",
+            "end_date": "2024-05-02",
             "active": True,
         },
     ]
@@ -117,9 +126,11 @@ class Hawaii(State):
     ]
 
     def get_session_list(self):
-        # doesn't include current session, we need to change it
-        sessions = url_xpath(
-            "https://www.capitol.hawaii.gov/session/archives/main.aspx",
-            "//*[@id='ctl00_MainContent_yearList']/option/text()",
-        )
+        response = requests.get(
+            "https://www.capitol.hawaii.gov/session/archives/main.aspx", verify=False
+        ).content
+        page = lxml.html.fromstring(response)
+        # page doesn't include current session, we need to add it
+        sessions = page.xpath("//*[@name='ctl00$MainContent$yearList']/option/text()")
+        sessions.append("2024")
         return sessions

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -22,7 +22,7 @@ def create_bill_report_url(chamber, year, bill_type):
 
     return (
         HI_URL_BASE
-        + "/advreports/advreport.aspx?report=deadline&rpt_type=&measuretype="
+        + "/advreports/advreport.aspx?report=deadline&active=true&rpt_type=&measuretype="
         + bill_slug[bill_type]
         + "&year="
         + year
@@ -235,7 +235,7 @@ class HIBillScraper(Scraper):
             bill.add_document_link(name, filename, media_type=media_type)
 
     def scrape_bill(self, session, chamber, bill_type, url):
-        bill_html = self.get(url).text
+        bill_html = self.get(url, verify=False).text
         bill_page = lxml.html.fromstring(bill_html)
         bill_page.make_links_absolute(url)
 
@@ -323,9 +323,7 @@ class HIBillScraper(Scraper):
         self.parse_testimony(b, bill_page)
         self.parse_cmte_reports(b, bill_page)
 
-        if bill_page.xpath(
-            "//input[@id='ctl00_ContentPlaceHolderCol1_ImageButtonPDF']"
-        ):
+        if bill_page.xpath("//input[@id='MainContent_ImageButtonPDF']"):
             self.parse_bill_header_versions(b, bill_id, session, bill_page)
 
         current_referral = meta["Current Referral"].strip()
@@ -383,7 +381,7 @@ class HIBillScraper(Scraper):
             "gm": "proclamation",
         }[billtype]
 
-        list_html = self.get(report_page_url).text
+        list_html = self.get(report_page_url, verify=False).text
         list_page = lxml.html.fromstring(list_html)
         for bill_url in list_page.xpath("//a[@class='report']"):
             bill_url = bill_url.attrib["href"].replace("www.", "")

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -22,7 +22,7 @@ def create_bill_report_url(chamber, year, bill_type):
 
     return (
         HI_URL_BASE
-        + "/advreports/advreport.aspx?report=deadline&active=true&rpt_type=&measuretype="
+        + "/advreports/advreport.aspx?report=deadline&rpt_type=&measuretype="
         + bill_slug[bill_type]
         + "&year="
         + year
@@ -245,9 +245,15 @@ class HIBillScraper(Scraper):
             "//*[@id='ctl00_MainContent_UpdatePanel2']/div/div/div"
         )
 
-        metainf_table = bill_page.xpath(
-            '//div[contains(@id, "itemPlaceholder")]//table[1]'
-        )[0]
+        try:
+            metainf_table = bill_page.xpath(
+                '//div[contains(@id, "itemPlaceholder")]//table[1]'
+            )[0]
+        except IndexError:
+            self.error("Missing Metainf table")
+            self.error(bill_html)
+            return
+
         action_table = bill_page.xpath(
             '//div[contains(@id, "UpdatePanel1")]//table[1]'
         )[0]
@@ -275,7 +281,7 @@ class HIBillScraper(Scraper):
         companion = meta["Companion"].strip()
         if companion:
             companion_url = bill_page.xpath(
-                "//span[@id='ctl00_MainContent_ListView1_ctrl0_companionLabel']/a/@href"
+                "//span[@id='MainContent_ListView1_companionLabel_0']/a/@href"
             )[0]
             # a companion's session year is the last 4 chars of the link
             # this will match the _scraped_name of a session in __init__.py

--- a/scrapers/hi/events.py
+++ b/scrapers/hi/events.py
@@ -1,25 +1,25 @@
-from utils import LXMLMixin
 import datetime as dt
 from openstates.scrape import Scraper, Event
 from openstates.exceptions import EmptyScrape
 from .utils import get_short_codes
 from requests import HTTPError
 import pytz
-
+import lxml
 
 URL = "https://capitol.hawaii.gov/upcominghearings.aspx"
 
 TIMEZONE = pytz.timezone("Pacific/Honolulu")
 
 
-class HIEventScraper(Scraper, LXMLMixin):
+class HIEventScraper(Scraper):
     seen_hearings = []
     chambers = {"lower": "House", "upper": "Senate", "joint": "Joint"}
 
     def get_related_bills(self, href):
         ret = []
         try:
-            page = self.lxmlize(href)
+            self.info(f"GET {href}")
+            page = lxml.html.fromstring(self.get(href, verify=False).content)
         except HTTPError:
             return ret
 
@@ -46,12 +46,14 @@ class HIEventScraper(Scraper, LXMLMixin):
     def scrape(self):
 
         get_short_codes(self)
-        page = self.lxmlize(URL)
+        self.info(f"GET {URL}")
+        page = self.get(URL, verify=False).content
+        page = lxml.html.fromstring(page)
 
         if page.xpath("//td[contains(string(.),'No Hearings')]"):
             raise EmptyScrape
 
-        table = page.xpath("//table[@id='ctl00_MainContent_GridView1']")[0]
+        table = page.xpath("//table[@id='MainContent_GridView1']")[0]
 
         events = set()
         for event in table.xpath(".//tr")[1:]:

--- a/scrapers/hi/events.py
+++ b/scrapers/hi/events.py
@@ -125,4 +125,10 @@ class HIEventScraper(Scraper):
                 a = event.add_agenda_item(description=bill["descr"].strip())
                 bill["bill_id"] = bill["bill_id"].split(",")[0]
                 a.add_bill(bill["bill_id"], note=bill["type"])
+
+            if tds[5].xpath(".//a"):
+                video_url = tds[5].xpath(".//a/@href")[0]
+                self.info(video_url)
+                event.add_media_link("Hearing Stream", video_url, "text/html")
+
             yield event

--- a/scrapers/hi/utils.py
+++ b/scrapers/hi/utils.py
@@ -5,7 +5,7 @@ SHORT_CODES = "%s/legislature/committees.aspx?chamber=all" % (HI_URL_BASE)
 
 
 def get_short_codes(scraper):
-    list_html = scraper.get(SHORT_CODES).text
+    list_html = scraper.get(SHORT_CODES, verify=False).text
     list_page = lxml.html.fromstring(list_html)
     rows = list_page.xpath("//*[@id='ctl00_MainContent_GridView1']//tr")
     scraper.short_ids = {"CONF": {"chamber": "joint", "name": "Conference Committee"}}


### PR DESCRIPTION
@jessemortenson @NewAgeAirbender this is a patch for HI that will work w/ any transparent proxy, to minimize code changes and requiring a specific vendor.

Using zenrows, my test command was:

```shell
HTTPS_PROXY="http://API_KEY_HERE:premium_proxy=true&proxy_country=us@proxy.zenrows.com:8001" HTTP_PROXY="http://API_KEY_HERE:premium_proxy=true&proxy_country=us@proxy.zenrows.com:8001" PYTHONPATH=scrapers poetry run os-update hi bills --scrape
```

The same also works for events.

You might also want to set  ```PYTHONWARNINGS="ignore:Unverified HTTPS request"``` to shut up the insecure request warnings.

If we decide to go this route, i'll update the documentation too.