### PR TITLE
US: drop characters on event titles

### DIFF
--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -240,7 +240,7 @@ class USEventScraper(Scraper, LXMLMixin):
         event_name = f"{title[:100]}#{address}#{start_dt}"
         event = Event(
             start_date=start_dt,
-            name=title[:1000],
+            name=title[:290],
             location_name=address,
             classification="committee-meeting",
         )


### PR DESCRIPTION
There's a title that got submitted [incorrectly](https://docs.house.gov/Committee/Calendar/ByEvent.aspx?EventID=116690) on the site, just shortens it so bobsled scrapes don't error on validation