### PR TITLE
OK: add 2024 3rd special

### DIFF
--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -165,6 +165,15 @@ class Oklahoma(State):
             "end_date": "2024-05-31",
             "active": True,
         },
+        {
+            "_scraped_name": "2024 Third Special Session",
+            "identifier": "2024S3",
+            "name": "2024 Third Special Session",
+            "start_date": "2024-01-29",
+            # TODO: update end date
+            "end_date": "2024-01-30",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "2021 Regular Session - Web",

--- a/scrapers/ok/bills.py
+++ b/scrapers/ok/bills.py
@@ -41,6 +41,7 @@ class OKBillScraper(Scraper):
         "2023S1": "231X",
         "2023S2": "232X",
         "2024": "2400",
+        "2024S3": "243X",
     }
 
     def scrape(self, chamber=None, session=None, only_bills=None):


### PR DESCRIPTION
There's a [special session on taxation](https://www.news9.com/story/65a6ed12b1b013065b2bccc3/stitt-calls-for-special-session-on-tax-cuts) called for the 29th, setting as inactive for now until bills are posted