### PR TITLE
RI: split bill title into title and abstract

### DIFF
--- a/scrapers/ri/bills.py
+++ b/scrapers/ri/bills.py
@@ -80,6 +80,7 @@ BILL_STRING_FLAGS = {
 
 BILL_TITLE_RE = re.compile("ENTITLED,\s+([^(]+)(\(.+\))?")
 
+
 class RIBillScraper(Scraper):
     # when scraping votes we only get 'S101' so we can't tie them to their parent bill
     # so we keep a dict of (chamber, number) -> bill_id from the bill scrape to be used in the

--- a/scrapers/ri/bills.py
+++ b/scrapers/ri/bills.py
@@ -78,7 +78,7 @@ BILL_STRING_FLAGS = {
     "act": r"^Act\ \d*$",
 }
 
-BILL_TITLE_RE = re.compile("ENTITLED,\s+([^(]+)(\(.+\))?")
+BILL_TITLE_RE = re.compile(r"ENTITLED,\s+([^(]+)(\(.+\))?")
 
 
 class RIBillScraper(Scraper):

--- a/scrapers/ri/bills.py
+++ b/scrapers/ri/bills.py
@@ -78,6 +78,7 @@ BILL_STRING_FLAGS = {
     "act": r"^Act\ \d*$",
 }
 
+BILL_TITLE_RE = re.compile("ENTITLED,\s+([^(]+)(\(.+\))?")
 
 class RIBillScraper(Scraper):
     # when scraping votes we only get 'S101' so we can't tie them to their parent bill
@@ -243,7 +244,12 @@ class RIBillScraper(Scraper):
                     except KeyError:
                         pass
 
-                    title = bill["title"][len("ENTITLED, ") :]
+                    title_match = BILL_TITLE_RE.match(bill["title"])
+                    title = title_match[1].strip()
+                    abstract = None
+                    if title_match[2]:
+                        abstract = title_match[2].strip("() ")
+
                     billid = bill["bill_id"]
                     try:
                         subs = subjects[bill["bill_id"]]
@@ -265,6 +271,9 @@ class RIBillScraper(Scraper):
                         classification=self.get_type_by_name(bill["bill_id"]),
                     )
                     b.subject = subs
+
+                    if abstract:
+                        b.add_abstract(abstract, "summary")
 
                     # keep bill ID around
                     self._bill_id_by_type[


### PR DESCRIPTION
Rhode Island's bill listing includes the bill title and a summary of the bill in parentheses. I believe that summary is not strictly part of the bill title, per the bill document. For example: [H 7046 PDF](https://webserver.rilegislature.gov/BillText/BillText24/HouseText24/H7046.pdf) vs the output in bill search/listing:

```
House Bill No. [7046](http://webserver.rilegislature.gov/BillText/BillText24/HouseText24/H7046.pdf)
BY  Speakman, Cortvriend, Carson, Kislak, Potter, Boylan, Ajello, Tanzi, Henries
ENTITLED, AN ACT RELATING TO EDUCATION -- STUDENT COMPUTER DEVICE PRIVACY (Prohibits an educational institution or school district from accessing or using location data for tracking a student's institutional device or personal device, except in limited circumstances.)
```

So I think this improvement is more accurate, and would give us a useful abstract for many bills. But it also will change the existing bill titles significantly, so wanted to check in before merge.