### PR TITLE
MN: temp remove senate votes

### DIFF
--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -483,14 +483,15 @@ class MNBillScraper(Scraper, LXMLMixin):
             elif len(page_links) > 0:
                 pages.append(page_links[0])
 
+            # TODO: add votes back in once not broken
             # Try to extract vote
             # senate vote only, house votes are scraped by the vote_event.py scraper
-            if current_chamber == "upper":
-                vote = self.extract_vote_from_action(
-                    bill, bill_action, current_chamber, row, pages
-                )
-                if vote:
-                    votes.append(vote)
+            # if current_chamber == "upper":
+            #     vote = self.extract_vote_from_action(
+            #         bill, bill_action, current_chamber, row, pages
+            #     )
+            #     if vote:
+            #         votes.append(vote)
 
         return bill_actions, votes
 


### PR DESCRIPTION
Scrapes have been failing with bad vote links, removing so can get the bill data online while I work on a real fix