### PR TITLE
DE: Increase Timeout

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -28,6 +28,9 @@ class DEBillScraper(Scraper, LXMLMixin):
     }
 
     def scrape(self, session=None):
+        self.retry_attempts = 10
+        self.retry_wait_seconds = 30
+        self.timeout = 130
         # Cache the legislators, we'll need them for sponsors and votes
         self.scrape_legislators(session)
 


### PR DESCRIPTION
[HB 282](https://legis.delaware.gov/BillDetail?LegislationId=140826) takes over a full minute to load so bumps up the timeout & retries on DE Bill scraper