### PR TITLE
WA: update urls & move EmptyScrape to later to catch properly

### DIFF
--- a/scrapers/wa/events.py
+++ b/scrapers/wa/events.py
@@ -12,7 +12,7 @@ from .utils import xpath
 
 class WAEventScraper(Scraper, LXMLMixin):
     _tz = pytz.timezone("US/Pacific")
-    _ns = {"wa": "http://WSLWebServices.leg.wa.gov/"}
+    _ns = {"wa": "https://WSLWebServices.leg.wa.gov/"}
 
     meetings = None
 
@@ -44,13 +44,8 @@ class WAEventScraper(Scraper, LXMLMixin):
 
     # Only need to fetch the XML once for both chambers
     def get_xml(self, start, end):
-        if self.meetings is not None:
-            return self.meetings
-        else:
-            raise EmptyScrape
-
         event_url = (
-            "http://wslwebservices.leg.wa.gov/CommitteeMeetingService.asmx"
+            "https://wslwebservices.leg.wa.gov/CommitteeMeetingService.asmx"
             "/GetCommitteeMeetings?beginDate={}&endDate={}"
         )
 
@@ -60,6 +55,10 @@ class WAEventScraper(Scraper, LXMLMixin):
         page = lxml.etree.fromstring(page)
 
         self.meetings = page
+        if self.meetings is not None:
+            return self.meetings
+        else:
+            raise EmptyScrape
         return page
 
     def scrape_chamber(self, chamber, session, start, end):
@@ -113,7 +112,7 @@ class WAEventScraper(Scraper, LXMLMixin):
 
     def scrape_agenda_items(self, agenda_id, event):
         agenda_url = (
-            "http://wslwebservices.leg.wa.gov/CommitteeMeetingService.asmx/"
+            "https://wslwebservices.leg.wa.gov/CommitteeMeetingService.asmx/"
             "GetCommitteeMeetingItems?agendaId={}".format(agenda_id)
         )
 


### PR DESCRIPTION
Missing events because Senate isn't returning any meetings so it's raising EmptyScrape too early