### PR TITLE
OH: filter out duplicate bills coming back from source API

### DIFF
--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -388,7 +388,9 @@ class OHBillScraper(Scraper):
                 bill_numbers_seen.add(bill["number"])
                 total_bills.append(bill)
             else:
-                self.logger.warning(f"Duplicate bill found in bills API response: {bill['number']}")
+                self.logger.warning(
+                    f"Duplicate bill found in bills API response: {bill['number']}"
+                )
 
         res_url = f"https://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_{session}/resolutions"
         res_data = self.get(res_url, verify=False).json()
@@ -399,7 +401,9 @@ class OHBillScraper(Scraper):
                 bill_numbers_seen.add(bill["number"])
                 total_bills.append(bill)
             else:
-                self.logger.warning(f"Duplicate bill found in resolutions API response: {bill['number']}")
+                self.logger.warning(
+                    f"Duplicate bill found in resolutions API response: {bill['number']}"
+                )
 
         return total_bills
 

--- a/scrapers/oh/bills.py
+++ b/scrapers/oh/bills.py
@@ -376,17 +376,31 @@ class OHBillScraper(Scraper):
             yield page
 
     def get_total_bills(self, session):
+        # The /resolutions endpoint has included duplicate bills in its output, so use a set to filter duplicates
+        bill_numbers_seen = set()
+        total_bills = []
         bills_url = f"https://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_{session}/bills"
         bill_data = self.get(bills_url, verify=False).json()
         if len(bill_data["items"]) == 0:
             self.logger.warning("No bills")
+        for bill in bill_data["items"]:
+            if bill["number"] not in bill_numbers_seen:
+                bill_numbers_seen.add(bill["number"])
+                total_bills.append(bill)
+            else:
+                self.logger.warning(f"Duplicate bill found in bills API response: {bill['number']}")
 
         res_url = f"https://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_{session}/resolutions"
         res_data = self.get(res_url, verify=False).json()
         if len(res_data["items"]) == 0:
             self.logger.warning("No resolutions")
+        for bill in res_data["items"]:
+            if bill["number"] not in bill_numbers_seen:
+                bill_numbers_seen.add(bill["number"])
+                total_bills.append(bill)
+            else:
+                self.logger.warning(f"Duplicate bill found in resolutions API response: {bill['number']}")
 
-        total_bills = bill_data["items"] + res_data["items"]
         return total_bills
 
     def get_other_data_source(self, first_page, base_url, source_name):


### PR DESCRIPTION
I found that the number of bills in a local scrape far exceeded the number of total bills we had in the DB, so took a closer look. The `https://search-prod.lis.state.oh.us/solarapi/v1/general_assembly_{session}/resolutions` endpoint is currently returning a significant number of duplicate resolutions, seemingly with no substantive difference. This change filters those out before doing into detailed bill processing.