### PR TITLE
USA: Cleanup Event Titles

### DIFF
--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -41,9 +41,9 @@ class USEventScraper(Scraper, LXMLMixin):
         "FHOB": "Ford House Office Building, 441 2nd Street SW, Washington, D.C. 20515",
         "CAPITOL": "US Capitol, 25 Independence Ave SE, Washington, DC 20004",
         "HVC": "US Capitol Visitor's Center, House Side, "
-               "First Street Southeast, Washington, DC 20004",
+        "First Street Southeast, Washington, DC 20004",
         "SVC": "US Capitol Visitor's Center, Senate Side, "
-               "First Street Southeast, Washington, DC 20004",
+        "First Street Southeast, Washington, DC 20004",
     }
 
     # Senate XML uses non-standard bill prefixes

--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -128,6 +128,7 @@ class USEventScraper(Scraper, LXMLMixin):
                 name=title,
                 location_name=address,
                 classification="committee-meeting",
+                description=com,
             )
             event.dedupe_key = event_name
             agenda_item = event.add_agenda_item(description=agenda)
@@ -209,7 +210,7 @@ class USEventScraper(Scraper, LXMLMixin):
 
     def house_meeting(self, xml, source_url):
 
-        title = xml.xpath("string(//meeting-details/meeting-title)")
+        meeting_title = xml.xpath("string(//meeting-details/meeting-title)")
 
         meeting_date = xml.xpath("string(//meeting-date/calendar-date)")
         start_time = xml.xpath("string(//meeting-date/start-time)")
@@ -238,13 +239,14 @@ class USEventScraper(Scraper, LXMLMixin):
                 "string(//meeting-details/meeting-location/capitol-complex/room)"
             )
             address = f"{building}, Room {room}"
-        event_name = f"{title[:100]}#{address}#{start_dt}"
-        title = re.sub(r"\s+", " ", title[:290])
+        event_name = f"{meeting_title[:100]}#{address}#{start_dt}"
+        title = re.sub(r"\s+", " ", meeting_title[:290])
         event = Event(
             start_date=start_dt,
             name=title,
             location_name=address,
             classification="committee-meeting",
+            description=meeting_title,
         )
         event.dedupe_key = event_name
         event.add_source(source_url)

--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -41,9 +41,9 @@ class USEventScraper(Scraper, LXMLMixin):
         "FHOB": "Ford House Office Building, 441 2nd Street SW, Washington, D.C. 20515",
         "CAPITOL": "US Capitol, 25 Independence Ave SE, Washington, DC 20004",
         "HVC": "US Capitol Visitor's Center, House Side, "
-        "First Street Southeast, Washington, DC 20004",
+               "First Street Southeast, Washington, DC 20004",
         "SVC": "US Capitol Visitor's Center, Senate Side, "
-        "First Street Southeast, Washington, DC 20004",
+               "First Street Southeast, Washington, DC 20004",
     }
 
     # Senate XML uses non-standard bill prefixes
@@ -122,9 +122,10 @@ class USEventScraper(Scraper, LXMLMixin):
 
             event_date = self._TZ.localize(event_date)
             event_name = f"{com[:100]}#{address}#{event_date}"
+            title = re.sub(r"\s+", " ", com[:290])
             event = Event(
                 start_date=event_date,
-                name=com[:1000],
+                name=title,
                 location_name=address,
                 classification="committee-meeting",
             )
@@ -238,9 +239,10 @@ class USEventScraper(Scraper, LXMLMixin):
             )
             address = f"{building}, Room {room}"
         event_name = f"{title[:100]}#{address}#{start_dt}"
+        title = re.sub(r"\s+", " ", title[:290])
         event = Event(
             start_date=start_dt,
-            name=title[:290],
+            name=title,
             location_name=address,
             classification="committee-meeting",
         )


### PR DESCRIPTION
I'm sick of the Atomic Block warnings on scrape, so cutting down the length of event names in both chambers & adding the full text as a description.