### PR TITLE
WA: Bills: Scrape 'Substitute Passed Legislature' versions

### DIFF
--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -331,8 +331,6 @@ class WABillScraper(Scraper, LXMLMixin):
 
         bill.add_source(fake_source)
 
-        print(self.versions[bill_id])
-
         try:
             for version in self.versions[bill_id]:
                 bill.add_version_link(


### PR DESCRIPTION
We were missing some versions due to not scraping one of the listing pages.