### PR TITLE
WY Events: Strip leading zeros from bill number

### DIFF
--- a/scrapers/wy/events.py
+++ b/scrapers/wy/events.py
@@ -3,6 +3,7 @@ from openstates.exceptions import EmptyScrape
 from dateutil import parser, relativedelta
 import datetime
 import pytz
+import re
 from utils.events import set_location_url, match_coordinates
 
 
@@ -88,7 +89,12 @@ class WYEventScraper(Scraper):
                         bills_agenda_item = event.add_agenda_item(
                             "Bills under Consideration"
                         )
-                    bills_agenda_item.add_bill(bill["billNumber"])
+                    # Separate "SF" from "0012" in "SF0012" to strip leading zeroes
+                    num_match = re.search('([A-Z]+)(\d+)',bill["billNumber"] )
+                    if (num_match):
+                        bills_agenda_item.add_bill(num_match[1] + " " + num_match[2].lstrip("0"))
+                    else:
+                        bills_agenda_item.add_bill(bill["billNumber"])
 
                 web_url = "https://www.wyoleg.gov/Calendar/{year}{month}01/Meeting?type=committee&id={meeting_id}"
                 web_url = web_url.format(

--- a/scrapers/wy/events.py
+++ b/scrapers/wy/events.py
@@ -90,9 +90,11 @@ class WYEventScraper(Scraper):
                             "Bills under Consideration"
                         )
                     # Separate "SF" from "0012" in "SF0012" to strip leading zeroes
-                    num_match = re.search('([A-Z]+)(\d+)',bill["billNumber"] )
-                    if (num_match):
-                        bills_agenda_item.add_bill(num_match[1] + " " + num_match[2].lstrip("0"))
+                    num_match = re.search(r"([A-Z]+)(\d+)", bill["billNumber"])
+                    if num_match:
+                        bills_agenda_item.add_bill(
+                            num_match[1] + " " + num_match[2].lstrip("0")
+                        )
                     else:
                         bills_agenda_item.add_bill(bill["billNumber"])
 


### PR DESCRIPTION
WY Events scraper was adding agenda items with name/identifier that looked like `SF0013`, these do not match bill numbers in this jurisdiction, which cause later pipeline steps matching events to bills to fail. The fix presented here is to separate out the numerical part of the "bill number" and strip leading zeros before adding the agenda item. 