### PR TITLE
WV: Name Check on Senate Votes

### DIFF
--- a/scrapers/wv/bills.py
+++ b/scrapers/wv/bills.py
@@ -439,21 +439,25 @@ class WVBillScraper(Scraper):
             for vote_val, name in vals:
                 vote_val = vote_val.strip()
                 name = name.strip()
-                if vote_val == "Y":
-                    # Fix for "Class Y special hunting" in
-                    # http://www.wvlegislature.gov/legisdocs/2020/RS/votes/senate/01-27-0033.pdf
-                    if "Class Y" in line:
-                        continue
+                # check that it's an uppercase name, not a sentence
+                # was catching 'A squatter cannot be considered a tenant in WV.' as an absent vote
+                # on https://www.wvlegislature.gov/legisdocs/2024/RS/votes/senate/03-05-0369.pdf
+                if name.isupper():
+                    if vote_val == "Y":
+                        # Fix for "Class Y special hunting" in
+                        # http://www.wvlegislature.gov/legisdocs/2020/RS/votes/senate/01-27-0033.pdf
+                        if "Class Y" in line:
+                            continue
 
-                    vote.yes(name)
-                    yes_count += 1
-                elif vote_val == "N":
-                    vote.no(name)
-                    no_count += 1
-                else:
-                    vote.vote("other", name)
-                    other_count += 1
-                actual_vote[vote_val] += 1
+                        vote.yes(name)
+                        yes_count += 1
+                    elif vote_val == "N":
+                        vote.no(name)
+                        no_count += 1
+                    else:
+                        vote.vote("other", name)
+                        other_count += 1
+                    actual_vote[vote_val] += 1
         vote.set_count("yes", yes_count)
         vote.set_count("no", no_count)
         vote.set_count("other", other_count)


### PR DESCRIPTION
Had a sentence catching as an absent vote since it started with "A ", checks that the `name` is uppercase before counting votes to avoid this.