### PR TITLE
HI: add dedupe_key to vote events

### DIFF
--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -132,10 +132,12 @@ class HIBillScraper(Scraper):
                 )
                 reconsiderations.discard(actor)
                 vote.add_source(url)
-                vote.set_count("yes", int(v["n_yes"] or 0))
-                vote.set_count("no", int(v["n_no"] or 0))
+                yays = v["n_yes"]
+                nays = v["n_no"]
+                vote.set_count("yes", int(yays or 0))
+                vote.set_count("no", int(nays or 0))
                 vote.set_count("not voting", int(v["n_excused"] or 0))
-                vote.dedupe_key = f"{date}#yes{int(v["n_yes"] or 0)}#no{int(v["n_no"] or 0)}"
+                vote.dedupe_key = f"{date}#yes{yays}#no{nays}"
                 for voter in split_specific_votes(v["yes"]):
                     voter = self.clean_voter_name(voter)
                     vote.yes(voter)

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -135,6 +135,7 @@ class HIBillScraper(Scraper):
                 vote.set_count("yes", int(v["n_yes"] or 0))
                 vote.set_count("no", int(v["n_no"] or 0))
                 vote.set_count("not voting", int(v["n_excused"] or 0))
+                vote.dedupe_key = f"{date}#yes{int(v["n_yes"] or 0)}#no{int(v["n_no"] or 0)}"
                 for voter in split_specific_votes(v["yes"]):
                     voter = self.clean_voter_name(voter)
                     vote.yes(voter)


### PR DESCRIPTION
Scrape is failing on validating [HB 2029](https://www.capitol.hawaii.gov/session/measure_indiv.aspx?billtype=HB&billnumber=2029&year=2024) since there are 2 actions on 3-19 that are "PASSED, WITH AMENDMENTS" but there are different yes/no vote counts, so adding a `dedupe_key` that includes those so validation/import passes