### PR TITLE
CT: add dedupe key to vote with url

### DIFF
--- a/scrapers/ct/votes.py
+++ b/scrapers/ct/votes.py
@@ -95,6 +95,7 @@ class CTVoteScraper(Scraper):
         vote.set_count("no", no_count)
         vote.set_count("absent", other_count)
         vote.add_source(url)
+        vote.dedupe_key = url
 
         for voter in voters:
             name = string.capwords(voter["name"])


### PR DESCRIPTION
Currently failing vailidation with SB 126 having 2 votes ([57](https://www.cga.ct.gov/2024/vote/s/pdf/2024SV-00057-R00SB00126-SV.PDF) & [58](https://www.cga.ct.gov/2024/vote/s/pdf/2024SV-00058-R00SB00126-SV.PDF)) on the same day a few minutes apart. Should work since the pdf links are different.