### PR TITLE
NE: skip bad bill

### DIFF
--- a/scrapers/ne/bills.py
+++ b/scrapers/ne/bills.py
@@ -12,6 +12,13 @@ TIMEZONE = pytz.timezone("US/Central")
 
 class NEBillScraper(Scraper, LXMLMixin):
     priority_bills = {}
+    bad_links = [
+        "https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50214",
+        "https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=49892",
+        "https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50764",
+        "https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50501",
+        "https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50756",
+    ]
 
     def scrape(self, session=None):
         if session is None:
@@ -98,8 +105,8 @@ class NEBillScraper(Scraper, LXMLMixin):
             # bill_link = bill_resp.url
             # bill_page = bill_resp.text
 
-            # LB 9 is causing a 500 error in 108 session, remove with new session start
-            if bill_link != 'https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50214':
+            # a few bill detail pages are causing a 500 error in 108 session, remove with new session start
+            if bill_link not in self.bad_links:
                 yield from self.bill_info(bill_link, session, main_url)
 
     def bill_info(self, bill_link, session, main_url):

--- a/scrapers/ne/bills.py
+++ b/scrapers/ne/bills.py
@@ -98,7 +98,9 @@ class NEBillScraper(Scraper, LXMLMixin):
             # bill_link = bill_resp.url
             # bill_page = bill_resp.text
 
-            yield from self.bill_info(bill_link, session, main_url)
+            # LB 9 is causing a 500 error in 108 session, remove with new session start
+            if bill_link != 'https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50214':
+                yield from self.bill_info(bill_link, session, main_url)
 
     def bill_info(self, bill_link, session, main_url):
         bill_page = self.lxmlize(bill_link)


### PR DESCRIPTION
There are some bad bills causing a 500 error right now so skipping, should remove when new session starts or they fix that page (emailed them the list of bills so hopefully they fix)