### PR TITLE
OK: Temp Remove Senate Event Scrape

### DIFF
--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -38,7 +38,7 @@ class OKEventScraper(Scraper):
     # poetry run os-update ne \
     # events --scrape start=2022-02-01 end=2022-03-02
     def scrape(self, start=None, end=None):
-        yield from self.scrape_senate()
+        # yield from self.scrape_senate()
 
         if start is None:
             delta = datetime.timedelta(days=90)


### PR DESCRIPTION
Looks like they're implementing a [new website format](https://oksenate.gov/committees/meeting-notices/joint-committee-pandemic-relief-funding-health-and-human-services-10) (& maybe internal api looking at the network requests?) for OK Senate site. Getting that new scraper scoped out but commenting it out for now so we don't miss House Events