### PR TITLE
OK: add IndexError default on Senate Events

### DIFF
--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -71,9 +71,12 @@ class OKEventScraper(Scraper):
         page.make_links_absolute(url)
 
         title = page.xpath("//span[contains(@class,'field--name-title')]/text()")[0]
-        location = page.xpath("//a[contains(@class,'events_custom_timetable')]/text()")[
-            0
-        ]
+        try:
+            location = page.xpath(
+                "//a[contains(@class,'events_custom_timetable')]/text()"
+            )[0]
+        except IndexError:
+            location = "Senate"
 
         title = f"Senate {title}"
         title = re.sub(r"(2ND|3RD|4TH)* REVISED", "", title).strip()


### PR DESCRIPTION
There are [some events](https://accessible.oksenate.gov/committees/meeting-notices/senate-legslative-session) that don't have a link to a specific location & just say "Senate" so adding that as a default for when `IndexErrors` come up on that xpath