### PR TITLE
IA: add sub_comm events

### DIFF
--- a/scrapers/ia/events.py
+++ b/scrapers/ia/events.py
@@ -44,27 +44,27 @@ class IAEventScraper(Scraper):
 
         page = lxml.html.fromstring(self.get(url).text)
         page.make_links_absolute(url)
-        for link in page.xpath(
-            "//div[contains(@class, 'meetings')]/table[1]/"
-            "tbody/tr[not(contains(@class, 'hidden'))]"
-        ):
-            comm = None
-            desc = None
-            pretty_name = None
+
+        comm_rows = page.xpath(
+            "//div[contains(@class, 'meetings')]/table[1]"
+            "/tbody/tr[not(contains(@class, 'hidden'))]"
+        )
+
+        for meeting_row in comm_rows:
             status = "tentative"
 
-            comm = link.xpath("string(./td[2]/a[1]/span/text())").strip()
+            comm = meeting_row.xpath("string(./td[2]/a[1]/span/text())").strip()
             if comm == "":
-                comm = link.xpath("string(./td[2]/a[1]/text())").strip()
+                comm = meeting_row.xpath("string(./td[2]/a[1]/text())").strip()
             desc = comm + " Committee Hearing"
 
-            location = link.xpath("string(./td[3]/span/text())").strip()
+            location = meeting_row.xpath("string(./td[3]/span/text())").strip()
             if location == "":
-                location = link.xpath("string(./td[3]/text())").strip()
+                location = meeting_row.xpath("string(./td[3]/text())").strip()
 
-            when = link.xpath("string(./td[1]/span[1]/text())").strip()
+            when = meeting_row.xpath("string(./td[1]/span[1]/text())").strip()
             if when == "":
-                when = link.xpath("string(./td[1]/text())").strip()
+                when = meeting_row.xpath("string(./td[1]/text())").strip()
 
             if "cancelled" in when.lower() or "upon" in when.lower():
                 status = "cancelled"
@@ -72,9 +72,9 @@ class IAEventScraper(Scraper):
                 continue
 
             # sometimes they say cancelled, sometimes they do a red strikethrough
-            if link.xpath("./td[1]/span[contains(@style,'line-through')]"):
+            if meeting_row.xpath("./td[1]/span[contains(@style,'line-through')]"):
                 status = "cancelled"
-            if "cancelled" in link.xpath("@class")[0]:
+            if "cancelled" in meeting_row.xpath("@class")[0]:
                 status = "cancelled"
 
             junk = ["Reception"]
@@ -105,12 +105,14 @@ class IAEventScraper(Scraper):
                 status=status,
             )
 
-            if link.xpath("td[4]/span/a"):
-                video_link = link.xpath("td[4]/span/a/@href")[0]
+            if meeting_row.xpath("td[4]/span/a"):
+                video_link = meeting_row.xpath("td[4]/span/a/@href")[0]
                 event.add_media_link("Video of Hearing", video_link, "text/html")
 
-            if status != "cancelled" and link.xpath('.//a[contains(text(),"Agenda")]'):
-                agenda_rows = link.xpath(
+            if status != "cancelled" and meeting_row.xpath(
+                './/a[contains(text(),"Agenda")]'
+            ):
+                agenda_rows = meeting_row.xpath(
                     'following-sibling::tr[1]/td/div[contains(@class,"agenda")]/p'
                 )
 
@@ -128,3 +130,113 @@ class IAEventScraper(Scraper):
             event.add_participant(comm, note="host", type="committee")
 
             yield event
+
+        # Separate handling for Subcommittee on Bills table.
+        # The lxml `table` appears to be structured differently when
+        #  accessed via xpath (no `tbody`), and each row pertains to
+        #  a particular bill's discussion.
+        sub_comm_rows = page.xpath(
+            "//div[contains(@class, 'meetings')]/table[1]"
+            "/tr[not(contains(@class, 'hidden'))]"
+        )
+
+        sub_comm_meetings = {}
+        agenda_zoom_re = re.compile(r"(Join Zoom Meeting.+)\s+Meeting ID:", re.DOTALL)
+        agenda_item_re = re.compile(r"Agenda:\s+(.+)")
+
+        for sub_comm_row in sub_comm_rows:
+            status = "tentative"
+
+            comm = sub_comm_row.xpath("string(./td[3]/a[1]/span/text())").strip()
+            if comm == "":
+                comm = sub_comm_row.xpath("string(./td[3]/a[1]/text())").strip()
+            desc = comm + " Subcommittee on Bills Hearing"
+
+            location = sub_comm_row.xpath("string(./td[4]/span/text())").strip()
+            if location == "":
+                location = sub_comm_row.xpath("string(./td[4]/text())").strip()
+
+            when = sub_comm_row.xpath("string(./td[1]/span[1]/text())").strip()
+            if when == "":
+                when = sub_comm_row.xpath("string(./td[1]/text())").strip()
+
+            if "cancelled" in when.lower() or "upon" in when.lower():
+                status = "cancelled"
+            if "To Be Determined" in when:
+                continue
+
+            # sometimes they say cancelled, sometimes they do a red strikethrough
+            if sub_comm_row.xpath("./td[1]/span[contains(@style,'line-through')]"):
+                status = "cancelled"
+            if "cancelled" in sub_comm_row.xpath("@class")[0]:
+                status = "cancelled"
+
+            junk = ["Reception"]
+            for key in junk:
+                when = when.replace(key, "")
+
+            pretty_name = f"{self.chambers[chamber]} {desc}"
+
+            when = re.sub(r"\s+", " ", when).strip()
+            if "tbd" in when.lower():
+                # OK. This is a partial date of some sort.
+                when = datetime.datetime.strptime(when, "%m/%d/%Y TIME - TBD %p")
+            else:
+                try:
+                    when = datetime.datetime.strptime(when, "%m/%d/%Y %I:%M %p")
+                except ValueError:
+                    try:
+                        when = datetime.datetime.strptime(when, "%m/%d/%Y %I %p")
+                    except ValueError:
+                        self.warning(f"error parsing timestamp {when} on {pretty_name}")
+                        continue
+
+            bill_id = sub_comm_row.xpath("./td[2]")[0].text_content().strip()
+            raw_agenda = sub_comm_row.xpath("./following-sibling::tr[1]")[
+                0
+            ].text_content()
+            agenda_zoom = agenda_zoom_re.search(raw_agenda)
+            agenda_item = agenda_item_re.search(raw_agenda)
+            if agenda_zoom:
+                agenda_desc = agenda_zoom.groups()[0]
+            elif agenda_item:
+                agenda_desc = agenda_item.groups()[0]
+            else:
+                agenda_desc = bill_id
+
+            meeting_key = f"{comm}-{when}-{location}"
+
+            if not sub_comm_meetings.get(meeting_key):
+                sub_comm_meetings[meeting_key] = {
+                    "event_obj": {
+                        "name": pretty_name,
+                        "description": desc,
+                        "start_date": self._tz.localize(when),
+                        "location": location,
+                        "status": status,
+                    },
+                    "agenda_list": [{"agenda_item": agenda_desc, "bill": bill_id}],
+                }
+            else:
+                sub_comm_meetings[meeting_key]["agenda_list"].append(
+                    {"agenda_item": agenda_desc, "bill": bill_id}
+                )
+
+        for sub_comm_meeting in sub_comm_meetings.values():
+            meeting_details = sub_comm_meeting["event_obj"]
+            sub_comm_event = Event(
+                name=meeting_details["name"],
+                description=meeting_details["description"],
+                start_date=meeting_details["start_date"],
+                location_name=meeting_details["location"],
+                status=meeting_details["status"],
+            )
+
+            for agenda_detail in sub_comm_meeting["agenda_list"]:
+                agenda = sub_comm_event.add_agenda_item(agenda_detail["agenda_item"])
+                agenda.add_bill(agenda_detail["bill"])
+
+            sub_comm_event.add_source(url)
+            sub_comm_event.add_participant(comm, note="host", type="committee")
+
+            yield sub_comm_event


### PR DESCRIPTION
IA Events scraper was not getting events included in the "Subcommittees on Bills" table on pages like [this](https://www.legis.iowa.gov/committees/meetings/meetingsListChamber?chamber=S&reqType=S%2CSUB%2CA%2CI%2C&chamberID=S&committeeTypeStanding=on&committeeTypeSub=on&bDate=03%2F06%2F2024&eDate=03%2F10%2F2024&committeeTypeApprop=on&committeeTypeInterim=on).

This was because the rows in that hidden table act strangely in the DOM.

While the other table rows follow the typical nesting pattern:
```
<table>
    <tbody>
        <tr>
        <tr>
    </tbody>
</table>
```

The Subcommittees on Bills table rows *appear* to follow this same pattern when inspected in Chrome DevTools, yet they act as though they are contained `<table>` parent without any `<tbody>` present, and consequently needed to be accessed accordingly via xpath.

Additionally, rather than each row always representing a distinct hearing (as in the other tables), the Subcommittees on Bills table rows each represent a separate bill under discussion at a given bill subcommittee hearing. Consequently, the new code in this PR includes the use of a dictionary, with keys corresponding to the unique combination of committee name, hearing time, and location, in order to prevent creation of duplicate events.