### PR TITLE
MO: events multi bills regex string captures more formats

### DIFF
--- a/scrapers/mo/events.py
+++ b/scrapers/mo/events.py
@@ -20,7 +20,7 @@ class UnknownBillStringPattern(BaseException):
 # Regex pattern for extracting multiple bill ids
 #  ex. "HJRs 33 & 45" or "HBs 882 & 518"
 multi_bills_re = re.compile(
-    r"(SJR|SRB|HCR|HB|HR|SRM|SCR|SB|HRM|HCB|HJR|SM|HRB|HEC|GRP|HC|SR)s\s+(.+)"
+    r"(SJR|SRB|HCR|HB|HR|SRM|SCR|SB|HRM|HCB|HJR|SM|HRB|HEC|GRP|HC|SR)s*\s+(\d+)"
 )
 
 


### PR DESCRIPTION
This PR modifies the regex pattern used to capture additional formats of multiple bills on committee hearing agendas.