### PR TITLE
NJ: add another committee vote motion option

### DIFF
--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -200,6 +200,7 @@ class NJBillScraper(Scraper, MDBMixin):
         "r/Sca": "Reported out of Senate committee with amendments",
         "r/favorably": "Reported favorably out of committee",
         "Not rep./Aca": "Not reported out of Assembly Committee with Amendments",
+        "Not rep./Acs": "Not reported out of Assembly Committee with Substitutes",
     }
 
     _doctypes = {


### PR DESCRIPTION
Scraper is failing out because `Not rep./Acs` is not an option on Votes