### PR TITLE
IL: temp remove committee parsing & votes

### DIFF
--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -7,7 +7,6 @@ import scrapelib
 import lxml.html
 from openstates.scrape import Scraper, Bill, VoteEvent
 from openstates.utils import convert_pdf
-from ._utils import canonicalize_url
 
 central = pytz.timezone("US/Central")
 
@@ -503,7 +502,7 @@ class IlBillScraper(Scraper):
         sponsor_list = build_sponsor_list(doc.xpath('//a[contains(@class, "content")]'))
         # don't add just yet; we can make them better using action data
 
-        committee_actors = {}
+        # committee_actors = {}
 
         # actions
         action_tds = doc.xpath('//a[@name="actions"]/following-sibling::table[1]/td')
@@ -519,18 +518,19 @@ class IlBillScraper(Scraper):
             action = action_elem.text_content()
             classification, related_orgs = _categorize_action(action)
 
-            if related_orgs and any(c.startswith("committee") for c in classification):
-                try:
-                    ((name, source),) = [
-                        (a.text, a.get("href"))
-                        for a in action_elem.xpath("a")
-                        if "committee" in a.get("href")
-                    ]
-                    source = canonicalize_url(source)
-                    actor_id = {"sources__url": source, "classification": "committee"}
-                    committee_actors[source] = name
-                except ValueError:
-                    self.warning("Can't resolve voting body for %s" % classification)
+            # TODO: add as related_entity not actor
+            # if related_orgs and any(c.startswith("committee") for c in classification):
+            #     try:
+            #         ((name, source),) = [
+            #             (a.text, a.get("href"))
+            #             for a in action_elem.xpath("a")
+            #             if "committee" in a.get("href")
+            #         ]
+            #         source = canonicalize_url(source)
+            #         actor_id = {"sources__url": source, "classification": "committee"}
+            #         committee_actors[source] = name
+            #     except ValueError:
+            #         self.warning("Can't resolve voting body for %s" % classification)
 
             bill.add_action(
                 action,
@@ -562,8 +562,8 @@ class IlBillScraper(Scraper):
         yield bill
 
         # temporarily remove vote processing due to pdf issues
-        votes_url = doc.xpath('//a[text()="Votes"]/@href')[0]
-        yield from self.scrape_votes(session, bill, votes_url, committee_actors)
+        # votes_url = doc.xpath('//a[text()="Votes"]/@href')[0]
+        # yield from self.scrape_votes(session, bill, votes_url, committee_actors)
 
     def scrape_documents(self, bill, version_url):
         html = self.get(version_url).text


### PR DESCRIPTION
Just checking if lint is weird on the other branch or all of em

Now that session is over, I'm experimenting because some Bills still have Actions missing. Skipping votes for run time cut down (will add it back after this tests right), but adding the committees as actors is causing a bunch of Import errors (below) locally & commenting it out makes it work. Think it should be reworked to be add committees as a related_entity to those actions instead.
![Screenshot 2024-06-11 at 5 55 00 PM](https://github.com/openstates/openstates-scrapers/assets/34139325/51bc9203-5998-4a88-b918-87a65f026192)
