### PR TITLE
GA: add agenda as dedupe_key

### DIFF
--- a/scrapers/ga/events.py
+++ b/scrapers/ga/events.py
@@ -70,6 +70,7 @@ class GAEventScraper(Scraper):
                 event.add_document(
                     "Agenda", row["agendaUri"], media_type="application/pdf"
                 )
+                event.dedupe_key = row["agendaUri"]
                 # Scrape bill ids from agenda pdf
                 try:
                     for bill_id in Agenda(source=URL(row["agendaUri"])).do_scrape():


### PR DESCRIPTION
Helps in the case that there's a Joint committee meeting but they have different agenda links per chamber