### PR TITLE
DE: vote dedupe key more specific

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -322,7 +322,9 @@ class DEBillScraper(Scraper, LXMLMixin):
             # Vote URL is just a generic search URL with POSTed data,
             # so provide a different link
             vote.add_source(vote_pdf_url)
-            vote.dedupe_key = vote_pdf_url
+            vote.dedupe_key = (
+                f"{bill}#{vote_id}#{vote_motion}#{vote_chamber}#{vote_date}"
+            )
             vote.set_count("yes", roll["YesVoteCount"])
             vote.set_count("no", roll["NoVoteCount"])
             vote.set_count("other", other_count)


### PR DESCRIPTION
Makes it a bit easier to debug & import is failing right now because there's some votes with the same id & chamber but different bills so hoping this clears up that issue