### PR TITLE
DE: check for long string instead of date on eff_date

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -219,7 +219,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             else:
                 code_url = None
 
-            if "N/A" in eff_date or eff_date == "":
+            if "N/A" in eff_date or eff_date == "" or len(eff_date) > 9:
                 eff_date = None
 
             if "N/A" in exp_date or exp_date == "":


### PR DESCRIPTION
[SB 15](https://legis.delaware.gov/BillDetail?LegislationId=141235) has a really long string instead of an effective date