### PR TITLE
NE: set regular session inactive

### DIFF
--- a/scrapers/ne/__init__.py
+++ b/scrapers/ne/__init__.py
@@ -83,7 +83,7 @@ class Nebraska(State):
             "start_date": "2023-01-04",
             "end_date": "2024-04-19",
             "classification": "primary",
-            "active": True,
+            "active": False,
         },
         {
             "_scraped_name": "108th Legislature 1st Special Session",


### PR DESCRIPTION
Having issues importing bills since there are bills with the same number in each session ex: LB 6 in [regular](https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=50032) vs [special](https://nebraskalegislature.gov/bills/view_bill.php?DocumentID=58102), so just not scraping regular session that's inactive