### PR TITLE
IL: Sponsorship Cleanup

### DIFF
--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -534,8 +534,8 @@ class IlBillScraper(Scraper):
                 related_entities=related_orgs,
             )
 
-            if action.lower().find("sponsor") != -1:
-                self.refine_sponsor_list(actor, action, sponsor_list, bill_id)
+            # if action.lower().find("sponsor") != -1:
+            #     self.refine_sponsor_list(actor, action, sponsor_list, bill_id)
 
         # now add sponsors
         for spontype, sponsor, chamber, official_type in sponsor_list:


### PR DESCRIPTION
## Description

- [#1213 Sponsorship Cleanup](https://github.com/openstates/issues/issues/1213)
- I've checked the current scraper and found that we don't need refine_sponsor_list function because the sponsor list in the source website is the last list after happened all actions. so the first sponsor is the Chief Sponsor and others are Co-sponsors. Please let me know if you have opinion for my thought.