### PR TITLE
DE: Fix end date on 2023-2024 session to improve legislator matching

### DIFF
--- a/scrapers/de/__init__.py
+++ b/scrapers/de/__init__.py
@@ -101,7 +101,7 @@ class Delaware(State):
             "identifier": "152",
             "name": "152nd General Assembly (2023-2024)",
             "start_date": "2022-01-10",
-            "end_date": "2022-06-30",
+            "end_date": "2024-06-30",
             "active": True,
         },
     ]


### PR DESCRIPTION
https://legis.delaware.gov/docs/default-source/default-document-library/legislativecalendar-2024.pdf?sfvrsn=76ff8938_2

https://legis.delaware.gov/SessionCalendar

https://ballotpedia.org/2024_Delaware_legislative_session