### PR TITLE
CA: check for actual 'to' instead of splitting 'October'

### DIFF
--- a/scrapers/ca/events_web.py
+++ b/scrapers/ca/events_web.py
@@ -228,7 +228,7 @@ class CAEventWebScraper(Scraper, LXMLMixin):
                     " ".join([hearing_date, hearing_time])
                     .split("or")[0]
                     .split("and")[0]
-                    .split("to")[0]
+                    .split(" to ")[0]
                     .strip()
                 )
                 when = dateutil.parser.parse(when)


### PR DESCRIPTION
It's splitting up "october" & failing validation 