### PR TITLE
Multi: metadata cleanup

### DIFF
--- a/scrapers/az/__init__.py
+++ b/scrapers/az/__init__.py
@@ -290,7 +290,6 @@ class Arizona(State):
         },
     ]
     ignored_scraped_sessions = [
-        "2024 - Fifty-sixth Legislature - Second Regular Session",
         "2008 - Forty-eighth Legislature - Second Regular Session",
         "2007 - Forty-eighth Legislature - First Regular Session",
         "2006 - Forty-seventh Legislature - First Special Session",

--- a/scrapers/id/__init__.py
+++ b/scrapers/id/__init__.py
@@ -153,8 +153,6 @@ class Idaho(State):
         },
     ]
     ignored_scraped_sessions = [
-        "2021 Session",
-        "2020 Session",
         "2010 Session",
         "2009 Session",
         "2008 Session",

--- a/scrapers/mo/__init__.py
+++ b/scrapers/mo/__init__.py
@@ -107,7 +107,6 @@ class Missouri(State):
         },
     ]
     ignored_scraped_sessions = [
-        "2022 1st Extraordinary Session",
         "2018 Regular Session",
         "2018 Special Session",
         "2018 1st Extraordinary Session",

--- a/scrapers/va/__init__.py
+++ b/scrapers/va/__init__.py
@@ -191,8 +191,7 @@ class Virginia(State):
         },
         {
             "_scraped_name": "2023 Session",
-            # TODO: remove classification when more than bills, histories, & votes posted
-            "classification": "special",
+            "classification": "primary",
             "identifier": "2023",
             "name": "2023 Regular Session",
             "start_date": "2023-01-11",

--- a/scrapers/vt/__init__.py
+++ b/scrapers/vt/__init__.py
@@ -105,7 +105,6 @@ class Vermont(State):
         },
     ]
     ignored_scraped_sessions = [
-        "2021 Special Session",
         "2020 Training Session",
         "2009 Special Session",
     ]


### PR DESCRIPTION
Just getting rid of some `ignored_sessions` that are scraped & swapped the `classification` for a regular session in VA