### PR TITLE
DC: Events: Use API

### DIFF
--- a/scrapers/dc/events.py
+++ b/scrapers/dc/events.py
@@ -1,15 +1,10 @@
-import lxml.html
 import pytz
-import re
+import datetime
+
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
-import datetime
-import itertools
-import operator
-
-from ics import Calendar
 from openstates.scrape import Scraper, Event
-from utils.media import get_media_type
+from utils.events import month_range
 
 
 class DCEventScraper(Scraper):
@@ -29,10 +24,14 @@ class DCEventScraper(Scraper):
         else:
             end_date = parser.parse(start_date)
 
-        for d in self.month_range(start_date, end_date):
+        for d in month_range(start_date, end_date):
             data = self.scrape_month_json(d.month, d.year)
             for row in data:
                 yield from self.parse_event(row)
+
+        # note: there is also https://lims.dccouncil.gov/Hearings/API/Public/GetUpcomingHearings
+        # but that just seems to be a worse version of GetHearingsCalendar,
+        # as it doesn't have any more info and lacks structured agendas
 
     def scrape_month_json(self, month: int, year: int):
         self.info(f"Scraping {str(year)}-{str(month)}")
@@ -68,6 +67,7 @@ class DCEventScraper(Scraper):
         e.add_committee(row["hearingTitle"])
 
         for topic in row["topics"]:
+            # some topics have a structured obj, some are just strings
             agenda_row = e.add_agenda_item(topic["topic"])
 
             if topic["legislationNumber"]:
@@ -82,83 +82,3 @@ class DCEventScraper(Scraper):
             )
 
         yield e
-
-    def old_scrape(self):
-        # use ical to get the full feed and start dates, which aren't cleanly in the html
-        ical_url = (
-            "https://dccouncil.gov/?post_type=tribe_events&ical=1&eventDisplay=list"
-        )
-
-        ical = self.get(ical_url).text
-        self.info("Parsing event feed. This may take a moment.")
-        cal = Calendar(ical)
-        for e in cal.events:
-            yield from self.scrape_cal_page(e)
-
-    def scrape_cal_page(self, e):
-        # scrape the html to get the correct links and description
-        page = lxml.html.fromstring(self.get(e.url).content)
-
-        title = e.name
-        start = str(e.begin)
-        location = e.location
-        description = str(e.description)
-
-        event = Event(
-            title,
-            start,
-            location,
-            description=description,
-            end_date=str(e.end),
-        )
-
-        bill_regex = r"(?P<type>Bill|Resolution) (?P<session>\d+)-(?P<billnumber>\d+)"
-        matches = re.findall(bill_regex, description, flags=re.IGNORECASE)
-
-        for match in matches:
-            bill = (
-                f"{self.bill_prefixes[match[0].lower()]} {match[1]}-{match[2].zfill(4)}"
-            )
-            event.add_bill(bill)
-
-        try:
-            header = page.xpath(
-                "//header[contains(@class,'article-header')]/p[1]/text()"
-            )[0]
-        except IndexError:
-            header = page.xpath(
-                "//header[contains(@class,'article-header')]/h1[1]/text()"
-            )[0]
-        if "&bullet;" in header:
-            com_name = header.split("&bullet;")[1].strip()
-            if "whole" not in com_name.lower():
-                event.add_participant(com_name, type="committee", note="host")
-
-        materials = page.xpath(
-            "//section[contains(@class,'aside-section')]//a[contains(@class,'icon-link')]"
-        )
-        for mat in materials:
-            # sometimes they add broken empty links here
-            if mat.xpath("text()"):
-                title = mat.xpath("text()")[0].strip()
-                url = mat.xpath("@href")[0]
-                event.add_document(title, url, media_type=get_media_type(url))
-
-        event.add_source(e.url)
-
-        yield event
-
-    def month_range(
-        self,
-        start: datetime.date,
-        end: datetime.date,
-    ):
-        """Yields the 1st day of each month in the given date range."""
-        yield from itertools.takewhile(
-            lambda date: date < end,
-            itertools.accumulate(
-                itertools.repeat(relativedelta(months=1)),
-                operator.add,
-                initial=start,
-            ),
-        )

--- a/scrapers/dc/events.py
+++ b/scrapers/dc/events.py
@@ -1,6 +1,11 @@
 import lxml.html
 import pytz
 import re
+from dateutil import parser
+from dateutil.relativedelta import relativedelta
+import datetime
+import itertools
+import operator
 
 from ics import Calendar
 from openstates.scrape import Scraper, Event
@@ -12,7 +17,59 @@ class DCEventScraper(Scraper):
 
     bill_prefixes = {"bill": "B", "resolution": "R"}
 
-    def scrape(self):
+    def scrape(self, start_date=None, end_date=None):
+
+        if start_date is None:
+            start_date = datetime.date.today() + relativedelta(months=-3)
+        else:
+            start_date = parser.parse(start_date)
+
+        if end_date is None:
+            end_date = datetime.date.today() + relativedelta(months=+3)
+        else:
+            end_date = parser.parse(start_date)
+
+        for d in self.month_range(start_date, end_date):
+            data = self.scrape_month_json(d.month, d.year)
+            for row in data:
+                yield from self.parse_event(row)
+
+    def scrape_month_json(self, month: int, year: int):
+        self.info(f"Scraping {str(year)}-{str(month)}")
+        headers = {
+            "accept": "application/json, text/plain, */*",
+            "content-type": "application/json",
+        }
+
+        json_data = {
+            "month": month,
+            "year": year,
+            "committeeId": 0,
+            "searchText": "",
+        }
+
+        response = self.post(
+            "https://lims.dccouncil.gov/Hearings/API/Public/GetHearingsCalendar",
+            headers=headers,
+            json=json_data,
+        )
+        return response.json()
+
+    def parse_event(self, data):
+        when = parser.parse(data["hearingDateTime"])
+        when = self._tz.localize(when)
+
+        e = Event(
+            data["hearingTitle"], when, data["address"], upstream_id=data["hearingId"]
+        )
+
+        e.add_source(
+            f"https://lims.dccouncil.gov/Hearings/hearings/{data['hearingId']}"
+        )
+
+        yield e
+
+    def old_scrape(self):
         # use ical to get the full feed and start dates, which aren't cleanly in the html
         ical_url = (
             "https://dccouncil.gov/?post_type=tribe_events&ical=1&eventDisplay=list"
@@ -76,3 +133,18 @@ class DCEventScraper(Scraper):
         event.add_source(e.url)
 
         yield event
+
+    def month_range(
+        self,
+        start: datetime.date,
+        end: datetime.date,
+    ):
+        """Yields the 1st day of each month in the given date range."""
+        yield from itertools.takewhile(
+            lambda date: date < end,
+            itertools.accumulate(
+                itertools.repeat(relativedelta(months=1)),
+                operator.add,
+                initial=start,
+            ),
+        )

--- a/scrapers/utils/events.py
+++ b/scrapers/utils/events.py
@@ -1,3 +1,10 @@
+import datetime
+import itertools
+import operator
+
+from dateutil.relativedelta import relativedelta
+
+
 # the current function to set coordinates requires a
 # valid URL and Note, which we often don't have.
 # so this will add just coordinates
@@ -26,3 +33,18 @@ def match_coordinates(event, locations):
         if location.lower() in event.location.get("name").lower():
             set_coordinates(event, coords[0], coords[1])
             return
+
+
+def month_range(
+    start: datetime.date,
+    end: datetime.date,
+):
+    """Yields the 1st day of each month in the given date range."""
+    yield from itertools.takewhile(
+        lambda date: date < end,
+        itertools.accumulate(
+            itertools.repeat(relativedelta(months=1)),
+            operator.add,
+            initial=start,
+        ),
+    )


### PR DESCRIPTION
@NewAgeAirbender I added a new utility function to utils.events -- month_range, might come in handy in the future. 

I modded this scraper to default to 3 months ago -> 3 months from now, but you can pass an optional start_date and end_date to custom set them. We've been taking this approach in other scrapers where possible and I think it's a good balance. I'll probably abstract that out to a utility function at some point.

