### PR TITLE
AK: fix sponsorship type

### DIFF
--- a/scrapers/ak/bills.py
+++ b/scrapers/ak/bills.py
@@ -138,7 +138,7 @@ class AKBillScraper(Scraper):
                 if spons_str:
                     bill.add_sponsorship(
                         spons_str,
-                        entity_type="person",
+                        entity_type="organization",
                         classification="primary",
                         primary=True,
                     )


### PR DESCRIPTION
We've already got it as a committee above in the check, so just need to set it as an "organization" instead of "person" in `add_sponsorship`