### PR TITLE
WA: Skip their test bills

### DIFF
--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -309,6 +309,10 @@ class WABillScraper(Scraper, LXMLMixin):
 
         title = xpath(page, "string(wa:LongDescription)")
 
+        if "TEST BILL FOR" in title.upper():
+            self.info("Skipping test bill.")
+            return
+
         bill_type = xpath(
             page, "string(wa:ShortLegislationType/wa:LongLegislationType)"
         )


### PR DESCRIPTION
WA snuck a couple of test bills into their production site. They've since been deleted from the WA site, but just avoid scraping them in the future.