### PR TITLE
Update CA event scraper

### DIFF
--- a/scrapers/ca/events_web.py
+++ b/scrapers/ca/events_web.py
@@ -209,6 +209,7 @@ class CAEventWebScraper(Scraper, LXMLMixin):
                     .split(", Chair")[0]
                     .split("AND")
                 ]
+                members = [item for sublist in members for item in sublist.split(", ")]
 
                 time_loc = content_xpath.xpath(
                     './/div[@class="attribute time-location"]'


### PR DESCRIPTION
 I see this scraper issue in CA events. Soria and Papan are 2 chairs for "Agriculture"  and "Water, Parks and Wildlife" committees. But the scraper returns them are 1 participants 'Soria, Papan'. Can we create a ticket for a fix.
![image](https://github.com/user-attachments/assets/00d38865-2248-46b1-a067-5317908e31ae)
![image](https://github.com/user-attachments/assets/239534de-f64b-4d44-84c7-181dfbb74898)

