### PR TITLE
NJ: Remove ancient 'phony bill' logic that is blocking real bills

### DIFF
--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -537,16 +537,8 @@ class NJBillScraper(Scraper, MDBMixin):
             else:
                 self.warning("invalid bill id in BillSubj: %s" % bill_id)
 
-        phony_bill_count = 0
         # save all bills at the end
         for bill in bill_dict.values():
             # add sources
-            if not bill.actions and not bill.versions:
-                self.warning("probable phony bill detected %s", bill.identifier)
-                phony_bill_count += 1
-            else:
-                bill.add_source("https://www.njleg.state.nj.us/downloads.asp")
-                yield bill
-
-        if phony_bill_count:
-            self.warning("%s total phony bills detected", phony_bill_count)
+            bill.add_source("https://pub.njleg.state.nj.us/leg-databases/")
+            yield bill


### PR DESCRIPTION
Some real bills have been blocked from being saved to the DB by "phony bill" detection logic that appears it was added like a decade ago :) I spot checked a bunch and none of the missing bills seem to be "phony." 