### PR TITLE
USA: reduce duplicate 'Subcommittee Hearings Held' events

### DIFF
--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -376,8 +376,12 @@ class USBillScraper(Scraper):
                 )
             action_date = self._TZ.localize(action_date)
             location = "Washington, DC 20004"
+            if committee_name:
+                event_name = f"{action_text} - {bill.identifier} - {committee_name}"
+            else:
+                event_name = f"{action_text} - {bill.identifier}"
             event = Event(
-                action_text,
+                event_name,
                 action_date,
                 location_name=location,
             )


### PR DESCRIPTION
cc @showerst  in case you are doing event collation and this might impact you

The USA bill scraper has been yielding hearing events related to bills since April. However recently I have noticed a number of `DuplicateItemError` in our data processing pipeline, I believe because these events have sparse information and generic titles often, thus yielding more frequently detected duplicates.

My goal here is to reduce these duplicates, but also provide a more helpful title to the event.