### PR TITLE
WA: fix bug where bill version notes are long repeated strings

### DIFF
--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -124,7 +124,9 @@ class WABillScraper(Scraper, LXMLMixin):
 
                 bill_id = chamber[0] + bill_types[bill_type] + " " + bill_num
 
-                if bill_type != "Passed Legislature":
+                if bill_type == "Passed Legislature":
+                    name = "Passed Legislature"
+                else:
                     name = bill_type[:-1]
 
                 if is_substitute:
@@ -138,6 +140,7 @@ class WABillScraper(Scraper, LXMLMixin):
 
                 if not self.versions.get(bill_id):
                     self.versions[bill_id] = []
+
                 self.versions[bill_id].append(
                     {"note": name, "url": link, "media_type": "text/html"}
                 )


### PR DESCRIPTION
We were getting string repeats concatenated into bill version notes field, like `Second Substitute Substitute Substitute Substitute Substitute Second Substitute Joint Resolution` because the loop didn't reliably initialize a variable. Some bill versions failed to import because the notes got so long, which is how I noticed.

A default of "Passed Legislature" is a little weird for passed bill versions ... but to fix we'd need to scrape each bill version page and hunt around for the right text. Which I don't think is really worth it but could be a good improvement in the future.