### PR TITLE
MD & WY: add chamber to bill scrapers add_sponsorships()

### DIFF
--- a/scrapers/md/bills.py
+++ b/scrapers/md/bills.py
@@ -347,6 +347,18 @@ class MDBillScraper(Scraper):
             bill.add_subject(row[0])
 
     def scrape_bill_sponsors(self, bill, page):
+        sponsors_title = "".join(
+            page.xpath(
+                '//dt[contains(text(), "Sponsored by")]/following-sibling::dd[1]/text()'
+            )
+        )
+        if "Delegate" in sponsors_title:
+            chamber = "lower"
+        elif "Senator" in sponsors_title:
+            chamber = "upper"
+        else:
+            chamber = None
+
         sponsors = page.xpath(
             '//dt[contains(text(), "Sponsored by")]/following-sibling::dd[1]/a'
         )
@@ -363,12 +375,21 @@ class MDBillScraper(Scraper):
                 # sponsor the list is done
                 # (e.g. http://mgaleg.maryland.gov/mgawebsite/Legislation/Details/sb0125?ys=2021RS)
                 break
-            bill.add_sponsorship(
-                sponsor,
-                sponsor_type,
-                primary=sponsor_type == "primary",
-                entity_type=entity_type,
-            )
+            if chamber:
+                bill.add_sponsorship(
+                    sponsor,
+                    sponsor_type,
+                    primary=sponsor_type == "primary",
+                    entity_type=entity_type,
+                    chamber=chamber,
+                )
+            else:
+                bill.add_sponsorship(
+                    sponsor,
+                    sponsor_type,
+                    primary=sponsor_type == "primary",
+                    entity_type=entity_type,
+                )
 
     def scrape_bill(self, chamber, session, url):
         html = self.get(url).content

--- a/scrapers/wy/bills.py
+++ b/scrapers/wy/bills.py
@@ -198,12 +198,26 @@ class WYBillScraper(Scraper, LXMLMixin):
         for sponsor in bill_json["sponsors"]:
             status = "primary" if sponsor["primarySponsor"] else "cosponsor"
             sponsor_type = "person" if sponsor["sponsorTitle"] else "organization"
-            bill.add_sponsorship(
-                name=sponsor["name"],
-                classification=status,
-                entity_type=sponsor_type,
-                primary=sponsor["primarySponsor"],
+            chamber = (
+                "lower"
+                if sponsor["house"] == "H"
+                else ("upper" if sponsor["house"] == "S" else None)
             )
+            if chamber:
+                bill.add_sponsorship(
+                    name=sponsor["name"],
+                    classification=status,
+                    entity_type=sponsor_type,
+                    primary=sponsor["primarySponsor"],
+                    chamber=chamber,
+                )
+            else:
+                bill.add_sponsorship(
+                    name=sponsor["name"],
+                    classification=status,
+                    entity_type=sponsor_type,
+                    primary=sponsor["primarySponsor"],
+                )
 
         if bill_json["summary"]:
             bill.add_abstract(note="summary", abstract=bill_json["summary"])


### PR DESCRIPTION
In Maryland House bills can only be sponsored by House Members and the same applies to Senate bills. [Example - HB0901](https://mgaleg.maryland.gov/mgawebsite/Legislation/Details/hb0901?ys=2024RS).
* Adding chamber will help improve matching, especially in Maryland where several legislators share last name.