### PR TITLE
MO: Improve Senate sponsor psuedo_person_id

### DIFF
--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -202,9 +202,20 @@ class MOBillScraper(Scraper, LXMLMixin):
             sponsor = bill_page.xpath('//span[@id="lSponsor"]')[0]
 
         bill_sponsor = sponsor.text_content()
-        # bill_sponsor_link = sponsor.attrib.get('href')
+
+        bill_sponsor_link = sponsor.attrib.get("href")
+
+        if "Senators" in bill_sponsor_link:
+            chamber = "upper"
+        else:
+            chamber = None
+
         bill.add_sponsorship(
-            bill_sponsor, entity_type="person", classification="primary", primary=True
+            bill_sponsor,
+            entity_type="person",
+            classification="primary",
+            primary=True,
+            chamber=chamber,
         )
 
         # cosponsors show up on their own page, if they exist


### PR DESCRIPTION
MO: House and Senate source website are quite different. House Sponsors mostly have full name as seen [here](https://documents.house.mo.gov/xml/241-HB2.xml) while senate can sometimes be just the last name [for example](https://www.senate.mo.gov/24info/BTS_Web/Bill.aspx?SessionType=R&BillID=11). So the change only apply to Senate Sponsor scrape.