### PR TITLE
TX: strip title from event participants name

### DIFF
--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -88,6 +88,7 @@ class TXEventScraper(Scraper, LXMLMixin):
         chair = None
         if "CHAIR" in metainfo:
             chair = metainfo["CHAIR"]
+            chair = re.sub(r"(Rep\. |Senator |Representative |Sen\. )", "", chair)
 
         plaintext = re.sub(r"\s+", " ", plaintext).strip()
         bills = bill_re.findall(plaintext)


### PR DESCRIPTION
Title in legislators name causes event participants mismatch for TX.