### PR TITLE
Update NY event organization names

### DIFF
--- a/scrapers/ny/events.py
+++ b/scrapers/ny/events.py
@@ -88,7 +88,7 @@ class NYEventScraper(Scraper):
         # careful, the committee name in the page #committee_div
         # is getting inserted via JS
         # so use the one from the table, and strip the chair name
-        com_name = re.sub(r"\(.*\)", "", meta[0])
+        com_name = re.sub(r"\(.*\)", "", meta[0]).strip()
         com_name = f"Assembly {com_name}"
 
         when = self.clean_date(meta[1])

--- a/scrapers/ny/events.py
+++ b/scrapers/ny/events.py
@@ -113,7 +113,10 @@ class NYEventScraper(Scraper):
         if table.xpath('.//a[contains(@href, "/leg/")]'):
             agenda = event.add_agenda_item("Bills under Consideration")
             for bill_link in table.xpath('.//a[contains(@href, "/leg/")]'):
-                agenda.add_bill(bill_link.text_content().strip())
+                bill_text = bill_link.text_content().strip()
+                # Remove trailing single character if it exists
+                bill_text = re.sub(r"[a-zA-Z]$", "", bill_text)
+                agenda.add_bill(bill_text)
 
         yield event, event_name
 


### PR DESCRIPTION
* Strip resulting committee names of leading and trailing white spaces
* Remove the trailing single character from bill_id
There might be a better place to make this change like in [core](https://github.com/openstates/openstates-core/blob/main/openstates/utils/transformers.py) but not sure.
CC: @jessemortenson 