### PR TITLE
VA: Fix duplicate vote bug with votes import

### DIFF
--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -238,8 +238,9 @@ class VaBillScraper(Scraper):
             # and right now OS core requires a pass or fail, so we skip them with a notice
             # also skip rows that correspond to a bill action that does not indicate a vote by presence of ##-Y / ##-N
             #   if we don't skip on that last criteria, we get duplicate vote events
-            if ((row["PassFail"] or row["IsVoice"] is not True)
-                    and vote_shorthand_regex.search(row["LegislationActionDescription"])):
+            if (
+                row["PassFail"] or row["IsVoice"] is not True
+            ) and vote_shorthand_regex.search(row["LegislationActionDescription"]):
                 vote_date = dateutil.parser.parse(row["VoteDate"]).date()
 
                 motion_text = row["VoteActionDescription"]
@@ -261,8 +262,10 @@ class VaBillScraper(Scraper):
 
                 # BatchNumber is not unique to an individual Vote Event, so we need to add context
                 # in order to avoid duplicate dedupe keys
-                v.dedupe_key = (f"{row['BatchNumber'].strip()}-{bill.identifier.strip()}-"
-                                f"{row['LegislationActionDescription'].strip()}`")[:500]
+                v.dedupe_key = (
+                    f"{row['BatchNumber'].strip()}-{bill.identifier.strip()}-"
+                    f"{row['LegislationActionDescription'].strip()}`"
+                )[:500]
 
                 tally = {
                     "Y": 0,

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -14,6 +14,7 @@ from .actions import Categorizer
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 four_digit_regex = re.compile("[0-9]{4}")
+vote_shorthand_regex = re.compile("[0-9]+-[YN]")
 
 
 class VaBillScraper(Scraper):
@@ -235,7 +236,10 @@ class VaBillScraper(Scraper):
         for row in page["Votes"]:
             # VA Voice votes don't indicate pass fail,
             # and right now OS core requires a pass or fail, so we skip them with a notice
-            if row["PassFail"] or row["IsVoice"] is not True:
+            # also skip rows that correspond to a bill action that does not indicate a vote by presence of ##-Y / ##-N
+            #   if we don't skip on that last criteria, we get duplicate vote events
+            if ((row["PassFail"] or row["IsVoice"] is not True)
+                    and vote_shorthand_regex.search(row["LegislationActionDescription"])):
                 vote_date = dateutil.parser.parse(row["VoteDate"]).date()
 
                 motion_text = row["VoteActionDescription"]
@@ -255,7 +259,10 @@ class VaBillScraper(Scraper):
                     classification=[],
                 )
 
-                v.dedupe_key = row["BatchNumber"]
+                # BatchNumber is not unique to an individual Vote Event, so we need to add context
+                # in order to avoid duplicate dedupe keys
+                v.dedupe_key = (f"{row['BatchNumber'].strip()}-{bill.identifier.strip()}-"
+                                f"{row['LegislationActionDescription'].strip()}`")[:500]
 
                 tally = {
                     "Y": 0,
@@ -290,7 +297,9 @@ class VaBillScraper(Scraper):
 
                 # https://lis.virginia.gov/vote-details/HB88/20251/H1003V0001
                 v.add_source(
-                    f"https://lis.virginia.gov/vote-details/{row['VoteLegislation']}/{self.session_code}/{row['BatchNumber']}"
+                    f"https://lis.virginia.gov/vote-details/"
+                    f"{row['VoteLegislation'][0].get('LegislationNumber', 'NOT_FOUND')}/"
+                    f"{self.session_code}/{row['BatchNumber']}"
                 )
                 yield v
             else:


### PR DESCRIPTION
VA vote events were failing to import with errors like:

```
INFO - [base] openstates.exceptions.DuplicateItemError: attempt to import data that would conflict with data already in the import: {'identifier': '', 'motion_text': 'Reported with amendments', 'motion_classification': [], 'start_date': '2024-01-31', 'result': 'pass', 'extras': {}, 'dedupe_key': 'H092024-01-311', 'legislative_session_id': UUID('27766658-dae9-4950-8565-ca0a88ea931e'), 'organization_id': 'ocd-organization/0c3daf42-2835-49cf-8f58-b1d771dae687', 'bill_id': 'ocd-bill/61eb4a36-d3f6-4855-a913-7f45613910e2', 'bill_action_id': UUID('37298987-68ef-4d79-99d8-6a8dec9fa5e2')} (already imported as Reported with amendments on HB 582 in Virginia 2025 Regular Session)
INFO - [base] obj1 sources: ["[https://lis.virginia.gov/vote-details/[{'VoteLegislationID':](https://lis.virginia.gov/vote-details/[%7B'VoteLegislationID':) 306230, 'LegislationID': 92156, 'LegislationNumber': 'HB582', 'Description': 'Public high schools; each school board to employ at least one career coach.                         ', 'VoteNumber': None, 'VoteItems': []}]/20251/H092024-01-311"]
INFO - [base] obj2 sources: ["[https://lis.virginia.gov/vote-details/[{'VoteLegislationID':](https://lis.virginia.gov/vote-details/[%7B'VoteLegislationID':) 306230, 'LegislationID': 92156, 'LegislationNumber': 'HB582', 'Description': 'Public high schools; each school board to employ at least one career coach.                         ', 'VoteNumber': None, 'VoteItems': []}]/20251/H092024-01-311"]
```

Looks like dedupe key used was not actually unique. Also fixes URL used as sources for votes.