### PR TITLE
USA/NV: fix small bugs affecting bill import

### DIFF
--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -447,6 +447,7 @@ class VoteList(HtmlPage):
         date_re = re.compile(r"Date\s+(?P<date>.*)", re.U | re.I)
         index = 0
 
+        date_motion_counts = {}
         for row in CSS(".vote-revision", min_items=0).match(self.root):
             summary = summaries[index]
             index += 1
@@ -471,6 +472,16 @@ class VoteList(HtmlPage):
                 if date_match:
                     start_date = date_match.groupdict()["date"]
                     start_date = parse_date(start_date)
+
+            # sometimes two votes with the same motion happen on the same day
+            # hence we need to make motion text unique otherwise import fails
+            date_motion = f"{start_date.date()}{summary}"
+            if start_date is not None and date_motion in date_motion_counts:
+                num_existing = date_motion_counts[date_motion]
+                summary = f"{summary} ({num_existing + 1})"
+                date_motion_counts[date_motion] += 1
+            else:
+                date_motion_counts[date_motion] = 1
 
             vote = VoteEvent(
                 chamber=chamber,

--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -411,7 +411,7 @@ class USBillScraper(Scraper):
                 self.warning("Check amendment url ordinals")
 
             bill.add_document_link(
-                note=f"{self.get_xpath(row, 'type')} {num}",
+                note=f"{self.get_xpath(row, 'type')} {num}"[:300],
                 url=f"https://www.congress.gov/amendment/{session}th-congress/{slugs[self.get_xpath(row, 'type')]}/{num}",
                 media_type="text/html",
             )


### PR DESCRIPTION
USA: bill document note can be over 300 characters, causing DB VARCHAR length error

NV: at least one bill has two votes on the same day with the same motion text (https://www.leg.state.nv.us/App/NELIS/REL/82nd2023/Bill/9667/Votes), so add a suffix when this is encountered.