### PR TITLE
IN: fix import duplicates by using unique meeting link as dedupe key

### DIFF
--- a/scrapers/in/events.py
+++ b/scrapers/in/events.py
@@ -57,6 +57,7 @@ class INEventScraper(Scraper):
 
             date_str = meeting["meetingdate"].replace(" ", "")
             time_str = meeting["starttime"]
+            custom_start_string = ""
             # Determine the 'when' variable based on the presence of time
             if time_str:
                 time_str = time_str.replace(
@@ -68,21 +69,22 @@ class INEventScraper(Scraper):
             else:
                 when = dateutil.parser.parse(date_str).date()
                 all_day = True
+                if "customstart" in meeting and meeting['customstart'] != "":
+                    custom_start_string = f" - {meeting['customstart']}"
 
             location = meeting["location"] or "See Agenda"
             video_url = (
                 f"https://iga.in.gov/legislative/{self.session}/meeting/watchlive/{_id}"
             )
-            event_name = f"{committee['chamber']}#{committee_name}#{location}#{when}"
 
             event = Event(
-                name=committee_name,
+                name=f"{committee_name}{custom_start_string}",
                 start_date=when,
                 all_day=all_day,
                 location_name=location,
                 classification="committee-meeting",
             )
-            event.dedupe_key = event_name
+            event.dedupe_key = meeting["link"]
             event.add_source(link, note="API details")
             name_slug = re.sub("[^a-zA-Z0-9]+", "-", committee_name.lower())
 

--- a/scrapers/in/events.py
+++ b/scrapers/in/events.py
@@ -69,7 +69,7 @@ class INEventScraper(Scraper):
             else:
                 when = dateutil.parser.parse(date_str).date()
                 all_day = True
-                if "customstart" in meeting and meeting['customstart'] != "":
+                if "customstart" in meeting and meeting["customstart"] != "":
                     custom_start_string = f" - {meeting['customstart']}"
 
             location = meeting["location"] or "See Agenda"


### PR DESCRIPTION
Import was failing due to events with same name/date/location. These were all-day events (no start time) with a "customstarttime" that narrative-describes when the event will start ('after X adjourns' etc.)