### PR TITLE
OK events: swallow exceptions for 404s on agenda PDFs

### DIFF
--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -10,6 +10,7 @@ from openstates.scrape import Scraper, Event
 from openstates.exceptions import EmptyScrape
 
 from utils.events import match_coordinates
+from scrapelib import HTTPError
 from spatula import PdfPage, URL
 
 bills_re = re.compile(
@@ -18,6 +19,13 @@ bills_re = re.compile(
 
 
 class Agenda(PdfPage):
+    def process_error_response(self, exception):
+        # OK has some known 404s for PDFs, so swallow those exceptions
+        if isinstance(exception, HTTPError):
+            self.logger.warning(f"Skipped PDF download due to to HTTPError {exception}")
+        else:
+            raise exception
+
     def process_page(self):
         # Find all bill ids
         bills = bills_re.findall(self.text)


### PR DESCRIPTION
At least one OK event has an associated PDF that 404s, and this is causing the scraper to fail. Fix by swallowing HTTP error on PDF downloads, warning in log instead.