### PR TITLE
Catch param case sensitivity on PA vote parsing

### DIFF
--- a/scrapers/pa/bills.py
+++ b/scrapers/pa/bills.py
@@ -277,7 +277,7 @@ class PABillScraper(Scraper):
             elif "/roll-call-votes/" in url:
                 # As of Nov 2024, this URL in the new site is broken
                 # but works if we add a query param
-                if "sessyr" not in url:
+                if "sessyr" not in url.lower():
                     url = f"{url}&sessyr={self.session_year}"
                 yield from self.parse_committee_votes(bill, url)
             else:

--- a/scrapers/pa/bills.py
+++ b/scrapers/pa/bills.py
@@ -278,7 +278,7 @@ class PABillScraper(Scraper):
                 # As of Nov 2024, this URL in the new site is broken
                 # but works if we add a query param
                 if "sessyr" not in url.lower():
-                    url = f"{url}&sessyr={self.session_year}"
+                    url = f"{url}&sessYr={self.session_year}"
                 yield from self.parse_committee_votes(bill, url)
             else:
                 msg = "Unexpected vote url: %r" % url


### PR DESCRIPTION
Hey there this is my first PR on this project so lmk if I'm doing something wrong here!

I noticed during running scraping for PA that it seems there can be times where the roll call votes include "sessYr" but it looks like we are looking for "sessyr", and thus we don't see it and attempt to add it, leading to a 404.

Example of log output from the scraper:
```
00:04:35 INFO scrapelib: GET - 'https://www.palegis.us/senate/committees/roll-call-votes/vote-list/vote-summary?committeecode=17&rollcallid=1378&sessYr=2023&sessInd=0&sessyr=2023'
00:04:37 WARNING openstates: There was an error in scraping https://www.palegis.us/legislation/bills/2023/sr359: Retry 1: Error: 404 while retrieving https://www.palegis.us/404
```

Seems like we attempted to work around this with a recent PR here: https://github.com/openstates/openstates-scrapers/pull/5086

I'm wondering if they added this onto links on the server side but they added it in a different format.

According to the RFC [rfc7230](https://www.rfc-editor.org/rfc/rfc7230#section-2.7.3) query params are actually case sensitive so I'm proposing we check for things in lowercase first, and if it does not exist then we add it in the case that the PA site seems to want there.

 
