### PR TITLE
GA: prep 2025 session, inactive for now

### DIFF
--- a/scrapers/ga/__init__.py
+++ b/scrapers/ga/__init__.py
@@ -98,6 +98,14 @@ class Georgia(State):
             "end_date": "2023-12-07",
             "active": False,
         },
+        {
+            "_scraped_name": "2025-2026 Regular Session",
+            "identifier": "2025_26",
+            "name": "2025-2026 Regular Session",
+            "start_date": "2025-01-13",
+            "end_date": "2026-04-02",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "2009-2010 Regular Session",

--- a/scrapers/ga/util.py
+++ b/scrapers/ga/util.py
@@ -52,6 +52,7 @@ def backoff(function, *args, **kwargs):
 # available via the session dropdown on
 # http://www.legis.ga.gov/Legislation/en-US/Search.aspx
 SESSION_SITE_IDS = {
+    "2025_26": 1033,
     "2023_ss": 1032,
     "2023_24": 1031,
     "2021_ss": 1030,


### PR DESCRIPTION
There are no bills posted on https://www.legis.ga.gov/search?s=1033&p=1 yet, and the SOAP service returns an empty string if the scraper is run on 2025 data. So keeping the new session Inactive for now.