### PR TITLE
CA: add 2025 special session 1

### DIFF
--- a/scrapers/ca/__init__.py
+++ b/scrapers/ca/__init__.py
@@ -434,6 +434,14 @@ class California(State):
             "end_date": "2026-11-30",
             "active": True,
         },
+        {
+            "classification": "special",
+            "identifier": "20252026 Special Session 1",
+            "name": "2025-2026, Special Session 1",
+            "start_date": "2024-12-02",
+            "end_date": "2024-12-02",
+            "active": True,
+        },
     ]
     ignored_scraped_sessions = [
         "2013-2014",


### PR DESCRIPTION
Weirdly CA has a special session overlapping with the start of regular session https://www.gov.ca.gov/2024/11/07/special-session-ca-values/