### PR TITLE
CA: set inactive 2025 special session 1

### DIFF
--- a/scrapers/ca/__init__.py
+++ b/scrapers/ca/__init__.py
@@ -440,7 +440,7 @@ class California(State):
             "name": "2025-2026, Special Session 1",
             "start_date": "2024-12-02",
             "end_date": "2024-12-02",
-            "active": True,
+            "active": False,
         },
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
Having special session enabled - even though scrape of 2025 session yields special session bills - causes empty scrape errors. Haven't sussed out the logic issue yet, so want to get this out to at least get the 2025 regular data in.