### PR TITLE
FL: disable TLS/SSL verification on another URL

### DIFF
--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -145,7 +145,7 @@ class BillDetail(HtmlPage):
     example_source = "https://flsenate.gov/Session/Bill/2021/1"
 
     def get_source_from_input(self):
-        return self.input.sources[0]["url"]
+        return URL(self.input.sources[0]["url"], verify=False)
 
     def process_page(self):
         if self.root.xpath("//div[@id = 'tabBodyBillHistory']//table"):


### PR DESCRIPTION
FL started to throw TLS validation errors on another URL, so disabling again.