### PR TITLE
Jan 1 Session Additions

### DIFF
--- a/scrapers/ct/__init__.py
+++ b/scrapers/ct/__init__.py
@@ -117,6 +117,14 @@ class Connecticut(State):
             "end_date": "2024-05-08",
             "active": True,
         },
+        {
+            "_scraped_name": "2025",
+            "identifier": "2025",
+            "name": "2025 Regular Session",
+            "start_date": "2025-01-04",
+            "end_date": "2025-05-08",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "1991",

--- a/scrapers/ct/__init__.py
+++ b/scrapers/ct/__init__.py
@@ -121,8 +121,8 @@ class Connecticut(State):
             "_scraped_name": "2025",
             "identifier": "2025",
             "name": "2025 Regular Session",
-            "start_date": "2025-01-04",
-            "end_date": "2025-05-08",
+            "start_date": "2025-01-08",
+            "end_date": "2025-06-04",
             "active": False,
         },
     ]

--- a/scrapers/dc/__init__.py
+++ b/scrapers/dc/__init__.py
@@ -62,6 +62,14 @@ class DistrictOfColumbia(State):
             "end_date": "2024-12-31",
             "active": True,
         },
+        {
+            "_scraped_name": "26",
+            "identifier": "26",
+            "name": "26th Council Period (2025-2026)",
+            "start_date": "2025-01-02",
+            "end_date": "2025-12-31",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "18",

--- a/scrapers/ma/__init__.py
+++ b/scrapers/ma/__init__.py
@@ -15,6 +15,24 @@ class Massachusetts(State):
     }
     legislative_sessions = [
         {
+            "_scraped_name": "184th",
+            "classification": "primary",
+            "identifier": "184th",
+            "name": "184th Legislature (2007-2008)",
+            "start_date": "2005-01-01",  # est
+            "end_date": "2006-07-31",  # est
+            "active": False,
+        },
+        {
+            "_scraped_name": "185th",
+            "classification": "primary",
+            "identifier": "185th",
+            "name": "185th Legislature (2007-2008)",
+            "start_date": "2007-01-01",  # est
+            "end_date": "2008-07-31",  # est
+            "active": False,
+        },
+        {
             "_scraped_name": "186th",
             "classification": "primary",
             "identifier": "186th",
@@ -81,7 +99,7 @@ class Massachusetts(State):
             "active": True,
         },
     ]
-    ignored_scraped_sessions = []
+    ignored_scraped_sessions = ["185th"]
 
     def get_session_list(self):
         doc = lxml.html.fromstring(

--- a/scrapers/ny/__init__.py
+++ b/scrapers/ny/__init__.py
@@ -69,6 +69,14 @@ class NewYork(State):
             "name": "2023 Regular Session",
             "start_date": "2023-01-04",
             "end_date": "2024-06-06",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2025",
+            "identifier": "2025-2026",
+            "name": "2025 Regular Session",
+            "start_date": "2025-01-08",
+            "end_date": "2026-12-31",
             "active": True,
         },
     ]

--- a/scrapers/ri/__init__.py
+++ b/scrapers/ri/__init__.py
@@ -118,6 +118,15 @@ class RhodeIsland(State):
             "end_date": "2024-06-30",
             "active": True,
         },
+        {
+            "_scraped_name": "2025",
+            "classification": "primary",
+            "identifier": "2025",
+            "name": "2025 Regular Session",
+            "start_date": "2025-01-02",
+            "end_date": "2025-06-30",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         "2015",


### PR DESCRIPTION
Adds prefiles for NY, some historical MA sessions, and placeholder sessions for CT, DC, and RI.