### PR TITLE
TX: votes: fix session year selection bug

### DIFF
--- a/scrapers/tx/votes.py
+++ b/scrapers/tx/votes.py
@@ -639,15 +639,11 @@ class TXVoteScraper(Scraper):
             yield vote
 
     def get_session_year(self, session):
-        if "R" in session:
-            session_num = session.strip("R")
-        else:
-            session_num = session
         session_instance = next(
             (
                 s
                 for s in self.jurisdiction.legislative_sessions
-                if s["identifier"] == session_num
+                if s["identifier"] == session or s["identifier"] == session.strip("R")
             ),
             None,
         )


### PR DESCRIPTION
@showerst well I broke the session naming convention in TX for this year (`89R` instead of `89`). Was that a dumb decision? I'd like to blame it on late night coding or something but the commit log says otherwise. 

Think I should revert the session identifier to `89` or do this fix (and any other likely following ones to adjust other assumptions about the session identifier string)?