### PR TITLE
USA: 119th congress

### DIFF
--- a/scrapers/usa/__init__.py
+++ b/scrapers/usa/__init__.py
@@ -65,10 +65,18 @@ class UnitedStates(State):
             "name": "118th Congress",
             "start_date": "2023-01-03",
             "end_date": "2025-01-03",
+            "active": False,
+        },
+        {
+            "classification": "primary",
+            "identifier": "119",
+            "name": "119th Congress",
+            "start_date": "2025-01-03",
+            "end_date": "2027-01-03",
             "active": True,
         },
     ]
     ignored_scraped_sessions = []
 
     def get_session_list(self):
-        return ["112", "113", "114", "115", "116", "117", "118"]
+        return ["112", "113", "114", "115", "116", "117", "118", "119"]

--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -302,6 +302,17 @@ class USBillScraper(Scraper):
                     self.warning(f"Skipping action with no source: {action_text}")
                     continue
 
+                action_type = self.get_xpath(row, "type")
+                actor = "lower"
+                if "Senate" in source:
+                    actor = "upper"
+                elif "House" in source:
+                    actor = "lower"
+                elif action_type == "BecameLaw" or action_type == "President":
+                    actor = "executive"
+                elif action_type == "Committee":
+                    continue
+
                 # house actions give a time, senate just a date
                 if row.findall("actionTime"):
                     action_date = f"{self.get_xpath(row, 'actionDate')} {self.get_xpath(row, 'actionTime')}"
@@ -322,16 +333,6 @@ class USBillScraper(Scraper):
                 if classification is None:
                     classification = self.classify_action_by_name(action_text)
 
-                action_type = self.get_xpath(row, "type")
-                actor = "lower"
-                if "Senate" in source:
-                    actor = "upper"
-                elif "House" in source:
-                    actor = "lower"
-                elif action_type == "BecameLaw" or action_type == "President":
-                    actor = "executive"
-                elif action_type == "Committee":
-                    continue
                 # LOC doesn't make the actor clear, but you can back into it
                 # from the actions
                 if source == "Library of Congress":


### PR DESCRIPTION
Moved chamber check higher to avoid a committee action that was blowing up the actions parser. TODO: sometimes those committee actions apparently do contain unique information, how do we parse the chamber out of them correctly and avoid dupes? See 

https://www.govinfo.gov/bulkdata/BILLSTATUS/119/hres/BILLSTATUS-119hres10.xml
https://www.congress.gov/bill/119th-congress/house-resolution/10/all-actions