### PR TITLE
MA: Fix invalid 194th session end date

### DIFF
--- a/scrapers/ma/__init__.py
+++ b/scrapers/ma/__init__.py
@@ -104,7 +104,7 @@ class Massachusetts(State):
             "identifier": "194th",
             "name": "194th Legislature (2025-2026)",
             "start_date": "2025-01-01",
-            "end_date": "2025-11-31",  # est
+            "end_date": "2026-07-31",
             "active": True,
         },
     ]


### PR DESCRIPTION
Massachusetts: The 194th session end date had an invalid date of 2025-11-31. This was changed to the correct end date of 2026-07-31. Here's the source of that information:
https://malegislature.gov/ClerksOffice/Senate/Deadlines