### PR TITLE
NH: bills: fix broken request for resolution details page

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -1,6 +1,7 @@
 import re
 import datetime as dt
 from collections import defaultdict
+
 import pytz
 
 import lxml.html
@@ -136,7 +137,7 @@ class NHBillScraper(Scraper):
                     # ex: HR 1 is lsr=847 but version id=838
                     resolution_url = (
                         "https://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?"
-                        + "lsr={}&sy={}&txtsessionyear={}".format(lsr, session, session)
+                        + "lsr={}&sy={}&txtsessionyear={}&txtbillnumber={}".format(lsr, session, session, bill_id)
                     )
                     resolution_page = self.get(
                         resolution_url, allow_redirects=True

--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -137,7 +137,9 @@ class NHBillScraper(Scraper):
                     # ex: HR 1 is lsr=847 but version id=838
                     resolution_url = (
                         "https://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?"
-                        + "lsr={}&sy={}&txtsessionyear={}&txtbillnumber={}".format(lsr, session, session, bill_id)
+                        + "lsr={}&sy={}&txtsessionyear={}&txtbillnumber={}".format(
+                            lsr, session, session, bill_id
+                        )
                     )
                     resolution_page = self.get(
                         resolution_url, allow_redirects=True


### PR DESCRIPTION
NH scraper was failing on HTTP errors trying to reach URLs such as https://www.gencourt.state.nh.us/bill_status/legacy/bs2016/bill_status.aspx?lsr=0174&sy=2025&txtsessionyear=2025

Server would display "Server Error in '/bill_status/Legacy/BS2016' Application."

Seems like adding another query param fixes it (following example from clicking Bill Status link on https://www.gencourt.state.nh.us/bill_status/legacy/bs2016/)