### PR TITLE
HI: Set 2025 to live, and update scraper to use data site

### DIFF
--- a/scrapers/hi/__init__.py
+++ b/scrapers/hi/__init__.py
@@ -106,6 +106,14 @@ class Hawaii(State):
             "name": "2024 Regular Session",
             "start_date": "2024-01-17",
             "end_date": "2024-05-02",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2025",
+            "identifier": "2025",
+            "name": "2025 Regular Session",
+            "start_date": "2025-01-17",
+            "end_date": "2025-05-02",
             "active": True,
         },
     ]
@@ -127,7 +135,7 @@ class Hawaii(State):
 
     def get_session_list(self):
         response = requests.get(
-            "https://www.capitol.hawaii.gov/session/archives/main.aspx", verify=False
+            "https://data.capitol.hawaii.gov/session/archives/main.aspx", verify=False
         ).content
         page = lxml.html.fromstring(response)
         # page doesn't include current session, we need to add it

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -208,11 +208,13 @@ class HIBillScraper(Scraper):
                 # some bills (and GMs) swap the order or double-link to the same format
                 # so detect the type, and ignore dupes
                 bill.add_version_link(
-                    name, http_link, media_type=self.classify_media(http_link)
+                    name,
+                    make_data_url(http_link),
+                    media_type=self.classify_media(http_link),
                 )
                 bill.add_version_link(
                     name,
-                    pdf_link,
+                    make_data_url(pdf_link),
                     media_type=self.classify_media(pdf_link),
                     on_duplicate="ignore",
                 )

--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -3,7 +3,7 @@ import lxml.html
 import re
 from openstates.scrape import Scraper, Bill, VoteEvent
 from .actions import Categorizer, find_committee
-from .utils import get_short_codes
+from .utils import get_short_codes, make_data_url
 from urllib import parse as urlparse
 import dateutil
 import pytz
@@ -267,7 +267,7 @@ class HIBillScraper(Scraper):
             bill.add_document_link(name, filename, media_type=media_type)
 
     def scrape_bill(self, session, chamber, bill_type, url):
-        bill_html = self.get(url, verify=False).text
+        bill_html = self.get(make_data_url(url), verify=False).text
         bill_page = lxml.html.fromstring(bill_html)
         bill_page.make_links_absolute(url)
 
@@ -418,7 +418,7 @@ class HIBillScraper(Scraper):
             "gm": "proclamation",
         }[billtype]
 
-        list_html = self.get(report_page_url, verify=False).text
+        list_html = self.get(make_data_url(report_page_url), verify=False).text
         list_page = lxml.html.fromstring(list_html)
         for bill_url in list_page.xpath("//a[@class='report']"):
             bill_url = bill_url.attrib["href"].replace("www.", "")
@@ -449,7 +449,7 @@ class HIBillScraper(Scraper):
     def scrape_xml(self, session, day):
         url = "https://www.capitol.hawaii.gov/sessions/session2024/rss/"
         self.info(f"fetching url {url}")
-        page = self.get(url, verify=False).text
+        page = self.get(make_data_url(url), verify=False).text
         # this content isn't amenable to lxml, but it's machine generated so regex should be ok
         bill_re = r"(?P<date>\d+\/\d+\/\d+)\s+(?P<time>.*?)\s+\d+\s\<a href=\"(?P<url>.*?)\">(?P<filename>.*?)\.xml<\/a>"
         for match in re.finditer(bill_re, page, flags=re.IGNORECASE):

--- a/scrapers/hi/events.py
+++ b/scrapers/hi/events.py
@@ -1,12 +1,12 @@
 import datetime as dt
 from openstates.scrape import Scraper, Event
 from openstates.exceptions import EmptyScrape
-from .utils import get_short_codes
+from .utils import get_short_codes, make_data_url
 from requests import HTTPError
 import pytz
 import lxml
 
-URL = "https://capitol.hawaii.gov/upcominghearings.aspx"
+URL = "https://www.capitol.hawaii.gov/upcominghearings.aspx"
 
 TIMEZONE = pytz.timezone("Pacific/Honolulu")
 
@@ -18,8 +18,10 @@ class HIEventScraper(Scraper):
     def get_related_bills(self, href):
         ret = []
         try:
-            self.info(f"GET {href}")
-            page = lxml.html.fromstring(self.get(href, verify=False).content)
+            self.info(f"GET {make_data_url(href)}")
+            page = lxml.html.fromstring(
+                self.get(make_data_url(href), verify=False).content
+            )
         except HTTPError:
             return ret
 
@@ -46,14 +48,14 @@ class HIEventScraper(Scraper):
     def scrape(self):
 
         get_short_codes(self)
-        self.info(f"GET {URL}")
-        page = self.get(URL, verify=False).content
+        self.info(f"GET {make_data_url(URL)}")
+        page = self.get(make_data_url(URL), verify=False).content
         page = lxml.html.fromstring(page)
 
         if page.xpath("//td[contains(string(.),'No Hearings')]"):
             raise EmptyScrape
 
-        table = page.xpath("//table[@id='MainContent_GridView1']")[0]
+        table = page.xpath("//table[@id='ctl00_MainContent_GridView1']")[0]
 
         events = set()
         for event in table.xpath(".//tr")[1:]:

--- a/scrapers/hi/utils.py
+++ b/scrapers/hi/utils.py
@@ -1,6 +1,6 @@
 import lxml
 
-HI_URL_BASE = "https://www.capitol.hawaii.gov"
+HI_URL_BASE = "https://data.capitol.hawaii.gov"
 SHORT_CODES = f"{HI_URL_BASE}/legislature/committees.aspx?chamber=all"
 
 
@@ -25,3 +25,10 @@ def get_short_codes(scraper):
         else:
             chamber = "joint"
         scraper.short_ids[short_id] = {"chamber": chamber, "name": ctty_name}
+
+
+def make_data_url(url: str) -> str:
+    if "www" in url:
+        return url.replace("www.", "data.")
+    else:
+        return url.replace("capitol.", "data.capitol.")


### PR DESCRIPTION
I spoke to the Hawaii capitol webmaster, and it turns out they maintain a separate mirror of the website that's not behind cloudflare. https://data.capitol.hawaii.gov/

I swapped in that url for the scrapers, but left the source URLs pointing to the originals. I was a little torn with what to do with versions, but since I figure they'll usually need downstream processing I went ahead and linked to the cloudflare free version.

This also activates 2025, because they've got some prefiles up.

@jessemortenson tag FYI.