### PR TITLE
ID: events: make links absolute

### DIFF
--- a/scrapers/id/events.py
+++ b/scrapers/id/events.py
@@ -31,6 +31,7 @@ class IDEventScraper(Scraper):
 
         page = self.get(url).content
         page = lxml.html.fromstring(page)
+        page.make_links_absolute(url)
 
         if page.xpath(
             "//div[@id='allDiv' and contains(text(),'No meetings scheduled')]"


### PR DESCRIPTION
Apparently events don't validate that attachment urls are not relative? 