### PR TITLE
MI Events: Update participants name cleanup

### DIFF
--- a/scrapers/mi/events.py
+++ b/scrapers/mi/events.py
@@ -47,7 +47,7 @@ class MIEventScraper(Scraper):
             chamber = "Senate"
         elif "rep." in chair.lower():
             chamber = "House"
-        chair = chair.split(".")[-1].strip()
+        chair = chair.replace("Rep. ", "").replace("Sen. ", "").strip()
 
         where = self.table_cell("Location")
         if where == "":


### PR DESCRIPTION
Name format changes in some cases for Chair. Just going to drop `Sen. ` or `Rep. ` 
![image](https://github.com/user-attachments/assets/3b4d072d-e03c-4c45-9446-3cf2e96f9ed2)
