### PR TITLE
SC Events: Update Event location

### DIFF
--- a/scrapers/sc/events.py
+++ b/scrapers/sc/events.py
@@ -228,15 +228,15 @@ class SCEventScraper(Scraper):
                     self.event_keys.add(event_key)
 
                 location = location.replace(
-                    "Blatt", "Blatt Building, 1105 Pendleton St, Columbia, SC 29201"
+                    "Blatt", "Blatt Building, 1105 Pendleton St, Columbia, SC 29201", 1,
                 )
                 location = location.replace(
                     "Gressette",
-                    "Gressette Building, 1101 Pendleton St, Columbia, SC 29201",
+                    "Gressette Building, 1101 Pendleton St, Columbia, SC 29201", 1,
                 )
                 location = location.replace(
                     "State House",
-                    "South Carolina State House, 1100 Gervais St, Columbia, SC 29208",
+                    "South Carolina State House, 1100 Gervais St, Columbia, SC 29208", 1,
                 )
 
                 event = Event(

--- a/scrapers/sc/events.py
+++ b/scrapers/sc/events.py
@@ -228,15 +228,19 @@ class SCEventScraper(Scraper):
                     self.event_keys.add(event_key)
 
                 location = location.replace(
-                    "Blatt", "Blatt Building, 1105 Pendleton St, Columbia, SC 29201", 1,
+                    "Blatt",
+                    "Blatt Building, 1105 Pendleton St, Columbia, SC 29201",
+                    1,
                 )
                 location = location.replace(
                     "Gressette",
-                    "Gressette Building, 1101 Pendleton St, Columbia, SC 29201", 1,
+                    "Gressette Building, 1101 Pendleton St, Columbia, SC 29201",
+                    1,
                 )
                 location = location.replace(
                     "State House",
-                    "South Carolina State House, 1100 Gervais St, Columbia, SC 29208", 1,
+                    "South Carolina State House, 1100 Gervais St, Columbia, SC 29208",
+                    1,
                 )
 
                 event = Event(


### PR DESCRIPTION
If there are multiple event locations like this  `Blatt Room 112 And Breakout Rooms: Blatt 108, Blatt 305 Blatt 317, Blatt 318, Blatt 321,` lets just replace only one Blatt with the full address.