### PR TITLE
WV Event: Ignore test event page

### DIFF
--- a/scrapers/wv/events.py
+++ b/scrapers/wv/events.py
@@ -86,6 +86,10 @@ class WVEventScraper(Scraper, LXMLMixin):
         com = re.sub(r"[\s\-]+Agenda", "", com)
         when = page.xpath('//div[@id="wrapleftcol"]/h1[1]/text()')[0].strip()
 
+        if when == "test, test":
+            # Ignore test page
+            return
+
         if "time to be announced" in when.lower() or "tba" in when.lower():
             when = re.sub("time to be announced", "", when, flags=re.IGNORECASE)
             when = re.sub("TBA", "", when, flags=re.IGNORECASE)


### PR DESCRIPTION
There is a test event [page](http://www.wvlegislature.gov/committees/senate/senate_com_agendas.cfm?input=test&Chart=enb) we should be ignoring