### PR TITLE
Add FL 2025 special session C

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -243,6 +243,14 @@ class Florida(State):
             "end_date": "2025-12-31",  # est
             "active": True,
         },
+        {
+            "name": "2025 Special Session C",
+            "identifier": "2025C",
+            "classification": "special",
+            "start_date": "2025-02-11",
+            "end_date": "2025-12-31",  # est
+            "active": True,
+        },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),


### PR DESCRIPTION
Added FL 2025 Special Session C. [Started Noon today ](https://www.flsenate.gov/PublishedContent/Offices/2024-2026/President/Documents/Special_Session_C_Combined_Files.pdf)