### PR TITLE
CA: Update Dockerfile

### DIFF
--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -52,7 +52,7 @@ RUN poetry install --no-root
 ADD . /opt/openstates/openstates/
 
 # the last step cleans out temporarily downloaded artifacts for poetry, shrinking our build
-RUN poetry install --extras "california" \
+RUN poetry install --extras --no-root "california" \
     && rm -r /root/.cache/pypoetry/cache /root/.cache/pypoetry/artifacts/ \
     && apt-get remove -y -qq \
       build-essential \


### PR DESCRIPTION
Seem Dockerfile.california is failing `Error: The current project could not be installed: No file/folder found for package openstates-scrapers`. Adding `--no-root`. CC: @jessemortenson 