### PR TITLE
xlmlize utilities should respect VERIFY_CERTS

### DIFF
--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -4,8 +4,12 @@ import logging
 import os
 
 
-def url_xpath(url, path, verify=False, user_agent=None):
+def url_xpath(url, path, verify=None, user_agent=None):
     headers = {"user-agent": user_agent} if user_agent else None
+
+    if verify is None:
+        verify = os.getenv("VERIFY_CERTS", "True").lower() == "true"
+
     res = requests.get(url, verify=verify, headers=headers)
     try:
         doc = lxml.html.fromstring(res.text)

--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -1,9 +1,10 @@
 import requests
 import lxml.html
 import logging
+import os
 
 
-def url_xpath(url, path, verify=True, user_agent=None):
+def url_xpath(url, path, verify=False, user_agent=None):
     headers = {"user-agent": user_agent} if user_agent else None
     res = requests.get(url, verify=verify, headers=headers)
     try:
@@ -21,7 +22,7 @@ def url_xpath(url, path, verify=True, user_agent=None):
 class LXMLMixin(object):
     """Mixin for adding LXML helper functions to Open States code."""
 
-    def lxmlize(self, url, raise_exceptions=False, verify=True):
+    def lxmlize(self, url, raise_exceptions=False, verify=None):
         """Parses document into an LXML object and makes links absolute.
 
         Args:
@@ -29,6 +30,9 @@ class LXMLMixin(object):
         Returns:
             Element: Document node representing the page.
         """
+        if verify is None:
+            verify = os.getenv("VERIFY_CERTS", "True").lower() == "true"
+
         try:
             # This class is always mixed into subclasses of `Scraper`,
             # which have a `get` method defined.


### PR DESCRIPTION
The shortcut methods for grabbing urls (self.lxmlize and url_xpath) weren't checking for a `VERIFY_CERTS` env var, so you couldn't globally set verify to false using the env var in the scrapers that used these methods. This should fix that that.

@jessemortenson courtesy ping, i'm changing the default function args for lxmlize and url_xpath from True to None, but then defaulting the `verify` keyword to `True` lower down in the code, so behavior shouldn't change.