### PR TITLE
Log external IP of each scraper run to assist with debug

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -21,5 +21,14 @@ elif [[ -n "${GOOGLE_CREDENTIAL_FILE}" ]]; then
     export GOOGLE_APPLICATION_CREDENTIALS
 fi
 
+###
+# Print external IP used: helpful for debugging connectivity/IP-based blocks
+# both OS-level and requests library (in case requests is using proxy)
+###
+ip="$(curl -s --insecure -m 5 https://ipecho.net/plain)"
+printf "OS-level external IP for this scraper run is: %s\n" "$ip"
+poetry run python scripts/log_external_ip.py
+echo "Keep in mind IP may not be stable from request to request if using a proxy"
+
 # shellcheck disable=SC2048 disable=SC2086
 poetry run os-update $*

--- a/scripts/log_external_ip.py
+++ b/scripts/log_external_ip.py
@@ -1,0 +1,16 @@
+import requests
+import sys
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+def log_external_ip():
+    try:
+        response = requests.get("https://ipecho.net/plain", verify=False)
+        print(f"Requests lib external IP for this scraper run is: {response.text}")
+    except Exception as e:
+        print(f"Failed to obtain external IP used by requests library with error: {e}")
+
+if __name__ == "__main__":
+    log_external_ip()
+    sys.exit()


### PR DESCRIPTION
In this age of more states adding anti-bot measures to their web services, it seems like it could be useful to just have the external IP address used by the scraper logged out on every run. Florida just responded by asking for an IP address re: their blocking behavior this week, for example. 

I added two checks here, one using `curl` and one using python `requests` since there might be a difference if `HTTP_PROXY`/`HTTPS_PROXY` is set. 

I don't 100% love using a third party service (https://ipecho.net) but also that's a lot easier than having infra for our own. I tried to double check bash recommendations for securely operating on unknown content.

Making you as a reviewer here @showerst in case this would introduce any wrinkle/concerns for you.