### PR TITLE
KS: workaround for persistent 500 error on HCR 5011 from KS API

### DIFF
--- a/scrapers/ks/bills.py
+++ b/scrapers/ks/bills.py
@@ -46,7 +46,9 @@ class KSBillScraper(Scraper):
             # 500 error on HCR 5011 for some reason
             # temporarily swallow this exception to allow scrape to finish
             if bill_id == "HCR5011":
-                self.logger.warning(f"Swallowing HTTPError for {bill_id} as a temporary fix: {e}")
+                self.logger.warning(
+                    f"Swallowing HTTPError for {bill_id} as a temporary fix: {e}"
+                )
                 return
             else:
                 raise e


### PR DESCRIPTION
We've been seeing persistent 500 errors from this one API path over the last day, temporarily working around it

```
scrapelib.HTTPError: 500 while retrieving https://www.kslegislature.gov/li/api/v12/rev-1/bill_status/HCR5011/
```