### PR TITLE
MT: add abstain vote type, stop throwing exception on new types

### DIFF
--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -592,8 +592,10 @@ class MTBillScraper(Scraper):
                     vote.vote("absent", voter)
                 elif v[vote_type_key] == "EXCUSED":
                     vote.vote("excused", voter)
+                elif v[vote_type_key] == "ABSTAINED":
+                    vote.vote("abstain", voter)
                 else:
-                    self.error(v)
-                    raise NotImplementedError
+                    self.warning(f"Could not match vote {vote_id} option for legislator vote: {v}")
+                    vote.vote("other", voter)
 
             yield vote

--- a/scrapers/mt/bills.py
+++ b/scrapers/mt/bills.py
@@ -595,7 +595,9 @@ class MTBillScraper(Scraper):
                 elif v[vote_type_key] == "ABSTAINED":
                     vote.vote("abstain", voter)
                 else:
-                    self.warning(f"Could not match vote {vote_id} option for legislator vote: {v}")
+                    self.warning(
+                        f"Could not match vote {vote_id} option for legislator vote: {v}"
+                    )
                     vote.vote("other", voter)
 
             yield vote


### PR DESCRIPTION
MT scrapes are getting longer, so more painful to catch and restart when these random new vote codes pop up. At this point rather mistakenly categorize some into `other` than have scrapes fail.