### PR TITLE
Bump Openstates version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1551,13 +1551,13 @@ et-xmlfile = "*"
 
 [[package]]
 name = "openstates"
-version = "6.21.6"
+version = "6.22.0"
 description = "core infrastructure for the openstates project"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "openstates-6.21.6-py3-none-any.whl", hash = "sha256:bb7cca3fced222f6ef7c4af0edb6b8b5124a75014bc42b9b94c63217ef8759ad"},
-    {file = "openstates-6.21.6.tar.gz", hash = "sha256:23d6328fab6d0e626d2072df2a78a30362079801dc0c146bd6c0888c1d915350"},
+    {file = "openstates-6.22.0-py3-none-any.whl", hash = "sha256:ca4f35ce728104bb049f1ef26b6c086c0e65bce8678cec5cdec314a12c09a654"},
+    {file = "openstates-6.22.0.tar.gz", hash = "sha256:0ce7b3a19bec35f393a9e0d03e42b8839087887e8cc23996c69c2e4dea8e1a59"},
 ]
 
 [package.dependencies]

--- a/poetry.lock
+++ b/poetry.lock
@@ -183,32 +183,32 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.37.38"
+version = "1.38.1"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "boto3-1.37.38-py3-none-any.whl", hash = "sha256:b6d42803607148804dff82389757827a24ce9271f0583748853934c86310999f"},
-    {file = "boto3-1.37.38.tar.gz", hash = "sha256:88c02910933ab7777597d1ca7c62375f52822e0aa1a8e0c51b2598a547af42b2"},
+    {file = "boto3-1.38.1-py3-none-any.whl", hash = "sha256:f192a4a34885a9e3e970b5ce5e6bec947be0f3fe6c4693b2a737c14407b12a5a"},
+    {file = "boto3-1.38.1.tar.gz", hash = "sha256:988e7fae7fd4d59798f84604d73a3a019c07b048f746c7c40258c0e656473887"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.38,<1.38.0"
+botocore = ">=1.38.1,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.11.0,<0.12.0"
+s3transfer = ">=0.12.0,<0.13.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.38"
+version = "1.38.1"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "botocore-1.37.38-py3-none-any.whl", hash = "sha256:23b4097780e156a4dcaadfc1ed156ce25cb95b6087d010c4bb7f7f5d9bc9d219"},
-    {file = "botocore-1.37.38.tar.gz", hash = "sha256:c3ea386177171f2259b284db6afc971c959ec103fa2115911c4368bea7cbbc5d"},
+    {file = "botocore-1.38.1-py3-none-any.whl", hash = "sha256:b1673975e3c42d0e2d1804f9f73e88961e95eac371c8f8c0a0d7e661ec3c90c3"},
+    {file = "botocore-1.38.1.tar.gz", hash = "sha256:c2eb42eeaa502f236ba894a65ea7f7241711150cc450b9d59fbbad41e741adc0"},
 ]
 
 [package.dependencies]
@@ -2472,13 +2472,13 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "s3transfer"
-version = "0.11.5"
+version = "0.12.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "s3transfer-0.11.5-py3-none-any.whl", hash = "sha256:757af0f2ac150d3c75bc4177a32355c3862a98d20447b69a0161812992fe0bd4"},
-    {file = "s3transfer-0.11.5.tar.gz", hash = "sha256:8c8aad92784779ab8688a61aefff3e28e9ebdce43142808eaa3f0b0f402f68b7"},
+    {file = "s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18"},
+    {file = "s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c"},
 ]
 
 [package.dependencies]
@@ -2927,4 +2927,4 @@ california = ["SQLAlchemy", "mysqlclient"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "4be63569252b1f0e21e8e5b9b6cccde5f0244365465462fbfb814d3611b85654"
+content-hash = "3a2d9d6f43d8b8225de0f10ceda3f7cdf7548ab587648c62e65c96964a21c86d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ cryptography = "^37.0.2"
 ics = "^0.7.2"
 pymupdf = "^1.23.8"
 pandas = "^2.1.4"
-openstates = "^6.21.6"
+openstates = "^6.22.0"
 
 [tool.poetry.extras]
 california = ["mysqlclient", "SQLAlchemy"]


### PR DESCRIPTION
With this bump in `openstates` version, scraper output will now have metadata `jurisdiction` and `scraped_at` keys like;
```
...
"jurisdiction": {"id": "ocd-jurisdiction/country:us/state:al/government", "name": "Alabama", "classification": "state", "division_id": "ocd-division/country:us/state:al"},
"scraped_at": "2025-04-14T19:59:48+00:00",
...
```
See related [version](https://github.com/openstates/openstates-core/pull/171).
