### PR TITLE
CA: support GRP bill, make CA docker entrypoint more flexible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 *.pyc
 data
 _data
+scrapers/_data
 cache
 _cache
 pubinfo_*

--- a/scrapers/ca/bills.py
+++ b/scrapers/ca/bills.py
@@ -264,6 +264,7 @@ class CABillScraper(Scraper, LXMLMixin):
                 "SCR": "concurrent resolution",
                 "SJR": "joint resolution",
                 "SR": "resolution",
+                "GRP": "bill",
             },
         }
 

--- a/scrapers/ca/ca-entrypoint.sh
+++ b/scrapers/ca/ca-entrypoint.sh
@@ -8,4 +8,4 @@ set -e
 
 mysqld --user root --max_allowed_packet=512M &
 /opt/openstates/openstates/scrapers/ca/download.sh
-poetry run os-update ca $1
+poetry run os-update ca $*


### PR DESCRIPTION
GRP is not a chamber-specific bill type, so I have it associated with upper only so that it is not ingested twice. But that is a little arbitrary.