### PR TITLE
USA: Upgrade events with congress.gov data

### DIFF
--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -339,7 +339,7 @@ class USEventScraper(Scraper, LXMLMixin):
     def congress_gov_api(
         self, congress_num: str, chamber: str, event: Event, congress_gov_id: str
     ):
-        if os.environ["CONGRESS_GOV_API_KEY"]:
+        if os.environ.get("CONGRESS_GOV_API_KEY", None):
             url = f"https://api.congress.gov/v3/committee-meeting/{congress_num}/{chamber}/{congress_gov_id}"
             # using params instead of ? in the url to avoid logging api keys
             params = {"api_key": os.environ["CONGRESS_GOV_API_KEY"]}

--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -176,6 +176,10 @@ class USEventScraper(Scraper, LXMLMixin):
 
             event.add_source("https://www.senate.gov/committees/hearings_meetings.htm")
 
+            self.congress_gov_api(
+                "119", "senate", event, row.xpath("string(identifier)")
+            )
+
             yield event
 
     # window is an int of how many days out to scrape
@@ -342,7 +346,6 @@ class USEventScraper(Scraper, LXMLMixin):
                 return
 
             data = data["committeeMeeting"]
-            print(data)
             if "witnesses" in data:
                 for witness in data["witnesses"]:
                     event.add_participant(self.format_witness(witness), "person")
@@ -364,7 +367,8 @@ class USEventScraper(Scraper, LXMLMixin):
     def add_documents_from_api(self, event: Event, docs: dict):
         seen_docs = {}
         for doc in docs:
-            print(doc)
+            if "url" not in doc:
+                continue
             if "name" in doc:
                 event.add_document(
                     doc["name"],

--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -176,8 +176,15 @@ class USEventScraper(Scraper, LXMLMixin):
 
             event.add_source("https://www.senate.gov/committees/hearings_meetings.htm")
 
+            if event_date.date() > datetime.date(
+                2025, 1, 3
+            ) and event_date.date() < datetime.date(2027, 1, 3):
+                congress_num = 119
+            else:
+                self.error("Code a congress number here.")
+
             self.congress_gov_api(
-                "119", "senate", event, row.xpath("string(identifier)")
+                congress_num, "senate", event, row.xpath("string(identifier)")
             )
 
             yield event
@@ -323,7 +330,9 @@ class USEventScraper(Scraper, LXMLMixin):
         event_id_matches = re.findall(r"EventID=(\d+)", source_url, re.IGNORECASE)
         if event_id_matches:
             event.extras["CONGRESS_GOV_EVENT_ID"] = event_id_matches[0]
-            self.congress_gov_api("119", "house", event, event_id_matches[0])
+
+            congress_num = xml.xpath("@congress-num")[0]
+            self.congress_gov_api(congress_num, "house", event, event_id_matches[0])
 
         yield event
 

--- a/scrapers/usa/events.py
+++ b/scrapers/usa/events.py
@@ -374,6 +374,7 @@ class USEventScraper(Scraper, LXMLMixin):
                     doc["name"],
                     doc["url"],
                     media_type=self.media_types[doc["format"].strip()],
+                    on_duplicate="ignore",
                 )
             elif doc["documentType"] not in seen_docs:
                 # "Witness Statement"
@@ -381,6 +382,7 @@ class USEventScraper(Scraper, LXMLMixin):
                     doc["documentType"],
                     doc["url"],
                     media_type=self.media_types[doc["format"].strip()],
+                    on_duplicate="ignore",
                 )
                 seen_docs[doc["documentType"]] = 1
             else:
@@ -393,6 +395,7 @@ class USEventScraper(Scraper, LXMLMixin):
                     doc_name,
                     doc["url"],
                     media_type=self.media_types[doc["format"].strip()],
+                    on_duplicate="ignore",
                 )
 
     def format_witness(self, witness: dict) -> str:


### PR DESCRIPTION
The US events scraper now pulls additional hearing testimonies, witness lists, and (where available) video links, if passed a congress.gov api key.

@jessemortenson ping. `CONGRESS_GOV_API_KEY` is the ENV var to trigger the new behavior.