### PR TITLE
HI: events: fix URL for hearings list

### DIFF
--- a/scrapers/hi/events.py
+++ b/scrapers/hi/events.py
@@ -6,7 +6,7 @@ from requests import HTTPError
 import pytz
 import lxml
 
-URL = "https://www.capitol.hawaii.gov/upcominghearings.aspx"
+URL = "https://www.capitol.hawaii.gov/session/upcominghearings.aspx"
 
 TIMEZONE = pytz.timezone("Pacific/Honolulu")
 


### PR DESCRIPTION
 (prior now giving 500 on "data" site, whereas the "www" redirects to this updated URL)