### PR TITLE
DC: fix API url from http to https

### DIFF
--- a/scrapers/dc/__init__.py
+++ b/scrapers/dc/__init__.py
@@ -94,7 +94,7 @@ class DistrictOfColumbia(State):
             "User-Agent": useragent,
         }
         resp = requests.get(
-            "http://lims.dccouncil.gov/api/v2/PublicData/CouncilPeriods",
+            "https://lims.dccouncil.gov/api/v2/PublicData/CouncilPeriods",
             headers=headers,
             verify=False,
         )

--- a/scrapers/dc/utils.py
+++ b/scrapers/dc/utils.py
@@ -2,7 +2,7 @@ import json
 import requests
 
 
-API_BASE_URL = "http://lims.dccouncil.us/_layouts/15/uploader/AdminProxy.aspx"
+API_BASE_URL = "https://lims.dccouncil.us/_layouts/15/uploader/AdminProxy.aspx"
 API_HEADERS = {"Content-Type": "application/json", "User-Agent": "openstates"}
 
 


### PR DESCRIPTION
Apparently the source of those 523 errors was hitting the API at `http` !!!!