### PR TITLE
NV: update index url

### DIFF
--- a/scrapers/nv/bills.py
+++ b/scrapers/nv/bills.py
@@ -117,10 +117,10 @@ class SubjectMapping(HtmlPage):
     def get_source_from_input(self):
         session = self.input["session"]
         slug = session_slugs[session]
-        year = slug[4:]
+        # year = slug[4:]
         url = (
             f"https://www.leg.state.nv.us/Session/{slug}/Reports/"
-            f"TablesAndIndex/{year}_{session}-index.html"
+            f"TablesAndIndex/index.html"
         )
         return url
 


### PR DESCRIPTION
I think current session now `https://www.leg.state.nv.us/Session/{slug}/Reports/TablesAndIndex/index.html` instead of `https://www.leg.state.nv.us/Session/{slug}/Reports/TablesAndIndex/{year}_{session}-index.html`. However, the previous sessions still maintain the latter format. Going to merge this for quick resolution. @jessemortenson 