### PR TITLE
VA: bills: include 'unsuccessful' bills in all scrapes

### DIFF
--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -56,7 +56,8 @@ class VaBillScraper(Scraper):
             "Accept": "application/json",
         }
 
-        body = {"SessionCode": self.session_code}
+        # If we don't IncludeFailed, we will only get a subset of legislation
+        body = {"SessionCode": self.session_code, "IncludeFailed": True}
 
         page = requests.post(
             f"{self.base_url}/Legislation/api/getlegislationlistasync",


### PR DESCRIPTION
Without this flag, our scrapes have been returning a set of bills that omits the "unsuccessful" ones. THis probably wasn't a huge deal because I presume not many of those bills got new activity after becoming unsuccessful, but still we should be getting full data here.