### PR TITLE
CA: bills: handle StopIteration when scraping different bill types

### DIFF
--- a/scrapers/ca/bills.py
+++ b/scrapers/ca/bills.py
@@ -270,7 +270,10 @@ class CABillScraper(Scraper, LXMLMixin):
 
         for chamber in chambers:
             for abbr, type_ in bill_types[chamber].items():
-                yield from self.scrape_bill_type(chamber, session, type_, abbr)
+                try:
+                    yield from self.scrape_bill_type(chamber, session, type_, abbr)
+                except StopIteration:
+                    continue
 
     def scrape_bill_type(
         self,


### PR DESCRIPTION
CA bills scraper started failing on an unhandled StopIteration exception. Dug around a bit and didn't really find a real problem, honestly don't 100% understand what changed here. With this change the scraper runs through and seems to return the expected number of bills.