### PR TITLE
CA: dockerfile failing to build, update libgdal version

### DIFF
--- a/Dockerfile.california
+++ b/Dockerfile.california
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
       unzip \
       mdbtools \
       libpq5 \
-      libgdal32 \
+      libgdal36 \
       libmariadb-dev \
       mariadb-server \
       mariadb-client \


### PR DESCRIPTION
Starting seeing `Unable to locate package libgdal32` in Docker build for the California dockerfile