### PR TITLE
NM: bills: stop skipping PDF links for introduced bill versions

### DIFF
--- a/scrapers/nm/bills.py
+++ b/scrapers/nm/bills.py
@@ -522,13 +522,9 @@ class NMBillScraper(Scraper):
             # Delete any errant words found following the file name
             fname = fname.split(" ")[0]
 
-            # skip PDFs for now -- everything but votes have HTML versions
-            if fname.endswith("pdf") and "VOTE" not in fname:
-                continue
-
             match = re.match(r"([A-Z]+)0*(\d{1,4})([^.]*)", fname.upper())
             if match is None:
-                self.warning("No match, skipping")
+                self.warning(f"No match, skipping {fname.upper()}")
                 continue
 
             bill_type, bill_num, suffix = match.groups()


### PR DESCRIPTION
Status quo code would yield, for some bills, an "introduced version" that only had an HTML link (no PDF link to the same version). Code was skipping PDFs in `scrape_documents()`, but it's not clear to me why. 

Running the scraper without that skip-PDF logic goes fine, and yields both the PDF + HTML source links for each version.
