### PR TITLE
DC: bills: fix bug when handling uppercase file extension

### DIFF
--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -93,7 +93,7 @@ class DCBillScraper(Scraper):
 
                         mimetype = (
                             "application/pdf"
-                            if ".pdf" in download
+                            if ".pdf" in download.lower()
                             else get_media_type(download)
                         )
                         is_version = False


### PR DESCRIPTION
`ValueError: could not guess mimetype for https://lims.dccouncil.gov/downloads/LIMS/57926/Committee_Report/PR26-0227-Committee_Report1.PDF?Id=223730, set default`