### PR TITLE
MA: bills: allow scrape scope to be split into equal chunks

### DIFF
--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -1,7 +1,6 @@
 import re
 import requests
 
-requests.packages.urllib3.disable_warnings()
 import os
 import json
 from datetime import datetime
@@ -10,6 +9,9 @@ from openstates.scrape import Scraper, Bill, VoteEvent
 from openstates.utils import convert_pdf
 
 from .actions import Categorizer
+
+
+requests.packages.urllib3.disable_warnings()
 
 
 class MABillScraper(Scraper):


### PR DESCRIPTION
MA has been failing for us more than usual. It's a really long running job with a lot of requests, and we just get intermittent HTTP connection problems that end up scotching the whole run frequently. My goal here is to provide an option (via CLI argument) that can run just 1/12th of the scrape, thus reducing the impact of a particular failure and improving time to recover from that failure.

So that new argument is `scrape_chunk_number=1`, `scrape_chunk_number=2` ... `scrape_chunk_number=12`

Other changes:

1. Noticed that a decent number of request retries happen on URLs like https://malegislature.gov/Bills/194/HD903 (the "Oh My Cod!" error page, which actually comes back with a 500 HTTP code, so it doesn't hit the scrapelib "don't retry on 404" thing. So changed to 0 retries on this scraper to try to speed up and reduce unnecessary requests. That might cause issues? not sure but seems OK so far
2. Disable SSL verification warnings, which on a long scrape just make log a lot of waste.