### PR TITLE
UT: bills: add committee names to referral action descriptions, better doc handling

### DIFF
--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -37,20 +37,20 @@ class UTBillScraper(Scraper, LXMLMixin):
     _TZ = pytz.timezone("America/Denver")
 
     def scrape(self, session=None, chamber=None):
-        # if you need to test on an individual bill...
-        # yield from self.scrape_bill(
-        #             chamber='lower',
-        #             session='2019',
-        #             bill_id='H.B. 87',
-        #             url='https://le.utah.gov/~2019/bills/static/HB0087.html'
-        #         )
-
         if session in SPECIAL_SLUGS:
             session_slug = SPECIAL_SLUGS[session]
         elif "S" in session:
             session_slug = session
         else:
             session_slug = "{}GS".format(session)
+
+        # if you need to test on an individual bill...
+        # yield from self.scrape_bill(
+        #             'lower',
+        #             '2019',
+        #             'https://le.utah.gov/~2025/bills/static/SR0002.html',
+        #             session_slug,
+        #         )
 
         session_url = "https://le.utah.gov/billlist.jsp?session={}".format(session_slug)
 
@@ -292,12 +292,16 @@ class UTBillScraper(Scraper, LXMLMixin):
                             bill.add_document_link(
                                 doc_data["shortDesc"], doc_url, media_type="text/xml"
                             )
-                        pdf_filepath = doc_url.replace(".xml", ".pdf")
-                        bill.add_document_link(
-                            doc_data["shortDesc"],
-                            pdf_filepath,
-                            media_type="application/pdf",
-                        )
+                        elif doc_url.lower().endswith("pdf"):
+                            bill.add_document_link(
+                                doc_data["shortDesc"],
+                                doc_url,
+                                media_type="application/pdf",
+                            )
+                        else:
+                            self.warning(
+                                f"Encountered unexpected document type for {doc_url}"
+                            )
 
         for subject in subjects:
             bill.add_subject(subject)


### PR DESCRIPTION
fyi @showerst this changes some UT behavior on actions and versions/docs, tagging in case any is sensitive for you.

1.  Action description for committee referral actions in UT now include `[COMMITTEE_NAME]` at the end, like `House/ to standing committee [House Government Operations Committee]`. Seems like prior version of the UT scraper did include committee names in the description. Current UT website has the committee name as the `owner` property, but it is displayed right next to the action in the public-facing website, so I feel this is a little more faithful.
2. Tries to make the version vs. document handling a little more precise (it was a TODO in comments). Pulls out things like fiscal note, transmission letter, and comparison of substitute to bill as documents (no longer treated as versions). It's a little weird because a lot of those URLs seem to 403 when accessed directly (vs. embedded in their site). THe "comparison to" documents could arguably be versions, but they also contain a disclaimer like "this is not the bill, you have to read the bill version itself also" ... so ....