### PR TITLE
MD committees: make lists discoverable to os-scrape, tweak name normalization

### DIFF
--- a/scrapers_next/md/committees.py
+++ b/scrapers_next/md/committees.py
@@ -1,3 +1,5 @@
+import re
+
 from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, URL
 from openstates.models import ScrapeCommittee
 
@@ -40,6 +42,10 @@ class CommitteeDetails(HtmlPage):
         for prefix in joint_prefixes:
             if name.startswith(prefix):
                 name = name.replace(prefix, "")
+
+        # Remove prefix from numbered committees
+        if name.startswith("No. "):
+            name = re.sub(r"No\. \d+ - ", "", name).strip()
 
         self.com = ScrapeCommittee(
             name=name,


### PR DESCRIPTION
See openstates/issues#1344

MD committee data is out-of-date on v3.openstates.org, but the commitee scraper appears to still work well.

One guess I have as to the cause is that running `os-scrape md committees` results in `ERROR spatula: found no list pages in module scrapers_next.md.committees`. This PR switches to uses spatula's `ListPage` in order to make the scraper classes discoverable, and the `os-scrape` command now appears to work for me.