### PR TITLE
NC: add 2025 extra session, inactive for now

### DIFF
--- a/scrapers/nc/__init__.py
+++ b/scrapers/nc/__init__.py
@@ -373,6 +373,15 @@ class NorthCarolina(State):
             "end_date": "2025-07-01",
             "active": True,
         },
+        {
+            "_scraped_name": "2025 Special Session",
+            "classification": "special",
+            "identifier": "2025E1",
+            "name": "2025 Extra Session",
+            "start_date": "2025-11-17",
+            "end_date": "2025-12-01",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = []
 


### PR DESCRIPTION
Scheduled to start Nov 17 so we'll need to check closer to then to activate this. Running with active at this point just hangs, I think the HTTP endpoint isn't working for that session yet.