### PR TITLE
CT: bills: handle missing bill history from bulk file

### DIFF
--- a/scrapers/ct/bills.py
+++ b/scrapers/ct/bills.py
@@ -148,6 +148,10 @@ class CTBillScraper(Scraper):
 
     def scrape_actions(self, bill: Bill, initial_chamber: str):
 
+        if bill.identifier not in self.action_list:
+            self.warning(f"Missing bill actions from FTP source for {bill.identifier}")
+            return
+
         actions = self.action_list[bill.identifier]
         actions.sort(key=itemgetter("act_date"))
         act_chamber = initial_chamber


### PR DESCRIPTION
Seems like the action history is just missing for at least one bill. Making it a warning for now, so we can see if the problem is more extensive and might require other mitigation.

error
```
			[2025-11-13, 05:41:06 UTC] {pod_manager.py:479} INFO - [base]   File "/opt/openstates/openstates/scrapers/ct/bills.py", line 151, in scrape_actions
			[2025-11-13, 05:41:06 UTC] {pod_manager.py:479} INFO - [base]     actions = self.action_list[bill.identifier]
			[2025-11-13, 05:41:11 UTC] {pod_manager.py:498} INFO - [base] KeyError: 'SJ00101'
```