### PR TITLE
Add Maryland 2026 Regular Session

### DIFF
--- a/scrapers/md/__init__.py
+++ b/scrapers/md/__init__.py
@@ -206,7 +206,7 @@ class Maryland(State):
             "name": "2025 Regular Session",
             "start_date": "2025-01-08",
             "end_date": "2025-04-07",
-            "active": False,
+            "active": True,
         },
         {
             "_scraped_name": "2026 Regular Session",
@@ -215,7 +215,7 @@ class Maryland(State):
             "name": "2026 Regular Session",
             "start_date": "2026-01-14",
             "end_date": "2026-04-13",
-            "active": True,
+            "active": False,
         },
     ]
     ignored_scraped_sessions = [


### PR DESCRIPTION
Fixes openstates/issues#1351

- Added 2026 Regular Session (Jan 14 - Apr 13, 2026)
- Marked 2025 session as inactive

Fixes scraper error: Session 2026 Regular Session was reported by get_session_list() but not found in legislative_sessions.