### PR TITLE
MI: bugfix regex when 'assigned pa' action is erroneous

### DIFF
--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -148,7 +148,9 @@ class MIBillScraper(Scraper):
                         citation_type="chapter",
                     )
                 else:
-                    self.logger.warning(f"Could not match Public Act pattern in string {action} for {bill}")
+                    self.logger.warning(
+                        f"Could not match Public Act pattern in string {action} for {bill}"
+                    )
 
     def scrape_votes(self, bill: Bill, page: lxml.html.HtmlElement):
 


### PR DESCRIPTION
Example of bad action text is here: https://www.legislature.mi.gov/Bills/Bill?ObjectName=2025-HB-4968 - `assigned PA {0} with immediate effect`

Causing error because regex is expecting a conventional  `assigned PA 25'25 with immediate effect` format