### PR TITLE
MD: enable 2025 special session 1

### DIFF
--- a/scrapers/md/__init__.py
+++ b/scrapers/md/__init__.py
@@ -206,6 +206,15 @@ class Maryland(State):
             "name": "2025 Regular Session",
             "start_date": "2025-01-08",
             "end_date": "2025-04-07",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2025 Special Session",
+            "classification": "special",
+            "identifier": "2025s1",
+            "name": "2025 Special Session",
+            "start_date": "2025-12-16",
+            "end_date": "2025-12-31",
             "active": True,
         },
         {


### PR DESCRIPTION
[MD has scheduled special session for Dec 16](https://governor.maryland.gov/news/press/pages/Governor-Moore-Signs-Executive-Order-Calling-for-Special-Session-of-the-Maryland-General-Assembly.aspx). Will need to merge this when bills actually show up:

* [senate](https://mgaleg.maryland.gov/mgawebsite/Legislation/Index/senate?ys=2025s1)
* [house](https://mgaleg.maryland.gov/mgawebsite/Legislation/Index/house?ys=2025s1)