### PR TITLE
NH: bills: fix handling of LSR value in web scrape

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -91,6 +91,9 @@ class NHBillScraper(Scraper):
 
             bill_id = item.billnumber
             lsr = item.lsrnumber
+            # Pad lsr with zeroes so that it is a 4-character string
+            # lsr value is a padding string in the bulk data documents that are parsed elsewhere, so needs to match
+            lsr = lsr.zfill(4)
 
             bills[lsr] = Bill(
                 legislative_session=session,
@@ -429,13 +432,14 @@ class NHBillScraper(Scraper):
                     self.warning("Error, can't find person %s" % employee)
 
         # actions
-        for line in (
+        action_lines = (
             self.get(
                 f"https://gc.nh.gov/dynamicdatadump/Docket.txt?x={self.cachebreaker}"
             )
             .content.decode("utf-8")
             .split("\n")
-        ):
+        )
+        for line in action_lines:
             if len(line) < 1:
                 continue
             # a few blank/irregular lines, irritating


### PR DESCRIPTION
Turns out that the LSR value (internal bill ID for NH?) is parsed differently between the web scrape and the bulk data scrape. So this was causing some bills (where LSR is something like `314` or `93`) to fail to match things like actions when scraped from web.