### PR TITLE
NJ: update web-based bills scraper to use in 2026

### DIFF
--- a/scrapers/nj/__init__.py
+++ b/scrapers/nj/__init__.py
@@ -2,6 +2,7 @@ import requests
 from openstates.scrape import State
 from .bills import NJBillScraper
 from .events import NJEventScraper
+from .bills_web import NJBillScraper as NJBillWebScraper
 
 # don't retry- if a file isn't on FTP just let it go
 settings = dict(SCRAPELIB_RETRY_ATTEMPTS=0)
@@ -10,6 +11,7 @@ settings = dict(SCRAPELIB_RETRY_ATTEMPTS=0)
 class NewJersey(State):
     scrapers = {
         "bills": NJBillScraper,
+        "bills_web": NJBillWebScraper,
         "events": NJEventScraper,
     }
     legislative_sessions = [
@@ -77,6 +79,14 @@ class NewJersey(State):
             "name": "2024-2025 Regular Session",
             "start_date": "2024-01-09",
             "end_date": "2025-12-31",
+            "active": False,
+        },
+        {
+            "_scraped_name": "2026-2027 Session",
+            "identifier": "222",
+            "name": "2026-2027 Regular Session",
+            "start_date": "2026-01-13",
+            "end_date": "2027-12-31",
             "active": True,
         },
     ]

--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -26,6 +26,8 @@ class NJBillScraper(Scraper, MDBMixin):
         "CR": "concurrent resolution",
     }
 
+    # PLEASE NOTE: the bills_web scraper uses the actions classifier instead of the below reference
+    # So if you make changes here, you may need to make changes to the actions.py classifier
     _actions = {
         "INT 1RA AWR 2RA": (
             "Introduced, 1st Reading without Reference, 2nd Reading",

--- a/scrapers/nj/bills_web.py
+++ b/scrapers/nj/bills_web.py
@@ -3,6 +3,7 @@ import json
 import logging
 import dateutil.parser
 from openstates.scrape import Scraper, Bill
+from .actions import Categorizer as ActionCategorizer
 
 TIMEZONE = pytz.timezone("US/Eastern")
 
@@ -14,6 +15,8 @@ class NJBillScraper(Scraper):
         "JR": "joint resolution",
         "CR": "concurrent resolution",
     }
+
+    categorizer = ActionCategorizer()
 
     def process_versions(self, year, bill):
         url = f"https://www.njleg.state.nj.us/api/billDetail/billText/{bill.identifier}/{year}"
@@ -51,10 +54,13 @@ class NJBillScraper(Scraper):
 
             actor = "upper" if "Senate" in action else "lower"
             # TODO: add action classification
+            action_attr = self.categorizer.categorize(action)
+            classification = action_attr["classification"]
             bill.add_action(
                 action,
                 date=TIMEZONE.localize(date),
                 chamber=actor,
+                classification=classification,
             )
 
     def process_sponsors(self, year, bill):


### PR DESCRIPTION
We're still waiting on the NJ bulk data, so decided to refresh the web-based scraper, and also rename it `bills_web` to match naming convention in other jurisdictions.

Added actions classifier, based on rules embedded in the main `bills.py`.

@showerst FYI - this supercedes your waiting-for-bulk-data NJ PR that is open. I'm going to make sure this  100% works and then close that (already tested locally).