### PR TITLE
NH: fixes for changed/removed urls

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -435,13 +435,14 @@ class NHBillScraper(Scraper):
                     date=time.strftime("%Y-%m-%d"),
                     classification=classification,
                 )
-                amendment_id = extract_amendment_id(action)
-                if amendment_id:
-                    self.bills[lsr].add_document_link(
-                        note="amendment %s" % amendment_id,
-                        url=AMENDMENT_URL % amendment_id,
-                        on_duplicate="ignore",
-                    )
+                # todo: how do we build the new urls?
+                # amendment_id = extract_amendment_id(action)
+                # if amendment_id:
+                #     self.bills[lsr].add_document_link(
+                #         note="amendment %s" % amendment_id,
+                #         url=AMENDMENT_URL % amendment_id,
+                #         on_duplicate="ignore",
+                #     )
 
         yield from self.scrape_votes(session)
 


### PR DESCRIPTION
@jessemortenson heads up --

NH changed their urls and removed a bunch of landing pages. I got text URLs working, and some source urls.

This gets it scraping again, but there's 3 sets of IDs that I can't seem to match up from the buik data.

1. Landing page IDs for carryovers, these don't seem to use the LSR as the ID, or maybe it's last year's LSR.
2. PDF version IDs to build a PDF url
3. Amendment IDs to build a url 

Here's an example bill that has a working bill page and text/html version -- 
https://gc.nh.gov/bill_Status/billinfo.aspx?id=1962&inflect=2

and here's one that i can't link up to the bulk data at all --

https://gc.nh.gov/bill_status/billinfo.aspx?id=564&inflect=2

A handful of us have been staring at this for a few hours this morning to no avail, maybe another set of eyes would help.

