### PR TITLE
FL: add 2026D special, inactive for now

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -259,6 +259,14 @@ class Florida(State):
             "end_date": "2026-03-13",
             "active": True,
         },
+        {
+            "name": "2026 Special Session D",
+            "identifier": "2026D",
+            "classification": "special",
+            "start_date": "2026-04-28",
+            "end_date": "2026-05-01",
+            "active": False,
+        },
     ]
     ignored_scraped_sessions = [
         *(str(each) for each in range(1997, 2010)),


### PR DESCRIPTION
Starts April 28, will need to mark as active closer to that date. 

No bills currently https://www.flsenate.gov/Session/Bills/2026D?chamber=house&searchOnlyCurrentVersion=True&isIncludeAmendments=False&isFirstReference=True&citationType=FL%20Statutes&pageNumber=1