### PR TITLE
TN: Fix errant bill passage classifier

### DIFF
--- a/scrapers/tn/actions.py
+++ b/scrapers/tn/actions.py
@@ -37,6 +37,16 @@ rules = (
     # Fix the chamber before moving on to the other rules.
     Rule(r"^H\.\s", stop=False, chamber="lower"),
     Rule(r"^S\.\s", stop=False, chamber="upper"),
+    Rule(
+        r"Passed on Second Consideration, refer to (?P<committees>Senate .+?Comm.+)",
+        ["referral-committee"],
+        chamber="upper",
+    ),
+    Rule(
+        r"Passed on Second Consideration, refer to (?P<committees>House .+?Comm.+)",
+        ["referral-committee"],
+        chamber="lower",
+    ),
     Rule(r"Signed by S(\.|enate) Speaker", chamber="upper"),
     Rule(r"Signed by H(\.|ouse) Speaker", chamber="lower"),
     # Extract the vote counts to help disambiguate chambers later.
@@ -115,6 +125,7 @@ rules = (
     Rule("Concurred, ", ["passage"]),
     Rule("Passed H., ", ["passage"]),
     Rule("Passed S., ", ["passage"]),
+    Rule("Passed on Second Consideration", ["referral-committee"]),
     Rule("Passed", "passage"),
     Rule("Second reading, adopted", ["passage", "reading-2"]),
     Rule("Second reading, failed", ["failure", "reading-2"]),

--- a/scrapers/tn/bills.py
+++ b/scrapers/tn/bills.py
@@ -97,6 +97,11 @@ class TNBillScraper(Scraper):
     def scrape(self, session=None, chamber=None):
         self._seen_votes = set()
         chambers = [chamber] if chamber else ["upper", "lower"]
+
+        # If you need to test an individual bill:
+        # yield from self.scrape_bill(session, "https://wapp.capitol.tn.gov/apps/BillInfo/Default?BillNumber=SB2624&ga=114")
+        # return
+
         for chamber in chambers:
             yield from self.scrape_chamber(chamber, session)
 


### PR DESCRIPTION
TN has a system with three 'passages', and only the third maps to chamber passage.

"passed on first consideration" is a committee referral
"passed on second consideration" is a committee referral
"passed on third consideration" is a chamber passage.

We were incorrectly classifying the second consideration as a chamber passage.