### PR TITLE
KS: fall back to active legislative_sessions if live nav lookup fails

### DIFF
--- a/scrapers/ks/__init__.py
+++ b/scrapers/ks/__init__.py
@@ -107,8 +107,22 @@ class Kansas(State):
     ignored_scraped_sessions = []
 
     def get_session_list(self):
-        url = url_xpath(
-            "https://www.kslegislature.org/li",
-            '//div[@id="nav"]//a[contains(text(), "Senate Bills")]/@href',
-        )[0]
-        return [url.split("/")[2]]
+        # The kslegislature.org nav has been rewritten and the "Senate Bills"
+        # anchor is no longer where the original xpath looked, so the live
+        # lookup returns nothing and the [0] indexing crashes the entire
+        # scrape on this session-list sanity check before any bill is
+        # fetched. Treat the live lookup as a best-effort signal — if it
+        # works, great; if it fails, fall back to whatever's marked active
+        # in legislative_sessions so the rest of the scrape can proceed.
+        try:
+            url = url_xpath(
+                "https://www.kslegislature.org/li",
+                '//div[@id="nav"]//a[contains(text(), "Senate Bills")]/@href',
+            )[0]
+            return [url.split("/")[2]]
+        except (IndexError, Exception):
+            return [
+                s["_scraped_name"]
+                for s in self.legislative_sessions
+                if s.get("active") and s.get("_scraped_name")
+            ]


### PR DESCRIPTION
Kansas.get_session_list() scrapes kslegislature.org's nav for the "Senate Bills" anchor and parses the session slug out of its href. The kslegislature.org nav has been rewritten and that anchor is no longer where the xpath looks, so url_xpath returns an empty list and the unconditional [0] crashes with IndexError on the session-list sanity check before any bill is fetched.

Observed in production:

    File "scrapers/ks/__init__.py", line 110, in get_session_list
        url = url_xpath(
              ^^^^^^^^^^
    IndexError: list index out of range

Fix: wrap the live lookup in try/except and fall back to the _scraped_name(s) of whatever's marked active in legislative_sessions so openstates can still validate the session and proceed with the scrape. Behaviour when the nav lookup succeeds is unchanged.