### PR TITLE
DE: drop per_page down to 20

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -62,7 +62,7 @@ class DEBillScraper(Scraper, LXMLMixin):
         # Cannot scrape a particular chamber, since the search-by-chamber
         # returns bills that are currently _active_ in a chamber,
         # and is not a search by chamber-of-origin
-        per_page = 200
+        per_page = 20
 
         bills_and_votes = []
         page_number = 1


### PR DESCRIPTION
I can't get a DE scrape to run unless I drop this down to 20.