### PR TITLE
Default the action categorizer Rule to case-insensitive matching

### DIFF
--- a/scrapers/utils/actions.py
+++ b/scrapers/utils/actions.py
@@ -17,7 +17,13 @@ class Rule(namedtuple("Rule", "regexes types stop attrs")):
     """
 
     def __new__(
-        _cls, regexes, types=None, stop=False, flexible_whitespace=True, **kwargs
+        _cls,
+        regexes,
+        types=None,
+        stop=False,
+        flexible_whitespace=True,
+        flags=re.IGNORECASE,
+        **kwargs,
     ):
         "Create new instance of Rule(regex, types, attrs, stop)"
 
@@ -25,12 +31,16 @@ class Rule(namedtuple("Rule", "regexes types stop attrs")):
         if isinstance(regexes, string_types) or hasattr(regexes, "match"):
             regexes = (regexes,)
         compiled_regexes = []
-        # pre-compile any string regexes
+        # pre-compile any string regexes. Strings default to case-insensitive
+        # since action text from upstream tends to drift between
+        # "Passed"/"PASSED"/"passed"; pass flags=0 to a Rule to opt back into
+        # case-sensitive matching. Already-compiled regex objects pass through
+        # untouched.
         for regex in regexes:
             if isinstance(regex, string_types):
                 if flexible_whitespace:
                     c_regex = re.sub(r"\s{1,4}", r"\\s{,10}", regex)
-                compiled_regexes.append(re.compile(c_regex))
+                compiled_regexes.append(re.compile(c_regex, flags))
             else:
                 compiled_regexes.append(regex)
 


### PR DESCRIPTION
Per @showerst's openstates/issues#1243 (greenlit by @jessemortenson and @alexobaseki): default `Rule` to compile string regexes with `re.IGNORECASE`, since upstream legislatures regularly flip case on their action text and silently break categorization.

`flags=0` (or any other re flag set) opts back into case-sensitive matching. Already-compiled regex objects pass through untouched.

Per @jessemortenson's note: the existing `(?i)` prefixes scattered through state scrapers (ma/, mt/, mo/, etc.) become redundant after this. Left them alone for a follow-up so this PR is just the default change.

Closes openstates/issues#1243.