### PR TITLE
utils.actions: import Iterable from collections.abc

### DIFF
--- a/scrapers/utils/actions.py
+++ b/scrapers/utils/actions.py
@@ -1,5 +1,6 @@
 import re
-from collections import namedtuple, defaultdict, Iterable
+from collections import namedtuple, defaultdict
+from collections.abc import Iterable
 from six import string_types
 
 


### PR DESCRIPTION
`collections.Iterable` was removed in Python 3.10 (it had been deprecated since 3.3). Importing `scrapers/utils/actions.py` raises `ImportError` on any current Python, which takes down every state scraper that subclasses `BaseCategorizer` (al, co, in, ma, nh, ut, va, and others).

Just moves the import to `collections.abc.Iterable`. `namedtuple` and `defaultdict` stay where they are.