### PR TITLE
nh: drop deprecated datetime.utcnow() in get_session_list

### DIFF
--- a/scrapers/nh/__init__.py
+++ b/scrapers/nh/__init__.py
@@ -126,4 +126,4 @@ class NewHampshire(State):
 
     def get_session_list(self):
         # no session list on the site, just every year -- hack to force us to add new year
-        return [str(datetime.datetime.utcnow().year)]
+        return [str(datetime.datetime.now(datetime.timezone.utc).year)]


### PR DESCRIPTION
Python 3.12 deprecates `datetime.datetime.utcnow()`. Swap for `datetime.datetime.now(timezone.utc)` so the year string still comes out the same.