### PR TITLE
Replace deprecated Logger.warn with .warning

### DIFF
--- a/scrapers/ma/votes.py
+++ b/scrapers/ma/votes.py
@@ -162,7 +162,7 @@ class SenateJournal(PdfPage):
         # If they disagree on number of matches, the scraper will not get
         # the data correctly so emit a warning and skip this pdf.
         if not (len(votes_mt) == len(votes_s) == len(votes_id)):
-            self.logger.warn(
+            self.logger.warning(
                 f"\nCould not accurately parse votes for "
                 f"{self.source.url}\n"
                 f"len(votes_mt):{len(votes_mt)}\n"
@@ -184,7 +184,7 @@ class SenateJournal(PdfPage):
     def parse_match(self, match, index):
         bill_id = self.get_bill_id(index)
         if not bill_id:
-            self.logger.warn(
+            self.logger.warning(
                 f"No valid bill id found preceding vote lines in {self.source.url}"
             )
             return {}
@@ -224,7 +224,7 @@ class SenateJournal(PdfPage):
         if motion_text:
             motion_text = motion_text.group(1)
         else:
-            self.logger.warn(
+            self.logger.warning(
                 f"No valid motion text found preceding vote lines in {self.source}"
             )
             return
@@ -239,7 +239,7 @@ class SenateJournal(PdfPage):
                 break
 
         if not vote_classification:
-            self.logger.warn(
+            self.logger.warning(
                 f"""
                 No vote_classification from {single_line_motion}" in journal at {self.source.url}
                 """
@@ -293,7 +293,7 @@ class SenateJournal(PdfPage):
         yea_mismatch = first_total_yea != total_yea
         nay_mismatch = first_total_nay != total_nay
         if yea_mismatch or nay_mismatch:
-            self.logger.warn(
+            self.logger.warning(
                 f"Cannot accurately parse to determine margins for vote {index + 1} in {self.source.url}"
             )
             return {}
@@ -304,7 +304,7 @@ class SenateJournal(PdfPage):
         for miscount in yea_matches_miscount, nay_matches_miscount:
             # Allows for minor miscount in cases of PDF formatting issues
             if abs(miscount) > determinative_margin:
-                self.logger.warn(
+                self.logger.warning(
                     f"Cannot accurately parse to determine margins for vote {index + 1} in {self.source.url}"
                 )
                 return {}
@@ -346,7 +346,7 @@ class SenateJournal(PdfPage):
             chamber, number = bill_id_match[-1]
             self.bill_id = f"{chamber[0]} {number}"
         if not self.bill_id:
-            self.logger.warn(
+            self.logger.warning(
                 f"No preceding bill id for vote {index + 1} in {self.source.url}"
             )
         return self.bill_id
@@ -516,7 +516,7 @@ class HouseRollCall(PdfPage):
         for vote in vote_text:
             vote_parser = HouseVoteRecordParser(vote, session=self.session)
             if (warning := vote_parser.get_warning()) is not None:
-                self.logger.warn(warning)
+                self.logger.warning(warning)
             else:
                 vote_parser.error_if_invalid()
                 vote_event = vote_parser.createVoteEvent()

--- a/scrapers/ny/bills.py
+++ b/scrapers/ny/bills.py
@@ -51,7 +51,7 @@ class NYBillScraper(Scraper):
         title = bill["title"].strip()
 
         if not title:
-            self.logger.warn("Bill missing title.")
+            self.logger.warning("Bill missing title.")
             return
 
         # Determine the chamber the bill originated from.
@@ -61,7 +61,7 @@ class NYBillScraper(Scraper):
             bill_chamber = "lower"
         else:
             warning = "Could not identify chamber for {}."
-            self.logger.warn(warning).format(bill_id)
+            self.logger.warning(warning).format(bill_id)
 
         senate_url = (
             "http://www.nysenate.gov/legislation/bills/{bill_session}/" "{bill_id}"

--- a/scrapers/or/bills.py
+++ b/scrapers/or/bills.py
@@ -88,7 +88,7 @@ class ORBillScraper(Scraper):
                     try:
                         legislator = legislators[legislator_code]
                     except KeyError:
-                        logger.warn(
+                        logger.warning(
                             "Legislator {} not found in session {}".format(
                                 legislator_code, session
                             )
@@ -118,7 +118,7 @@ class ORBillScraper(Scraper):
                         media_type="application/pdf",
                     )
                 except ValueError:
-                    logger.warn("Duplicate link found for {}".format(document_url))
+                    logger.warning("Duplicate link found for {}".format(document_url))
 
             for agenda_item in measure["CommitteeAgendaItems"]:
                 for document in agenda_item["CommitteeProposedAmendments"]:

--- a/scrapers/or/committees.py
+++ b/scrapers/or/committees.py
@@ -41,7 +41,7 @@ class ORCommitteeScraper(Scraper):
                 try:
                     member_name = legislators[member["LegislatorCode"]]
                 except KeyError:
-                    logger.warn(
+                    logger.warning(
                         "Legislator {} not found in session {}".format(
                             member["LegislatorCode"], session_key
                         )

--- a/scrapers/or/votes.py
+++ b/scrapers/or/votes.py
@@ -150,7 +150,7 @@ class ORVoteScraper(Scraper):
             try:
                 voter_name = self.legislators[voter["VoteName"]]
             except KeyError:
-                logger.warn(
+                logger.warning(
                     "Legislator {} not found in session {}".format(
                         voter["VoteName"], self.session_key
                     )

--- a/scrapers/utils/votes.py
+++ b/scrapers/utils/votes.py
@@ -22,4 +22,4 @@ def check_counts(vote, raise_error=False):
             if raise_error:
                 raise ValueError(msg)
             else:
-                logger.warn(msg)
+                logger.warning(msg)


### PR DESCRIPTION
`Logger.warn` has been deprecated since Python 3.3 in favour of `.warning`, and the shim emits a DeprecationWarning under 3.13. Swept the 15 call sites in MA, NY, OR scrapers and `utils/votes.py`.