### PR TITLE
utils/lxmlize: re-raise the original parse error instead of wrapping it

### DIFF
--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -13,13 +13,13 @@ def url_xpath(url, path, verify=None, user_agent=None):
     res = requests.get(url, verify=verify, headers=headers)
     try:
         doc = lxml.html.fromstring(res.text)
-    except Exception as e:
+    except Exception:
         logging.error(
             f"Failed to retrieve xpath from {url} :: returned:\n"
             f"CONTENT: {res.content} \n"
             f"RETURN CODE: {res.status_code}"
         )
-        raise Exception(e)
+        raise
     return doc.xpath(path)
 
 


### PR DESCRIPTION
Spotted reading `scrapers/utils/lxmlize.py`. The except branch logs the URL + body, then runs `raise Exception(e)`, which widens the type to bare `Exception` and drops the original traceback. Scraper logs end up showing `Exception: XMLSyntaxError(...)` rather than the actual lxml error and its chain.

Switched to a plain `raise` so the lxml exception propagates with its real type and traceback. The log line still fires first.