### PR TITLE
DATA-5684: Handle missing effective date in CO bill session laws

### DIFF
--- a/scrapers/co/bills.py
+++ b/scrapers/co/bills.py
@@ -90,7 +90,9 @@ class COBillScraper(Scraper, LXMLMixin):
         self.page_number += 1
 
     def clean(self, text):
-        if type(text) is list:
+        if isinstance(text, list):
+            if not text:
+                return ""
             return text[0].text_content().strip()
         return text.text_content().strip()
 
@@ -212,9 +214,11 @@ class COBillScraper(Scraper, LXMLMixin):
 
     def scrape_laws(self, bill: Bill, page: lxml.html.HtmlElement):
         for row in page.cssselect("div#bill-activity-session-laws tbody tr"):
-            effective = dateutil.parser.parse(
-                self.clean(row.xpath("td[1]/span"))
-            ).date()
+            effective_text = self.clean(row.xpath("td[1]/span"))
+            effective = None
+            if effective_text:
+                effective = dateutil.parser.parse(effective_text).date()
+
             chapter = self.clean(row.xpath("td[2]/span"))
             title = self.clean(row.xpath("td[3]/span"))
             chapter = f"Chapter: {chapter} {title}"


### PR DESCRIPTION
This PR fixes a crash in the Colorado bill scraper session law parsing by handling rows where the session law row has an empty or missing effective-date cell in td[1]/span. It updates clean() so empty XPath results return an empty string and changes scrape_laws() to read effective_text first, parse it only when non-empty, and set effective=None when the date is missing, while still adding the citation with chapter, title, and URL. The fix was verified by reviewing the HTML parsing logic and confirming the updated file compiles cleanly with no parser call on empty date strings, making Colorado session law parsing more robust against optional or incomplete row data.