### PR TITLE
UT: fix votes not scraped for 2025+ sessions (API-rendered bills)

### DIFF
--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -378,7 +378,9 @@ class UTBillScraper(Scraper, LXMLMixin):
 
                 # Recorded votes (voiceVote=="1" are voice votes with no individual records)
                 if action_data.get("voteID") and action_data.get("voiceVote") == "0":
-                    vote_chamber = "lower" if action_data["voteHouse"] == "H" else "upper"
+                    vote_chamber = (
+                        "lower" if action_data["voteHouse"] == "H" else "upper"
+                    )
                     vote_url = (
                         f"https://le.utah.gov/DynaBill/svotes.jsp"
                         f"?sessionid={session_slug}"
@@ -391,7 +393,7 @@ class UTBillScraper(Scraper, LXMLMixin):
                         date,
                         action_data["description"],
                         vote_url,
-                        action_data["voteID"],
+                        f"{action_data['voteID']}-{action_data['voteHouse']}",
                     )
 
     def parse_status(self, bill, status_table, chamber):

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -130,8 +130,7 @@ class UTBillScraper(Scraper, LXMLMixin):
             # starting 2025 seems UT is rendering bill data from an API/JSON
             # but prior years seem to have static-ish HTML
             # so we have two logic branches here
-            # TODO vote processing - need to see what data looks like
-            self.scrape_bill_details_from_api(bill, url, session_slug)
+            yield from self.scrape_bill_details_from_api(bill, url, session_slug)
         else:
             yield from self.parse_bill_details_from_html(
                 bill, bill_id, chamber, page, primary_info
@@ -377,6 +376,24 @@ class UTBillScraper(Scraper, LXMLMixin):
                         committee, entity_type="organization"
                     )
 
+                # Recorded votes (voiceVote=="1" are voice votes with no individual records)
+                if action_data.get("voteID") and action_data.get("voiceVote") == "0":
+                    vote_chamber = "lower" if action_data["voteHouse"] == "H" else "upper"
+                    vote_url = (
+                        f"https://le.utah.gov/DynaBill/svotes.jsp"
+                        f"?sessionid={session_slug}"
+                        f"&voteid={action_data['voteID']}"
+                        f"&house={action_data['voteHouse']}"
+                    )
+                    yield from self.parse_html_vote(
+                        bill,
+                        vote_chamber,
+                        date,
+                        action_data["description"],
+                        vote_url,
+                        action_data["voteID"],
+                    )
+
     def parse_status(self, bill, status_table, chamber):
         page = status_table
         uniqid = 0
@@ -531,7 +548,10 @@ class UTBillScraper(Scraper, LXMLMixin):
             self.warning(descr)
             raise NotImplementedError("Can't see if we passed or failed")
 
-        headings = page.xpath("//b")[1:]
+        # The "Yeas" heading uses <b><center><font ...> which lxml normalizes by
+        # promoting <center> out of <b>, leaving the <b> empty. Select the size=5
+        # Arial fonts directly — they appear in all three section headings.
+        headings = page.xpath('//font[@face="Arial"][@size="5"]')
         votes = page.xpath("//table")
         sets = zip(headings, votes)
         vdict = {}


### PR DESCRIPTION
## Summary

Three bugs fixed, all in `scrapers/ut/bills.py`:

**Root cause 1** — `scrape_bill_details_from_api` was called as a plain function (discarding all yielded objects) and had a `# TODO vote processing` comment with no implementation. Changed to `yield from` and added vote scraping in the `actionHistoryList` loop: for each action with a non-empty `voteID` and `voiceVote == "0"` (recorded vote), construct the `svotes.jsp` URL and call the existing `parse_html_vote`. Voice votes (`voiceVote == "1"`) are skipped — they have no individual records.

**Root cause 2** — `parse_html_vote` used `page.xpath("//b")[1:]` to locate the Yeas/Nays/Absent section headings. The Yeas heading is rendered as `<b><center><font size="5">Yeas - N</font></b>` — invalid HTML that lxml normalizes by promoting `<center>` out of `<b>`, leaving the `<b>` empty. This caused a `KeyError` on `vdict["Yeas"]`. Fixed by selecting `//font[@face="Arial"][@size="5"]` directly, which finds all three section headings regardless of nesting.

**Root cause 3** — When a bill receives votes in both chambers (e.g. House concurs with Senate amendment), `actionHistoryList` contains two entries with the same `voteID` but different `voteHouse` values (`H` and `S`). Passing the raw `voteID` as the `VoteEvent` identifier caused a `DuplicateItemError` on import. Fixed by appending the house code: `f"{voteID}-{voteHouse}"` so House and Senate votes on the same `voteID` are distinct records (`"283-H"`, `"283-S"`).

The `svotes.jsp` endpoint is unchanged and returns the same HTML format for 2025+ sessions.

## Test plan

- [x] Scraped full Utah 2026 session (1,016 bills, 1,907 vote events) with zero import errors
- [x] Verified 93,345 individual vote records imported including concurrent House/Senate votes
- [x] Verified voice votes (`voiceVote == "1"`) are correctly skipped
- [x] Confirmed `svotes.jsp` vote detail pages accessible for 2025 and 2026 sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)