### PR TITLE
MI: fix House votes never scraped due to regex mismatch and tab-separated names

### DIFF
--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -194,7 +194,8 @@ class MIBillScraper(Scraper):
                 actor = "upper"
 
             # Process roll call votes
-            rcmatch = re.search(r"Roll Call # (\d+)", action, re.IGNORECASE)
+            # House format: "Roll Call #44" (no space); Senate: "ROLL CALL # 1" (space)
+            rcmatch = re.search(r"Roll Call #\s*(\d+)", action, re.IGNORECASE)
             if rcmatch:
                 rc_num = rcmatch.groups()[0]
                 vote_url = None
@@ -347,8 +348,8 @@ class MIBillScraper(Scraper):
             elif p.startswith("In The Chair:"):
                 break
             elif vtype:
-                # Split on multiple spaces not preceded by commas
-                for line in re.split(r"(?<!,)\s{2,}", p):
+                # Split on tabs (House journals) or multiple spaces (Senate journals)
+                for line in re.split(r"\t|(?<!,)\s{2,}", p):
                     if line.strip():
                         if session == "2017-2018":
                             for leg in line.split():


### PR DESCRIPTION
## Summary

Two bugs introduced by #5379 (merged 2025-05-01) that together cause all Michigan **House** vote records to be silently dropped. Senate votes are unaffected.

- **Bug 1 — regex mismatch** (`scrape_votes`, line 197): The roll call pattern `r"Roll Call # (\d+)"` requires a space between `#` and the number. House action strings use `"Roll Call #44"` (no space); Senate uses `"ROLL CALL # 1"` (with space). Since `rcmatch` is always `None` for House actions, the `if rcmatch:` block is never entered — no House votes are ever scraped. Fixed with `r"Roll Call #\s*(\d+)"`.

- **Bug 2 — tab-separated voter names** (`parse_roll_call`, line 351): House journal `<p>` elements separate voter names with single tab characters (`"Alexander\tFarhat\tMartus\tSchmaltz"`), while Senate journals use multi-space padding. The split `re.split(r"(?<!,)\s{2,}", p)` requires 2+ consecutive whitespace characters, so a single `\t` goes unsplit — all four names on a line are stored as one fused string. A session-specific workaround for the identical tab issue already existed for `2017-2018` but was never generalised. Fixed by changing the split to `r"\t|(?<!,)\s{2,}"`, which handles both formats.

## Test plan

- [ ] Tested against 45 Michigan 2025-2026 bills (38 House, 7 Senate) from a known-missing dataset
- [ ] 31 House votes recovered with correct yea/nay counts and fully split individual voter names (e.g. HB4707 Ban RCV: 57 yeas, 44 nays — each voter a separate entry)
- [ ] House bills with no roll call floor vote correctly return 0 votes rather than erroring
- [ ] Senate bill parsing unaffected — Senate journals use multi-space format, both regex and split continue to work correctly
- [ ] Verified HB4004 end-to-end: `Roll Call #44 Yeas 102 Nays 3` → result=pass, yes=102, no=3, voters individually named

🤖 Generated with [Claude Code](https://claude.com/claude-code)