### PR TITLE
WV: bills: more specific selector to avoid spurious links in list

### DIFF
--- a/scrapers/wv/bills.py
+++ b/scrapers/wv/bills.py
@@ -85,7 +85,6 @@ class WVBillScraper(Scraper):
         #     "https://www.wvlegislature.gov/Bill_Status/Bills_history.cfm?input=500&year=2020&sessiontype=RS&btype=bill",
         # )
 
-        # for link in page.xpath("//a[contains(@href, 'Bills_history')]"):
         # First column in the results table contains a link to bill, text of link is bill ID
         for link in page.xpath("//table[@id='results']//tr/td[1]/a"):
             bill_id = link.xpath("string()").strip()
@@ -137,11 +136,7 @@ class WVBillScraper(Scraper):
         page = lxml.html.fromstring(html)
         page.make_links_absolute(url)
 
-        try:
-            bill_type = self.bill_types[bill_id.split()[0][1:]]
-        except KeyError:
-            bob = "huh"
-            bill_type = "yo"
+        bill_type = self.bill_types[bill_id.split()[0][1:]]
 
         bill = Bill(
             bill_id,

--- a/scrapers/wv/bills.py
+++ b/scrapers/wv/bills.py
@@ -85,7 +85,9 @@ class WVBillScraper(Scraper):
         #     "https://www.wvlegislature.gov/Bill_Status/Bills_history.cfm?input=500&year=2020&sessiontype=RS&btype=bill",
         # )
 
-        for link in page.xpath("//a[contains(@href, 'Bills_history')]"):
+        # for link in page.xpath("//a[contains(@href, 'Bills_history')]"):
+        # First column in the results table contains a link to bill, text of link is bill ID
+        for link in page.xpath("//table[@id='results']//tr/td[1]/a"):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
             if not title:
@@ -135,7 +137,11 @@ class WVBillScraper(Scraper):
         page = lxml.html.fromstring(html)
         page.make_links_absolute(url)
 
-        bill_type = self.bill_types[bill_id.split()[0][1:]]
+        try:
+            bill_type = self.bill_types[bill_id.split()[0][1:]]
+        except KeyError:
+            bob = "huh"
+            bill_type = "yo"
 
         bill = Bill(
             bill_id,


### PR DESCRIPTION
bill scraper was failing on parsing a link that contained unexpected text, looks like WV started adding bill links in a column where scraper was not expecting them. Revised selector to just the link in the first column.

```[2026-06-25, 02:36:59 UTC] {pod_manager.py:479} INFO - [base]   File "/opt/openstates/openstates/scrapers/wv/bills.py", line 94, in scrape_chamber
[2026-06-25, 02:36:59 UTC] {pod_manager.py:479} INFO - [base]     yield from self.scrape_bill(
[2026-06-25, 02:36:59 UTC] {pod_manager.py:479} INFO - [base]   File "/opt/openstates/openstates/scrapers/wv/bills.py", line 138, in scrape_bill
[2026-06-25, 02:36:59 UTC] {pod_manager.py:479} INFO - [base]     bill_type = self.bill_types[bill_id.split()[0][1:]]
[2026-06-25, 02:37:02 UTC] {pod_manager.py:498} INFO - [base] KeyError: 'ncorporated'```