### PR TITLE
fix: DC scraper crashes mid-run on non-PDF attachments, dropping bills

### DIFF
--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -49,7 +49,6 @@ class DCBillScraper(Scraper):
             leg_listing = resp.json()
 
             for leg in leg_listing:
-
                 bill = Bill(
                     leg["legislationNumber"],
                     legislative_session=session,
@@ -271,9 +270,11 @@ class DCBillScraper(Scraper):
                                         )
                                         v.add_source(leg_listing_url)
 
-                                        yes_count = no_count = absent_count = (
-                                            abstain_count
-                                        ) = other_count = 0
+                                        yes_count = (
+                                            no_count
+                                        ) = (
+                                            absent_count
+                                        ) = abstain_count = other_count = 0
                                         for leg_vote in act["voteDetails"]["votes"]:
                                             mem_name = leg_vote["councilMember"]
                                             if leg_vote["vote"] == "Yes":

--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -209,7 +209,7 @@ class DCBillScraper(Scraper):
                                 mimetype = (
                                     "application/pdf"
                                     if act["attachment"].endswith("pdf")
-                                    else None
+                                    else get_media_type(act["attachment"])
                                 )
                                 is_version = False
                                 # figure out if it's a version from type/name
@@ -271,11 +271,9 @@ class DCBillScraper(Scraper):
                                         )
                                         v.add_source(leg_listing_url)
 
-                                        yes_count = (
-                                            no_count
-                                        ) = (
-                                            absent_count
-                                        ) = abstain_count = other_count = 0
+                                        yes_count = no_count = absent_count = (
+                                            abstain_count
+                                        ) = other_count = 0
                                         for leg_vote in act["voteDetails"]["votes"]:
                                             mem_name = leg_vote["councilMember"]
                                             if leg_vote["vote"] == "Yes":


### PR DESCRIPTION
Fix: use get_media_type() for non-PDF attachments in DC bill details

When a DC bill's action attachment is not a PDF, mimetype is set to None and passed to add_version_link(). This causes OCD schema validation to fail with None is not of type 'string' for media_type, crashing the scraper mid-run. All bills after the failing bill in the API response are dropped from the output.

The legislationHistory attachment block above already uses get_media_type() for non-PDF files — this fix makes the leg_details["actions"] block consistent with it.