### PR TITLE
fix: skip votes for bills missing from bill_dict in NJ scraper

### DIFF
--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -456,6 +456,9 @@ class NJBillScraper(Scraper, MDBMixin):
                             f"Action string is empty, so cannot save VoteEvent for vote {vote_id}"
                         )
                     else:
+                        if bill_id not in bill_dict:
+                            self.warning("unknown bill %s in vote database" % bill_id)
+                            continue
                         if vote_id not in votes:
                             votes[vote_id] = VoteEvent(
                                 start_date=TIMEZONE.localize(date),


### PR DESCRIPTION
The NJ vote scraper crashes with `KeyError` when a bill appears in the vote files but is not in `bill_dict`.

Root cause: NJ publishes bill metadata (MAINBILL.TXT) and vote data (CA/CS zip files) independently. A bill can appear in a committee vote file before its MAINBILL.TXT entry is published, leaving a gap. The vote processing loop calls `bill_dict[bill_id]` directly without checking if the key exists.

Fix: Add the same guard that already exists in every other section of this file (sponsors, documents, actions, subjects):

if bill_id not in bill_dict:
    self.warning("unknown bill %s in vote database" % bill_id)
    continue
