### PR TITLE
FL: activity after session first adjourned

### DIFF
--- a/scrapers/fl/__init__.py
+++ b/scrapers/fl/__init__.py
@@ -287,7 +287,7 @@ class Florida(State):
             "classification": "primary",
             "start_date": "2026-01-13",
             "end_date": "2026-03-13",
-            "active": False,
+            "active": True,
             "extras": {"session_number": "113"},
         },
         {


### PR DESCRIPTION
We notice that there was bill activity after official adjourned date. https://flsenate.gov/Session/Bill/2026/1085/ByCategory