### PR TITLE
fix: handle PDF URLs with query strings in DC actions block

### DIFF
--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -49,7 +49,6 @@ class DCBillScraper(Scraper):
             leg_listing = resp.json()
 
             for leg in leg_listing:
-
                 bill = Bill(
                     leg["legislationNumber"],
                     legislative_session=session,
@@ -271,9 +270,11 @@ class DCBillScraper(Scraper):
                                         )
                                         v.add_source(leg_listing_url)
 
-                                        yes_count = no_count = absent_count = (
-                                            abstain_count
-                                        ) = other_count = 0
+                                        yes_count = (
+                                            no_count
+                                        ) = (
+                                            absent_count
+                                        ) = abstain_count = other_count = 0
                                         for leg_vote in act["voteDetails"]["votes"]:
                                             mem_name = leg_vote["councilMember"]
                                             if leg_vote["vote"] == "Yes":

--- a/scrapers/dc/bills.py
+++ b/scrapers/dc/bills.py
@@ -208,8 +208,8 @@ class DCBillScraper(Scraper):
                             if act["attachment"]:
                                 mimetype = (
                                     "application/pdf"
-                                    if act["attachment"].endswith("pdf")
-                                    else None
+                                    if ".pdf" in act["attachment"].lower()
+                                    else get_media_type(act["attachment"])
                                 )
                                 is_version = False
                                 # figure out if it's a version from type/name
@@ -271,11 +271,9 @@ class DCBillScraper(Scraper):
                                         )
                                         v.add_source(leg_listing_url)
 
-                                        yes_count = (
-                                            no_count
-                                        ) = (
-                                            absent_count
-                                        ) = abstain_count = other_count = 0
+                                        yes_count = no_count = absent_count = (
+                                            abstain_count
+                                        ) = other_count = 0
                                         for leg_vote in act["voteDetails"]["votes"]:
                                             mem_name = leg_vote["councilMember"]
                                             if leg_vote["vote"] == "Yes":


### PR DESCRIPTION
fix: handle PDF URLs with query strings in DC actions block

DC bill attachment URLs sometimes include query parameters (e.g. .pdf?Id=123)
which caused .endswith("pdf") to miss the extension, falling through to
get_media_type() which raises ValueError for unrecognized URLs.

Aligns the leg_details["actions"] block with the legislationHistory block
above it, which already uses ".pdf" in url.lower() to handle this correctly.

Follow-up to #5706.