### PR TITLE
fix: correct 2025-2026 session end_date for DC, MI, NC, PA (biennium year off by one)

### DIFF
--- a/scrapers/dc/__init__.py
+++ b/scrapers/dc/__init__.py
@@ -67,7 +67,7 @@ class DistrictOfColumbia(State):
             "identifier": "26",
             "name": "26th Council Period (2025-2026)",
             "start_date": "2025-01-02",
-            "end_date": "2025-12-31",
+            "end_date": "2026-12-31",
             "active": True,
         },
     ]

--- a/scrapers/mi/__init__.py
+++ b/scrapers/mi/__init__.py
@@ -74,7 +74,7 @@ class Michigan(State):
             "identifier": "2025-2026",
             "name": "2025-2026 Regular Session",
             "start_date": "2025-01-08",
-            "end_date": "2025-12-31",
+            "end_date": "2026-12-31",
             "active": True,
         },
     ]

--- a/scrapers/nc/__init__.py
+++ b/scrapers/nc/__init__.py
@@ -370,7 +370,7 @@ class NorthCarolina(State):
             "identifier": "2025",
             "name": "2025-2026 Session",
             "start_date": "2025-01-11",
-            "end_date": "2025-07-01",
+            "end_date": "2026-07-01",
             "active": True,
         },
         {

--- a/scrapers/pa/__init__.py
+++ b/scrapers/pa/__init__.py
@@ -103,7 +103,7 @@ class Pennsylvania(State):
             "identifier": "2025-2026",
             "name": "2025-2026 Regular Session",
             "start_date": "2025-01-07",
-            "end_date": "2025-11-30",
+            "end_date": "2026-11-30",
             "active": True,
             "extras": {"session_year": "2025"},
         },


### PR DESCRIPTION
Fix biennium end_date off-by-one for DC, MI, NC, and PA

The 2025-2026 session end_date for four states was set to the last day of 2025 (year 1 of the biennium) instead of the last day of 2026 (year 2). This is a consistent data entry pattern across all four states.

Changes:

DC: 2025-12-31 → 2026-12-31
MI: 2025-12-31 → 2026-12-31
NC: 2025-07-01 → 2026-07-01
PA: 2025-11-30 → 2026-11-30
Each corrected date follows the same end-of-session pattern as prior biennium sessions for that state.