### PR TITLE
VT: fix for sponsor regex

### DIFF
--- a/scrapers/vt/bills.py
+++ b/scrapers/vt/bills.py
@@ -115,7 +115,7 @@ class VTBillScraper(Scraper, LXMLMixin):
             # Capture sponsors
             sponsors = doc.xpath(
                 '//dl[@class="summary-table"]/dt[text()="Sponsor(s)"]/'
-                "following-sibling::dd[1]/ul/li"
+                "following-sibling::dd[1]/ul/li[a]"
             )
             sponsor_type = "primary"
             for sponsor in sponsors:


### PR DESCRIPTION
Site added an "additional sponsors" li without a link, that was breaking the xpath.