### PR TITLE
VA: fix csv_bills hardcoded session id

### DIFF
--- a/scrapers/va/csv_bills.py
+++ b/scrapers/va/csv_bills.py
@@ -23,7 +23,7 @@ class VaCSVBillScraper(Scraper):
     _bills = defaultdict(list)
     _summaries = defaultdict(list)
 
-    _session_id: int
+    _session_id: str
     categorizer = Categorizer()
 
     def get_file(self, filename):
@@ -207,7 +207,8 @@ class VaCSVBillScraper(Scraper):
             is_special = True
 
         session_id = SESSION_SITE_IDS[session]
-        self._session_id = "20251"
+        self._session_id = session_id
+
         # self._init_sftp(session_id)
         bill_url_base = "https://lis.virginia.gov/cgi-bin/"
 


### PR DESCRIPTION
The csv_bills scraper correctly looked up the session ID from SESSION_SITE_IDS but then immediately overwrote self._session_id with a hardcoded "20251" (2025 regular session). This caused all CSV file fetches to use 2025 data regardless of the --session argument passed.

Fix: assign session_id to self._session_id instead of the hardcoded value.