### PR TITLE
OK: strip (PROD) suffix from session list

### DIFF
--- a/scrapers/ok/__init__.py
+++ b/scrapers/ok/__init__.py
@@ -244,5 +244,7 @@ class Oklahoma(State):
             verify=False,
         )
         # OK Sometimes appends (Mainsys) to their session listings
-        sessions = [s.replace("(Mainsys)", "").strip() for s in sessions]
+        sessions = [
+            s.replace("(Mainsys)", "").replace("(PROD)", "").strip() for s in sessions
+        ]
         return sessions


### PR DESCRIPTION
Oklahoma's get_session_list() stripped "(Mainsys)" from session names but not "(PROD)", causing "1998 Regular Session (PROD)" to fail matching against ignored_scraped_sessions (which already has "1998 Regular Session").

Fix: also strip "(PROD)" so the name normalizes correctly.
