### PR TITLE
fix(wv): update bill listing XPath after site redesign

### DIFF
--- a/scrapers/wv/bills.py
+++ b/scrapers/wv/bills.py
@@ -85,8 +85,8 @@ class WVBillScraper(Scraper):
         #     "https://www.wvlegislature.gov/Bill_Status/Bills_history.cfm?input=500&year=2020&sessiontype=RS&btype=bill",
         # )
 
-        # First column in the results table contains a link to bill, text of link is bill ID
-        for link in page.xpath("//table[@id='results']//tr/td[1]/a"):
+        # Bill links are in td.tdborder cells (table lost id="results" in 2026 redesign)
+        for link in page.xpath("//td[@class='tdborder']/a[contains(@href, 'Bills_history')]"):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
             if not title:

--- a/scrapers/wv/bills.py
+++ b/scrapers/wv/bills.py
@@ -86,7 +86,9 @@ class WVBillScraper(Scraper):
         # )
 
         # Bill links are in td.tdborder cells (table lost id="results" in 2026 redesign)
-        for link in page.xpath("//td[@class='tdborder']/a[contains(@href, 'Bills_history')]"):
+        for link in page.xpath(
+            "//td[@class='tdborder']/a[contains(@href, 'Bills_history')]"
+        ):
             bill_id = link.xpath("string()").strip()
             title = link.xpath("string(../../td[2])").strip()
             if not title:
@@ -130,7 +132,6 @@ class WVBillScraper(Scraper):
         url,
         strip_sponsors=re.compile(r"\s*\(.{,50}\)\s*").sub,
     ):
-
         html = self.get(url, verify=False).text
 
         page = lxml.html.fromstring(html)


### PR DESCRIPTION
## Summary

`wvlegislature.gov` removed `id="results"` from the bills table at some point in 2026. The scraper's XPath `//table[@id='results']//tr/td[1]/a` finds nothing, so **zero regular bills are scraped** — only resolutions (which use a separate endpoint) are captured.

Bills are still present in the page but now in `<td class="tdborder">` cells. Fix: update XPath to `//td[@class='tdborder']/a[contains(@href, 'Bills_history')]`.

The title XPath (`../../td[2]`) and resolution scraper (`res_list.cfm`) are unaffected.

## Impact

WV 2026 session (Jan 14 – Mar 14) has ~1,500+ bills that were never scraped. A backfill run is needed after this fix merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)