### PR TITLE
VT: events: ignore failed SSL from source site

### DIFF
--- a/scrapers/vt/events.py
+++ b/scrapers/vt/events.py
@@ -6,7 +6,7 @@ from lxml import html
 from openstates.scrape import Scraper, Event
 from openstates.exceptions import EmptyScrape
 
-from spatula import CSS, HtmlPage, XPath
+from spatula import CSS, HtmlPage, URL, XPath
 
 TIMEZONE = pytz.timezone("America/New_York")
 
@@ -91,7 +91,7 @@ class VTEventScraper(Scraper):
 
         url = "https://legislature.vermont.gov/committee/meetings/{}".format(year_slug)
 
-        doc = html.fromstring(self.get(url).text)
+        doc = html.fromstring(self.get(url, verify=False).text)
         doc.make_links_absolute(url)
         event_count = 0
         # This should be some point in the past, because some event agendas actually include dates
@@ -100,7 +100,8 @@ class VTEventScraper(Scraper):
 
         for source in doc.xpath('//a[contains(@href, "/agenda/")]/@href'):
             # Determine when the committee meets
-            events = VTAgendaOfWeek(source=source)
+            source_url = URL(source, verify=False)
+            events = VTAgendaOfWeek(source=source_url)
             try:
                 yield from events.do_scrape()
             except Exception as e:


### PR DESCRIPTION
Vermont website has developed a broken SSL certificate chain. Ignoring to get VT events runnable again.