### PR TITLE
IL: bills: site changed bill title element HTML

### DIFF
--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -528,7 +528,7 @@ class IlBillScraper(Scraper):
         bill_id = doc_type + bill_num
 
         title = doc.xpath(
-            '//div[contains(@class, "tab-content")]/div[contains(@class, "row")][1]//h5/text()'
+            '//div[contains(@class, "tab-content")]/div[contains(@class, "row")][1]//h2/text()'
         )[0].strip()
 
         bill = Bill(


### PR DESCRIPTION
LOOK AT THIS ILLINOIS MARKUP

```<h2 class="h5 fw-bold">HEMP CANNABINOIDS-MINORS</h2>```

H2 with class of `h5` that used to be an H5! That's how you do it folks!!!