### PR TITLE
AZ: preserve session cookies across setsession.php POST

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -392,6 +392,7 @@ class AZBillScraper(Scraper):
 
         # Get the bills page to start the session
         req = self.get("https://www.azleg.gov/bills/", timeout=80)
+        session_cookies = dict(req.cookies)
 
         session_form_url = "https://www.azleg.gov/azlegwp/setsession.php"
         form = {"sessionID": session_id}
@@ -404,14 +405,15 @@ class AZBillScraper(Scraper):
         req = self.post(
             url=session_form_url,
             data=form,
-            cookies=req.cookies,
+            cookies=session_cookies,
             headers=headers,
             allow_redirects=True,
         )
+        session_cookies.update(dict(req.cookies))
 
         bill_list_url = "https://www.azleg.gov/bills/"
 
-        page = self.get(bill_list_url, timeout=80, cookies=req.cookies).content
+        page = self.get(bill_list_url, timeout=80, cookies=session_cookies).content
         # There's an errant close-comment that browsers handle
         # but LXML gets really confused.
         page = page.replace(b"--!>", b"-->")


### PR DESCRIPTION
## Summary

Fixes `AssertionError: Session ID not in bill list` which causes zero bills to be scraped for Arizona.

**Root cause**: The scraper makes three requests to set up the session:
1. GET `/bills/` → receives `PHPSESSID` cookie
2. POST `setsession.php` with that cookie → server sets session 130 against the `PHPSESSID`
3. GET `/bills/` again → should now show session 130 selected

The bug: after the POST, `req` is reassigned to the POST response. `req.cookies` in requests only contains cookies *returned* by that response (via `Set-Cookie` headers) — not the cookies that were *sent* with it. If `setsession.php` doesn't return a new `Set-Cookie: PHPSESSID=...` header, `req.cookies` is empty and the final GET has no session cookie, so the server doesn't know which session to show.

**Fix**: Save the initial GET cookies before the POST, merge in any new cookies from the POST response, and use the merged set for the final GET.

Logs from GitHub-hosted runner (Azure IP):
```
INFO scrapelib: GET - 'https://www.azleg.gov/bills/'
INFO scrapelib: POST - 'https://www.azleg.gov/azlegwp/setsession.php'
INFO scrapelib: GET - 'https://www.azleg.gov/bills/'
AssertionError: Session ID not in bill list
```

Logs from self-hosted runner (home network, non-Azure IP):
```
INFO scrapelib: GET - 'https://www.azleg.gov/bills/'
INFO scrapelib: POST - 'https://www.azleg.gov/azlegwp/setsession.php'
INFO scrapelib: GET - 'https://www.azleg.gov/bills/'
AssertionError: Session ID not in bill list
```


Related to issue openstates/issues#1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)