### PR TITLE
VA: skip history rows with unknown chamber code in csv_bills

### DIFF
--- a/scrapers/va/csv_bills.py
+++ b/scrapers/va/csv_bills.py
@@ -311,6 +311,8 @@ class VaCSVBillScraper(Scraper):
                 action = hist["history_description"]
                 action_date = hist["history_date"]
                 date = dateutil.parser.parse(action_date).date()
+                if action[0] not in chamber_types:
+                    continue
                 chamber = chamber_types[action[0]]
                 vote_id = hist["history_refid"]
                 cleaned_action = action[2:]


### PR DESCRIPTION
## Summary

- `HISTORY.CSV` for the 2026 regular session contains at least one row where `history_description[0]` is not a known chamber code (`H`/`S`/`G`/`C`)
- This causes a `KeyError` crash mid-scrape: `chamber = chamber_types[action[0]]` → `KeyError: ' '`
- Fix: skip rows where the first character isn't in `chamber_types` rather than crashing

## Error from failing run

```
File "/opt/openstates/openstates/scrapers/va/csv_bills.py", line 314, in scrape
    chamber = chamber_types[action[0]]
KeyError: ' '
```

## Change

```python
# before
chamber = chamber_types[action[0]]

# after
if action[0] not in chamber_types:
    continue
chamber = chamber_types[action[0]]
```
