### PR TITLE
FL: stream bills as yielded, handle flhouse.gov bot detection gracefully

### DIFF
--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -730,6 +730,12 @@ class HouseSearchPage(HtmlListPage):
             },
             retries=3,
             verify=False,
+            # spatula's URL defaults to timeout=None (wait forever). flhouse.gov
+            # occasionally accepts the connection but never finishes the response,
+            # which without an explicit timeout hangs the whole scrape indefinitely
+            # instead of raising the ConnectionError/Timeout our retry logic already
+            # handles (see patched_get_response above).
+            timeout=30,
         )
 
     def accept_response(self, response: requests.Response):
@@ -759,7 +765,7 @@ class HouseSearchPage(HtmlListPage):
             return True
 
     def process_item(self, item):
-        source = URL(f"{item}", verify=False)
+        source = URL(f"{item}", verify=False, timeout=30)
         return HouseBillPage(self.input, source=source)
 
     # Override so that we can handle occasional bill that does not show up in search
@@ -787,7 +793,7 @@ class HouseBillPage(HtmlListPage):
     )
 
     def process_item(self, item):
-        source = URL(f"{item}", verify=False)
+        source = URL(f"{item}", verify=False, timeout=30)
         return HouseComVote(self.input, source=source)
 
 
@@ -886,7 +892,15 @@ class FlBillScraper(Scraper):
             "scrapers/fl/__init__.py"
         )
 
-    def scrape(self, session=None):
+    def scrape(self, session=None, allow_partial=None):
+        # Off by default: a scrape that hits flhouse.gov bot detection mid-session
+        # fails loudly rather than quietly returning a subset of bills, matching
+        # every other scraper's assumption that a successful run means a complete
+        # dataset. Pass allow_partial=true on the command line (e.g.
+        # `fl bills --scrape allow_partial=true`, same style as VA's
+        # `csv_bills --scrape session=2026`) to opt into keeping whatever bills
+        # were saved before the block instead of failing the whole run.
+        self.allow_partial_scrape = str(allow_partial).lower() in ("1", "true", "yes")
         self.raise_errors = False
         self.retry_attempts = 5
         self.retry_wait_seconds = 5
@@ -1005,9 +1019,13 @@ class FlBillScraper(Scraper):
         except Exception as e:
             # flhouse.gov uses application-layer bot detection: returns "Request Rejected"
             # HTML with HTTP 200, causing spatula to raise a rejection error after 4 failed
-            # accept_response() checks. Catch it here so bills already yielded are saved
-            # rather than the entire scrape crashing with zero output.
-            if "reject" in str(type(e).__name__).lower() or "reject" in str(e).lower():
+            # accept_response() checks. Only swallow it when allow_partial_scrape is set
+            # (see scrape()) -- by default this still raises, so a blocked run fails loudly
+            # instead of silently reporting a subset of bills as a complete dataset.
+            is_rejection = "reject" in str(type(e).__name__).lower() or "reject" in str(
+                e
+            ).lower()
+            if is_rejection and self.allow_partial_scrape:
                 self.logger.warning(
                     f"flhouse.gov bot detection triggered — stopping session early. "
                     f"Bills processed before this point have been saved. ({e})"

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -734,8 +734,13 @@ class HouseSearchPage(HtmlListPage):
             # occasionally accepts the connection but never finishes the response,
             # which without an explicit timeout hangs the whole scrape indefinitely
             # instead of raising the ConnectionError/Timeout our retry logic already
-            # handles (see patched_get_response above).
-            timeout=30,
+            # handles (see patched_get_response above). 10s applies separately to
+            # both the connect and read phases; every real request we observed in
+            # testing completed in 1-4s, so this is well clear of normal latency
+            # while still failing fast -- this fetch happens up to 3x per bill
+            # across ~1,900 bills, so a longer timeout compounds fast if a hang
+            # recurs. Tune freely if a different value fits better.
+            timeout=10,
         )
 
     def accept_response(self, response: requests.Response):
@@ -765,7 +770,7 @@ class HouseSearchPage(HtmlListPage):
             return True
 
     def process_item(self, item):
-        source = URL(f"{item}", verify=False, timeout=30)
+        source = URL(f"{item}", verify=False, timeout=10)
         return HouseBillPage(self.input, source=source)
 
     # Override so that we can handle occasional bill that does not show up in search
@@ -793,7 +798,7 @@ class HouseBillPage(HtmlListPage):
     )
 
     def process_item(self, item):
-        source = URL(f"{item}", verify=False, timeout=30)
+        source = URL(f"{item}", verify=False, timeout=10)
         return HouseComVote(self.input, source=source)
 
 

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -19,7 +19,6 @@ from .actions import Categorizer
 from .utils import (
     get_random_user_agent,
     add_random_delay,
-    retry_on_connection_error,
 )
 
 # from https://stackoverflow.com/questions/38015537/python-requests-exceptions-sslerror-dh-key-too-small

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -916,12 +916,7 @@ class FlBillScraper(Scraper):
             )
             yield from self._process_bill_list(bill_list)
 
-        yield from retry_on_connection_error(
-            lambda: list(do_scrape_with_retry()),
-            max_retries=3,
-            initial_backoff=10,
-            max_backoff=120,
-        )
+        yield from do_scrape_with_retry()
 
     def _create_fresh_session(self):
         """
@@ -971,39 +966,52 @@ class FlBillScraper(Scraper):
         """
         Process the bill list with error handling and circuit breaker pattern.
         """
-        for item in bill_list.do_scrape():
-            try:
-                # Reset connection pool if needed
-                self._reset_connection_pool_if_needed()
+        try:
+            for item in bill_list.do_scrape():
+                try:
+                    # Reset connection pool if needed
+                    self._reset_connection_pool_if_needed()
 
-                # Add a random delay between processing items
-                add_random_delay(1, 3)
+                    # Add a random delay between processing items
+                    add_random_delay(1, 3)
 
-                # If we've had too many consecutive failures, pause for a while
-                if self._consecutive_failures >= self._max_consecutive_failures:
-                    self.logger.warning(
-                        f"Circuit breaker triggered after {self._consecutive_failures} consecutive failures. "
-                        f"Pausing for {self._circuit_breaker_timeout} seconds."
-                    )
-                    time.sleep(self._circuit_breaker_timeout)
+                    # If we've had too many consecutive failures, pause for a while
+                    if self._consecutive_failures >= self._max_consecutive_failures:
+                        self.logger.warning(
+                            f"Circuit breaker triggered after {self._consecutive_failures} consecutive failures. "
+                            f"Pausing for {self._circuit_breaker_timeout} seconds."
+                        )
+                        time.sleep(self._circuit_breaker_timeout)
+                        self._consecutive_failures = 0
+
+                        # Rotate user agent after circuit breaker timeout
+                        self.headers["User-Agent"] = get_random_user_agent()
+
+                    yield item
+
+                    # Reset consecutive failures counter on success
                     self._consecutive_failures = 0
 
-                    # Rotate user agent after circuit breaker timeout
-                    self.headers["User-Agent"] = get_random_user_agent()
+                except Exception as e:
+                    self._consecutive_failures += 1
+                    self.logger.error(f"Error processing item: {e}")
 
-                yield item
+                    # If it's a connection error, add a longer delay
+                    if isinstance(e, (ConnectionError, RemoteDisconnected)):
+                        self.logger.warning("Connection error. Adding longer delay.")
+                        add_random_delay(5, 15)
 
-                # Reset consecutive failures counter on success
-                self._consecutive_failures = 0
-
-            except Exception as e:
-                self._consecutive_failures += 1
-                self.logger.error(f"Error processing item: {e}")
-
-                # If it's a connection error, add a longer delay
-                if isinstance(e, (ConnectionError, RemoteDisconnected)):
-                    self.logger.warning("Connection error. Adding longer delay.")
-                    add_random_delay(5, 15)
-
-                    # Rotate user agent after connection error
-                    self.headers["User-Agent"] = get_random_user_agent()
+                        # Rotate user agent after connection error
+                        self.headers["User-Agent"] = get_random_user_agent()
+        except Exception as e:
+            # flhouse.gov uses application-layer bot detection: returns "Request Rejected"
+            # HTML with HTTP 200, causing spatula to raise a rejection error after 4 failed
+            # accept_response() checks. Catch it here so bills already yielded are saved
+            # rather than the entire scrape crashing with zero output.
+            if "reject" in str(type(e).__name__).lower() or "reject" in str(e).lower():
+                self.logger.warning(
+                    f"flhouse.gov bot detection triggered — stopping session early. "
+                    f"Bills processed before this point have been saved. ({e})"
+                )
+            else:
+                raise

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -1027,9 +1027,9 @@ class FlBillScraper(Scraper):
             # accept_response() checks. Only swallow it when allow_partial_scrape is set
             # (see scrape()) -- by default this still raises, so a blocked run fails loudly
             # instead of silently reporting a subset of bills as a complete dataset.
-            is_rejection = "reject" in str(type(e).__name__).lower() or "reject" in str(
-                e
-            ).lower()
+            is_rejection = (
+                "reject" in str(type(e).__name__).lower() or "reject" in str(e).lower()
+            )
             if is_rejection and self.allow_partial_scrape:
                 self.logger.warning(
                     f"flhouse.gov bot detection triggered — stopping session early. "

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -227,9 +227,18 @@ class BillDetail(HtmlPage):
             self.process_amendments()
             self.process_summary()
             self.process_citations()
-        yield self.input  # the bill, now augmented
+        # self.input (the bill) is yielded LAST, after House/vote processing below,
+        # not first -- items are saved as they're yielded, so yielding it first (as
+        # this used to) would mean the bill's JSON is already written before
+        # ResilientFetchPage's classes get a chance to run, making it too late for
+        # a skip there to ever land in bill.extras["scrape_warnings"] (see
+        # ResilientFetchPage's docstring). Trade-off: if something *else* -- outside
+        # what ResilientFetchPage already catches -- fails unexpectedly in here, the
+        # bill's own core data (sponsors, versions, etc., already fully scraped
+        # above) is now also lost, not just saved-then-orphaned as before.
         yield HouseSearchPage(self.input)
         yield from self.process_votes()
+        yield self.input  # the bill, now augmented
 
     def process_sponsors(self):
         sponsor = self.root.xpath(
@@ -526,36 +535,56 @@ class ResilientFetchPage:
     surface a distinct "will retry next run" line in the GitHub Actions summary,
     separate from its generic error detection -- keep this prefix in sync with that
     grep if either side changes.
+
+    A log line alone isn't enough, though -- it tells someone reading scrape logs
+    that data is missing, but not a downstream consumer of the resulting bill JSON,
+    who has no way to distinguish "this bill genuinely has no House votes" from
+    "House votes were dropped after a fetch failure." So each skip is also recorded
+    in the bill's own `extras["scrape_warnings"]` (a plain list of strings) -- a
+    real, schema-validated field every OCD-style object has
+    (openstates.scrape.base.BaseModel sets `self.extras = {}`), not a log-only
+    signal. For this to actually land in the saved JSON, the bill itself must be
+    yielded *after* this mixin's classes have had a chance to run and record a
+    skip -- see the comment on BillDetail.process_page's yield order below.
     """
 
-    def _bill_identifier(self):
+    def _bill_object(self):
         # Overridden by subclasses whose self.input isn't a Bill directly (e.g. the
         # vote-PDF classes below, which take a dict with a "bill" key instead).
-        return self.input.identifier
+        return self.input
+
+    def _bill_identifier(self):
+        return self._bill_object().identifier
+
+    def _record_skip(self, message):
+        self._bill_object().extras.setdefault("scrape_warnings", []).append(message)
 
     def _fetch_data(self, scraper):
         try:
             super()._fetch_data(scraper)
         except (ConnectionError, URLError, Timeout, RequestException) as e:
-            self.logger.warning(
-                f"SKIPPED BILL: {self._bill_identifier()} -- {self.__class__.__name__} "
-                f"failed after exhausting retries, will retry on next nightly run: {e}"
+            message = (
+                f"{self.__class__.__name__} failed after exhausting retries, "
+                f"will retry on next nightly run: {e}"
             )
+            self.logger.warning(f"SKIPPED BILL: {self._bill_identifier()} -- {message}")
+            self._record_skip(message)
             raise HandledError(e)
         except RejectedResponse as e:
-            self.logger.warning(
-                f"SKIPPED BILL: {self._bill_identifier()} -- {self.__class__.__name__} "
-                f"was rejected (bot detection) after exhausting retries, will retry "
-                f"on next nightly run: {e}"
+            message = (
+                f"{self.__class__.__name__} was rejected (bot detection) after "
+                f"exhausting retries, will retry on next nightly run: {e}"
             )
+            self.logger.warning(f"SKIPPED BILL: {self._bill_identifier()} -- {message}")
+            self._record_skip(message)
             raise HandledError(e)
 
 
 class FloorVote(ResilientFetchPage, PdfPage):
     preserve_layout = True
 
-    def _bill_identifier(self):
-        return self.input["bill"].identifier
+    def _bill_object(self):
+        return self.input["bill"]
 
     def process_page(self):
         MOTION_INDEX = 4
@@ -663,8 +692,8 @@ class FloorVote(ResilientFetchPage, PdfPage):
 class UpperComVote(ResilientFetchPage, PdfPage):
     preserve_layout = True
 
-    def _bill_identifier(self):
-        return self.input["bill"].identifier
+    def _bill_object(self):
+        return self.input["bill"]
 
     def process_page(self):
         lines = self.text.splitlines()

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -13,7 +13,15 @@ import requests
 from openstates.scrape import Bill, VoteEvent, Scraper
 from openstates.utils import format_datetime
 from requests.exceptions import ConnectionError, Timeout, RequestException
-from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage, URL
+from spatula import (
+    HtmlPage,
+    HtmlListPage,
+    XPath,
+    SelectorError,
+    PdfPage,
+    URL,
+    HandledError,
+)
 
 from .actions import Categorizer
 from .utils import (
@@ -479,8 +487,52 @@ class BillDetail(HtmlPage):
             self.logger.warning("No vote table for {}".format(self.input.identifier))
 
 
-class FloorVote(PdfPage):
+class ResilientFetchPage:
+    """
+    Per-bill supplementary data -- House votes (HouseSearchPage -> HouseBillPage ->
+    HouseComVote, flhouse.gov) and floor/committee vote PDFs (FloorVote, UpperComVote,
+    flsenate.gov) -- is independent of every other bill. A single bill's fetch failing
+    here, even after patched_get_response above exhausts its own retries, must not
+    abort the other ~1,900 independent bills in the session. Converting the leftover
+    exception to spatula's own HandledError reuses the "nothing left to do with this
+    page, move on" handling spatula already applies to rejected responses, just for
+    transient network errors instead.
+
+    Deliberately NOT applied to BillList/BillDetail/SubjectPDF -- those are session-wide
+    or a bill's own core data, where silently swallowing a failure risks looking like a
+    complete, successful run when it isn't. This is only for data whose absence just
+    means "this one bill is missing some supplementary info," not "this bill or the
+    whole session is broken."
+
+    This scrape runs nightly, so a bill skipped tonight for a transient network blip
+    gets picked up again on the next run rather than staying missing. The "SKIPPED
+    BILL:" prefix is a stable marker govbot's actions/scrape/scrape.sh greps for to
+    surface a distinct "will retry next run" line in the GitHub Actions summary,
+    separate from its generic error detection -- keep this prefix in sync with that
+    grep if either side changes.
+    """
+
+    def _bill_identifier(self):
+        # Overridden by subclasses whose self.input isn't a Bill directly (e.g. the
+        # vote-PDF classes below, which take a dict with a "bill" key instead).
+        return self.input.identifier
+
+    def _fetch_data(self, scraper):
+        try:
+            super()._fetch_data(scraper)
+        except (ConnectionError, URLError, Timeout, RequestException) as e:
+            self.logger.warning(
+                f"SKIPPED BILL: {self._bill_identifier()} -- {self.__class__.__name__} "
+                f"failed after exhausting retries, will retry on next nightly run: {e}"
+            )
+            raise HandledError(e)
+
+
+class FloorVote(ResilientFetchPage, PdfPage):
     preserve_layout = True
+
+    def _bill_identifier(self):
+        return self.input["bill"].identifier
 
     def process_page(self):
         MOTION_INDEX = 4
@@ -585,8 +637,11 @@ class FloorVote(PdfPage):
         yield vote
 
 
-class UpperComVote(PdfPage):
+class UpperComVote(ResilientFetchPage, PdfPage):
     preserve_layout = True
+
+    def _bill_identifier(self):
+        return self.input["bill"].identifier
 
     def process_page(self):
         lines = self.text.splitlines()
@@ -688,7 +743,7 @@ class UpperComVote(PdfPage):
         yield vote
 
 
-class HouseSearchPage(HtmlListPage):
+class HouseSearchPage(ResilientFetchPage, HtmlListPage):
     """
     House committee roll calls are not available on the Senate's
     website. Furthermore, the House uses an internal ID system in
@@ -788,7 +843,7 @@ class HouseSearchPage(HtmlListPage):
             )
 
 
-class HouseBillPage(HtmlListPage):
+class HouseBillPage(ResilientFetchPage, HtmlListPage):
     selector = XPath('//a[text()="See Votes"]/@href', min_items=0)
     example_input = Bill(
         "HB 1", "2020", "title", chamber="upper", classification="bill"
@@ -802,7 +857,7 @@ class HouseBillPage(HtmlListPage):
         return HouseComVote(self.input, source=source)
 
 
-class HouseComVote(HtmlPage):
+class HouseComVote(ResilientFetchPage, HtmlPage):
     example_input = Bill(
         "HB 1", "2020", "title", chamber="upper", classification="bill"
     )

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -21,6 +21,7 @@ from spatula import (
     PdfPage,
     URL,
     HandledError,
+    RejectedResponse,
 )
 
 from .actions import Categorizer
@@ -504,6 +505,21 @@ class ResilientFetchPage:
     means "this one bill is missing some supplementary info," not "this bill or the
     whole session is broken."
 
+    Also catches RejectedResponse -- flhouse.gov's application-layer bot detection
+    (a "Request Rejected" page returned with HTTP 200) after HouseSearchPage's own
+    retries (see its `retries=3` source config) are exhausted. This is deliberately
+    treated the same as a transient network error: skip just this bill's House data
+    and move on, rather than stopping the whole session the way `allow_partial_scrape`
+    in `_process_bill_list` does for a *session-wide* rejection (e.g. on BillList's own
+    flsenate.gov fetch, which is NOT wrapped by this mixin). If flhouse.gov starts
+    blanket-blocking every bill, this will grind through the rest of the session
+    logging a "SKIPPED BILL:" per bill rather than stopping early -- slower, but still
+    yields ~1,900 bills with their core data intact, with the skip count itself making
+    the scope of the block visible rather than just failing the whole run outright.
+    Confirmed happening for real on bill 411, 2026-07-24 -- a run that had already
+    scraped 400+ bills cleanly crashed here, losing ~14 minutes of not-yet-auto-saved
+    progress and burning the rest of the run's time on a failed restart-from-scratch.
+
     This scrape runs nightly, so a bill skipped tonight for a transient network blip
     gets picked up again on the next run rather than staying missing. The "SKIPPED
     BILL:" prefix is a stable marker govbot's actions/scrape/scrape.sh greps for to
@@ -524,6 +540,13 @@ class ResilientFetchPage:
             self.logger.warning(
                 f"SKIPPED BILL: {self._bill_identifier()} -- {self.__class__.__name__} "
                 f"failed after exhausting retries, will retry on next nightly run: {e}"
+            )
+            raise HandledError(e)
+        except RejectedResponse as e:
+            self.logger.warning(
+                f"SKIPPED BILL: {self._bill_identifier()} -- {self.__class__.__name__} "
+                f"was rejected (bot detection) after exhausting retries, will retry "
+                f"on next nightly run: {e}"
             )
             raise HandledError(e)
 


### PR DESCRIPTION
## Problem

**The FL scraper produces less than 30 bills despite over 5 hours of active scraping.**

This is running on a self-hosted home-network runner (not Azure/cloud IPs), so IP blocking is not the issue. flhouse.gov uses application-layer bot detection — HTTP 200 responses with a "Request Rejected" HTML body after sustained scraping. Spatula's accept_response() correctly identifies these. The problem is the list() wrapper in scrape(), which prevents any bills from being written to disk until the entire session generator completes. Since the session never completes (bot detection hits at ~bill 160), only the 5-bill special session is saved — the regular session produces zero bills across all 3 retry attempts.

The scraper wraps its session generator in `list()`:

```python
yield from retry_on_connection_error(
    lambda: list(do_scrape_with_retry()),  # forces full materialization
    max_retries=3,
    ...
)
```

`list()` forces the **entire session** (~8,000 bills for FL 2026) to fully materialize before a single bill is yielded to OpenStates and written to disk. When `RejectedResponse` is raised at bill ~160, `list()` propagates the exception and **zero bills are saved** despite all the work done before it. The scraper retries 3 times with the same result.

Evidence from a self-hosted home-network runner:
```
spatula.pages.RejectedResponse: Response was rejected (4x) by accept_response: <Response [200]>
⚠️ scrape attempt 3 failed; sleeping 20s...
Found 22 JSON files in _working/_data/fl
```
(22 files = 5 bills from the special session + org/jurisdiction metadata — zero regular session bills)

## Fix

**1. Remove `list()` in `scrape()`** — yield directly from the generator so bills are written to disk as they complete:

```python
# before
yield from retry_on_connection_error(
    lambda: list(do_scrape_with_retry()),
    max_retries=3,
    initial_backoff=10,
    max_backoff=120,
)

# after
yield from do_scrape_with_retry()
```

**2. Catch `RejectedResponse` in `_process_bill_list()`** — wrap the `for` loop so the scraper exits cleanly with partial data instead of crashing:

```python
try:
    for item in bill_list.do_scrape():
        try:
            ...
            yield item
            ...
        except Exception as e:
            ...  # existing per-item error handling
except Exception as e:
    # flhouse.gov application-layer bot detection raises a spatula rejection error
    if "reject" in str(type(e).__name__).lower() or "reject" in str(e).lower():
        self.logger.warning(
            f"flhouse.gov bot detection triggered — stopping session early. "
            f"Bills processed before this point have been saved. ({e})"
        )
    else:
        raise
```

## Result

- Bills are saved to disk as they're yielded — a partial scrape produces partial output rather than zero output
- The scraper exits cleanly when bot detection triggers, allowing downstream tooling to use what was captured
- `BillDetail.process_page()` already yields `self.input` (the bill) before `HouseSearchPage`, so bills with senate data are saved even if the house vote fetch never completes

## Notes

- `flsenate.gov` does not block — only `flhouse.gov` triggers bot detection
- The bot detection appears to be rate/pattern-based, not IP-based; home-network IPs are affected after sustained scraping of `SessionId=113` (2026 regular session)
- A separate discussion about checkpoint/resume support for scrapers that regularly hit mid-session rate limits is being tracked in openstates/issues