### PR TITLE
WY: advance people scraper to 2025 session

### DIFF
--- a/scrapers_next/wy/people.py
+++ b/scrapers_next/wy/people.py
@@ -95,11 +95,19 @@ class LegList(JsonListPage):
         return LegDetail(p, source=URL(detail_link, timeout=30))
 
 
+# WY LSO API is keyed by the biennium's start year; bump this each new session.
+SESSION = "2025"
+
+
 class Senate(LegList):
-    source = URL("https://wyoleg.gov/LsoService/api/legislator/2023/S", timeout=30)
+    source = URL(
+        f"https://wyoleg.gov/LsoService/api/legislator/{SESSION}/S", timeout=30
+    )
     chamber = "upper"
 
 
 class House(LegList):
-    source = URL("https://wyoleg.gov/LsoService/api/legislator/2023/H", timeout=30)
+    source = URL(
+        f"https://wyoleg.gov/LsoService/api/legislator/{SESSION}/H", timeout=30
+    )
     chamber = "lower"


### PR DESCRIPTION
Apologies for the overzealous Claude description. This should fix pulling in the latest phones for WY reps.

## Problem

The WY people scraper's `Senate`/`House` list endpoints were pinned to the 2023 biennium (`https://wyoleg.gov/LsoService/api/legislator/2023/{S,H}`). That endpoint now returns only a partial, stale roster — **37 House + 26 Senate = 63** — and carries **no phone numbers for current members**. As a result the committed WY YAML has current members (kept up via other paths) but empty `district_office.voice` for most of them.

## Fix

Point the list endpoints at the current **2025** session via a single `SESSION` constant (so future biennium bumps are a one-line change and both chambers can't drift out of sync).

## Verification

Ran the scraper's `process_item` over the live 2025 endpoints:

- `2025/H` → **62** representatives, **62** with `district_office.voice`
- `2025/S` → **31** senators, **31** with `district_office.voice`
- **Total: 93 people, 93 with a phone** (previously most were empty)

`black --check` and `flake8` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)