### PR TITLE
VA: add 2027 session, inactive for now

### DIFF
--- a/scrapers/va/__init__.py
+++ b/scrapers/va/__init__.py
@@ -255,6 +255,15 @@ class Virginia(State):
             "active": True,
             "extras": {"session_code": "20262"},
         },
+        {
+            "_scraped_name": "2027 Regular Session",
+            "identifier": "2027",
+            "name": "2027 Regular Session",
+            "start_date": "2027-01-13",
+            "end_date": "2027-02-27",
+            "active": False,
+            "extras": {"session_code": "20271"},
+        },
     ]
     ignored_scraped_sessions = [
         "2025 Session",


### PR DESCRIPTION
Virginia [says that 2027 prefiles start July 20](https://dls.virginia.gov/pubs/calendar/cal2027_1.pdf), so we will need to come back and check when bills actually start showing up (@showerst )

There is no data (literally 204 response) for 2027 session at present. 