### PR TITLE
CO: bills: fix leading space on sponsor names preventing match

### DIFF
--- a/scrapers/co/bills.py
+++ b/scrapers/co/bills.py
@@ -240,7 +240,7 @@ class COBillScraper(Scraper, LXMLMixin):
         ):
             sponsor = self.clean(row)
             chamber = "upper" if "Sen." in sponsor else "lower"
-            sponsor = sponsor.replace("Sen.", "").replace("Rep.", "")
+            sponsor = sponsor.replace("Sen.", "").replace("Rep.", "").strip()
             bill.add_sponsorship(
                 sponsor,
                 classification="sponsor",


### PR DESCRIPTION
cc @harshitasingh360 just since this is kind of a fun gotcha. In the previous code here the sponsor name was "cleaned," but after that the bill sponsor's title (Rep or Sen) is removed from the string. However there was a space between the title and the name, so the space was retained. This lead to sponsor names being scraped like:

` A. Smith` <- leading space character

And that was causing sponsor names not to be matched to their Person records. 

I'm going to try to fix this upstream as well so a scraper mistake like this can't cause a big problem. But thought it was a "fun" example of how a small, easy-to-miss mistake in string handling can lead to significant bugs.