### PR TITLE
Missing DE Bills

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -288,13 +288,7 @@ class DEBillScraper(Scraper, LXMLMixin):
         for fiscal in fiscals:
             self.scrape_fiscal_note(bill, fiscal)
 
-        try:
-            self.scrape_actions(bill, row["LegislationId"])
-        except:  # noqa: E722
-            # Collecting bills we had to skip because of failure to fetch
-            failure = FailedBillFetch(bill_id, "fetch_bill_page")
-            yield failure
-            return
+        self.scrape_actions(bill, row["LegislationId"])
 
         if row["HasAmendments"] is True:
             self.scrape_amendments(bill, row["LegislationId"])
@@ -511,7 +505,16 @@ class DEBillScraper(Scraper, LXMLMixin):
             verify=False,
             headers=self.headers,
         )
-        page = self.decode_and_retry_request("scrape_actions", request_method)
+        page = self.decode_and_retry_request(
+            "scrape_actions", request_method, raise_exception=False
+        )
+        # DE sometimes returns an empty body for a bill's actions (notably for
+        # very recently introduced bills). Treat that as "no actions yet" rather
+        # than a fatal failure, so the bill is still imported. Actions will
+        # backfill automatically once DE's endpoint returns data.
+        if not page:
+            self.warning(f"No actions returned for {bill.identifier}")
+            return
         for row in page["Data"]:
             action_name = row["ActionDescription"]
             action_date = dt.datetime.strptime(


### PR DESCRIPTION
**Root Cause**
The bills HB 481 and HB 479 were being fetched fine from the DE search API, but were dropped during the action-scraping step. The scraper caught any failure while fetching a bill's actions and, on failure, discarded the entire bill rather than keeping it.
Delaware's actions endpoint returns an empty or undecodable response for very recently introduced bills (both of these are new — session 153, introduced around the June 30 timeframe). When the scraper's retries were exhausted, this empty response was treated as a failure, so the bill was dropped on every run. That's why these two bills were persistently missing despite the scraper running regularly.
**The Fix**
Two coordinated changes were made. First, the scraper no longer discards a bill when its actions fail to load. Second, when Delaware returns an empty actions response, the scraper now treats it as "no actions yet" (logging a warning) instead of a fatal failure, so the bill is still imported.
**Verification**
Both bills are now present and well-formed in the scraper output. HB 481 has the correct identifier, session 153, its title and abstract, one primary sponsor, and its source URL. HB 479 likewise has the correct identifier, session 153, its title and abstract, one primary sponsor (Frank Burns), and its source URL. Both bills currently have no actions, which is expected and correct — these are brand-new bills for which Delaware's actions endpoint returns no data yet. Actions will backfill automatically on future runs once Delaware's endpoint starts returning data.
The bills on the Delaware website:
**- HB 481:** https://legis.delaware.gov/BillDetail?LegislationId=143678
**- HB 479:** https://legis.delaware.gov/BillDetail?LegislationId=143675
**Conclusion**
The output is in line with what the fix intends. Both previously-missing bills are now produced as valid records with correct identifiers, titles, abstracts, sponsors, and sources.