### PR TITLE
IL: events: fix missing events #5728

### DIFF
--- a/scrapers/il/events.py
+++ b/scrapers/il/events.py
@@ -41,7 +41,7 @@ class IlEventScraper(Scraper):
         ctty_name = committee_name_re.match(ctty_name).group(1)
 
         tables = doc.xpath(
-            '//div[contains(@class, "card")][.//h4[contains(., "Hearing Details")]]//table'
+            '//div[contains(@class, "card")][.//h2[contains(., "Hearing Details")]]//table'
         )
         if not tables:
             self.warning(f"Empty hearing data for {url}")


### PR DESCRIPTION
The IL events scraper (scrapers/il/events.py) is reporting “no objects returned" from IL EventScraper scrape, but there IS an event it should be getting.


There was a change in the XPath that caused the issue in the IL events scraper. The heading tag changed from h4 to h2.