### PR TITLE
AZ: fix cache-poisoning bug where --fastmode masks the session-setting POST

### DIFF
--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -413,7 +413,20 @@ class AZBillScraper(Scraper):
 
         bill_list_url = "https://www.azleg.gov/bills/"
 
-        page = self.get(bill_list_url, timeout=80, cookies=session_cookies).content
+        # scrapelib's FileCache keys purely on URL, ignoring cookies -- so under
+        # --fastmode (which flips cache_write_only to False, enabling cache *reads*),
+        # this GET to the same bill_list_url as the pre-session-set request above would
+        # be served from that earlier cached response instead of hitting the network,
+        # meaning it can never reflect the session cookie set by the POST just above.
+        # That produces a 100%-reproducible "Session ID not in bill list" assertion
+        # failure regardless of network path -- confirmed via direct reproduction
+        # against a fresh cache. Force a live fetch for this one request.
+        cache_write_only = self.cache_write_only
+        self.cache_write_only = True
+        try:
+            page = self.get(bill_list_url, timeout=80, cookies=session_cookies).content
+        finally:
+            self.cache_write_only = cache_write_only
         # There's an errant close-comment that browsers handle
         # but LXML gets really confused.
         page = page.replace(b"--!>", b"-->")


### PR DESCRIPTION
## Summary

Fixes `AssertionError: Session ID not in bill list`, which has caused zero bills to be scraped for Arizona.

Thanks to the cookie-handling fix in #5722 (merged) for ruling out the cookie-merge angle -- that let us keep digging and turned up a deeper root cause underneath it.

**What's actually happening**: `scrape()` does GET `/bills/` -> POST `setsession.php` -> GET `/bills/` again, asserting the session now shows as `selected`. Turns out our own `--fastmode` flag (which sets `cache_write_only = False` in `openstates/scrape/base.py`) enables scrapelib's `FileCache` to serve GET responses from disk, keyed only on URL -- cookies aren't part of the cache key. So that second GET was quietly being served the *first* GET's cached response, from before the session was ever set. It's 100% reproducible on every run, independent of network/hosting, which is what made it look like a persistent site-side block for so long.

Confirmed by reproducing from a fresh `_cache/` dir with a small scrapelib script -- the cached page had no `<option selected>` at all. The same 3-step flow with a plain `requests`/`curl` session (no fastmode-style caching) works cleanly every time, which is probably also why it was hard to reproduce outside of a `--fastmode` run.

**Fix**: force a live fetch (bypass the cache read) for just that one post-session GET.

**Confirmed working live**: dispatched through our pipeline against the real site -- first successful AZ scrape we've seen, 2,190 bills / 3,462 vote events, committed cleanly: [run 30109209415](https://github.com/govbot-openstates-scrapers/az-legislation/actions/runs/30109209415).

Related to openstates/issues#1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)