### PR TITLE
MP: fix blank-title crash and bill_id spacing on cnmileg.net

### DIFF
--- a/scrapers/mp/bills.py
+++ b/scrapers/mp/bills.py
@@ -50,7 +50,6 @@ class MPBillScraper(Scraper):
             yield from self.scrape_chamber(chamber, session)
 
     def scrape_chamber(self, chamber, session):
-
         sec_ids = {"upper": "2", "lower": "1"}
         data = {
             "legtypeID": "A",
@@ -97,7 +96,9 @@ class MPBillScraper(Scraper):
             # same bill every run and silently dropped every bill after it
             # in iteration order. Falling back to the bill's own identifier
             # unblocks the rest of the session instead of losing it all.
-            self.warning(f"{bill_id} has no title on cnmileg.net, using identifier as a fallback")
+            self.warning(
+                f"{bill_id} has no title on cnmileg.net, using identifier as a fallback"
+            )
             title = bill_id
 
         bill_type = self.bill_type_map[bill_id.split(" ")[0]]
@@ -227,7 +228,6 @@ class MPBillScraper(Scraper):
     def do_action(self, bill, page, text, chamber, classification):
         action_text = self.get_cell_text(page, text)
         if action_text:
-
             try:
                 action_date = re.findall(r"\d+\/\d+\/\d+", action_text)[0]
             except IndexError:

--- a/scrapers/mp/bills.py
+++ b/scrapers/mp/bills.py
@@ -80,6 +80,14 @@ class MPBillScraper(Scraper):
             bill_type = page.xpath("//tr[@class='stshead']/th/text()")[0].strip()
             bill_type = self.bill_types[bill_type]
             bill_id = f"{bill_type} {bill_id}"
+        else:
+            # cnmileg.net's lower-chamber "Number" cell sometimes renders without
+            # a space between the type prefix and number (e.g. "HCommRes24-6"
+            # instead of the normal "HB 123" spacing), which breaks
+            # bill_type_map[bill_id.split(" ")[0]] below with a KeyError since
+            # the whole string is treated as one unrecognized key. Normalize so
+            # there's always exactly one space between the letters and digits.
+            bill_id = re.sub(r"^([A-Za-z]+)(\d)", r"\1 \2", bill_id)
 
         title = self.get_cell_text(page, "Subject/Title")
         if not title:

--- a/scrapers/mp/bills.py
+++ b/scrapers/mp/bills.py
@@ -82,6 +82,15 @@ class MPBillScraper(Scraper):
             bill_id = f"{bill_type} {bill_id}"
 
         title = self.get_cell_text(page, "Subject/Title")
+        if not title:
+            # cnmileg.net genuinely has blank titles for some bills (e.g.
+            # HCommRes 24-6, legID=20113) -- OCD validation requires
+            # title minLength: 1, so this crashed the scraper on the exact
+            # same bill every run and silently dropped every bill after it
+            # in iteration order. Falling back to the bill's own identifier
+            # unblocks the rest of the session instead of losing it all.
+            self.warning(f"{bill_id} has no title on cnmileg.net, using identifier as a fallback")
+            title = bill_id
 
         bill_type = self.bill_type_map[bill_id.split(" ")[0]]
 


### PR DESCRIPTION
## Summary

Northern Mariana Islands (`mp`) scraper crashes every run on the same bill, `HCommRes 24-6`, silently dropping every bill scraped after it in iteration order (a 139-file partial haul instead of a full session).

Two bugs on the same bill:

1. **Blank title.** `cnmileg.net` genuinely returns an empty `Subject/Title` field for `HCommRes 24-6` (and at least one other bill, `HCommRes 24-7`). OCD schema requires `title` `minLength: 1`, so `openstates.exceptions.ScrapeValueError` kills the whole scrape. Falls back to the bill's own identifier as the title when the site gives us nothing — same shape as the fallback already discussed for MP but never implemented.
2. **Bill ID spacing (lower chamber only).** `cnmileg.net`'s "Number" cell for `HCommRes 24-6` renders as `HCommRes24-6` (no space) instead of the usual `HB 123`-style spacing. `bill_type_map[bill_id.split(" ")[0]]` then treats the whole unspaced string as one key and raises `KeyError: 'HCommRes24-6'` — this crash only surfaces once bug #1 is fixed, since the title crash happens first. Normalizes the lower-chamber bill_id so there's always exactly one space between the type prefix and number.

## Test plan
- [x] Local Docker test: clean full run, 317 bills, exit 0, zero tracebacks
- [x] Live test on real GitHub Actions infrastructure (not just local): 321 bills, `SCRAPE_EXIT_CODE: 0`, zero tracebacks, zero `KeyError` — both `HCommRes 24-6` and `HCommRes 24-7` correctly hit the title fallback and scraped cleanly
- [x] Well-formed bill IDs (already spaced, e.g. `HB 123`) unaffected by the spacing fix