### PR TITLE
TX: events: Improvements

### DIFF
--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -94,7 +94,7 @@ class TXEventScraper(Scraper, LXMLMixin):
             chair = re.sub(r"(Rep\. |Senator |Representative |Sen\. )", "", chair)
 
         plaintext = re.sub(r"\s+", " ", plaintext).strip()
-        bills = bill_re.findall(plaintext)
+        # bills = bill_re.findall(plaintext)
 
         event = Event(
             name=committee,
@@ -135,11 +135,11 @@ class TXEventScraper(Scraper, LXMLMixin):
                 text = " ".join("".join(span.itertext()).split())
                 if text and text not in results:
                     agenda_text = text.rstrip(" :")
-                    agenda = event.add_agenda_item(agenda_text)
+                    event.add_agenda_item(agenda_text)
 
-        for alpha, num in bills:
-            bill_id = f"{alpha} {num}"
-            agenda.add_bill(bill_id)
+        # for alpha, num in bills:
+        #     bill_id = f"{alpha} {num}"
+        #     agenda.add_bill(bill_id)
 
         day = datetime.strftime("%Y-%m-%d")
         videos = []

--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -95,13 +95,18 @@ class TXEventScraper(Scraper, LXMLMixin):
         bills = bill_re.findall(plaintext)
 
         event = Event(
-            name=committee, start_date=self._tz.localize(datetime), location_name=where, status=status
+            name=committee,
+            start_date=self._tz.localize(datetime),
+            location_name=where,
+            status=status,
         )
         event.dedupe_key = url
 
         pdf_document = url.replace("html", "pdf").replace("HTM", "pdf")
 
-        event.add_document(note="Agenda PDF", url=pdf_document, media_type="application/pdf")
+        event.add_document(
+            note="Agenda PDF", url=pdf_document, media_type="application/pdf"
+        )
 
         event.add_source(url)
 
@@ -131,7 +136,7 @@ class TXEventScraper(Scraper, LXMLMixin):
                     results.append(text.rstrip(" :"))
 
         results = ", ".join(results)
-        agenda = event.add_agenda_item(results if results else 'Agenda Not found')
+        agenda = event.add_agenda_item(results if results else "Agenda Not found")
 
         for alpha, num in bills:
             bill_id = f"{alpha} {num}"
@@ -199,7 +204,11 @@ class TXEventScraper(Scraper, LXMLMixin):
                 datetime = dt.datetime.strptime(datetime, "%A, %B %d, %Y %I:%M %p")
 
                 yield from self.scrape_event_page(
-                    session, chamber, event.attrib["href"], datetime, status="cancelled" if cancelled else "confirmed"
+                    session,
+                    chamber,
+                    event.attrib["href"],
+                    datetime,
+                    status="cancelled" if cancelled else "confirmed",
                 )
 
     def scrape_committee_upcoming(self, session, chamber):

--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -101,11 +101,7 @@ class TXEventScraper(Scraper, LXMLMixin):
 
         pdf_document = url.replace("html", "pdf").replace("HTM", "pdf")
 
-        event.add_document(
-            note="Agenda PDF",  
-            url=pdf_document,
-            media_type="application/pdf",        
-        )
+        event.add_document(note="Agenda PDF", url=pdf_document, media_type="application/pdf")
 
         event.add_source(url)
 

--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -63,7 +63,9 @@ class TXEventScraper(Scraper, LXMLMixin):
         if event_count < 1:
             raise EmptyScrape
 
-    def scrape_event_page(self, session, chamber, url, datetime, status=None, pdf_link=None):
+    def scrape_event_page(
+        self, session, chamber, url, datetime, status=None, pdf_link=None
+    ):
         try:
             page = self.lxmlize(url)
         except scrapelib.HTTPError:
@@ -212,7 +214,7 @@ class TXEventScraper(Scraper, LXMLMixin):
                     event.attrib["href"],
                     datetime,
                     status="cancelled" if cancelled else "confirmed",
-                    pdf_link=pdf_href
+                    pdf_link=pdf_href,
                 )
 
     def scrape_committee_upcoming(self, session, chamber):

--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -63,7 +63,7 @@ class TXEventScraper(Scraper, LXMLMixin):
         if event_count < 1:
             raise EmptyScrape
 
-    def scrape_event_page(self, session, chamber, url, datetime, status=None):
+    def scrape_event_page(self, session, chamber, url, datetime, status=None, pdf_link=None):
         try:
             page = self.lxmlize(url)
         except scrapelib.HTTPError:
@@ -102,11 +102,10 @@ class TXEventScraper(Scraper, LXMLMixin):
         )
         event.dedupe_key = url
 
-        pdf_document = url.replace("html", "pdf").replace("HTM", "pdf")
-
-        event.add_document(
-            note="Agenda PDF", url=pdf_document, media_type="application/pdf"
-        )
+        if pdf_link:
+            event.add_document(
+                note="Agenda PDF", url=pdf_link, media_type="application/pdf"
+            )
 
         event.add_source(url)
 
@@ -133,10 +132,8 @@ class TXEventScraper(Scraper, LXMLMixin):
             for span in p_element.xpath(xpath):
                 text = " ".join("".join(span.itertext()).split())
                 if text and text not in results:
-                    results.append(text.rstrip(" :"))
-
-        results = ", ".join(results)
-        agenda = event.add_agenda_item(results if results else "Agenda Not found")
+                    agenda_text = text.rstrip(" :")
+                    agenda = event.add_agenda_item(agenda_text)
 
         for alpha, num in bills:
             bill_id = f"{alpha} {num}"
@@ -188,9 +185,15 @@ class TXEventScraper(Scraper, LXMLMixin):
                 time = time_elem[0].text_content()
 
             # cancelled = row.xpath("./td/span[contains(@class, 'redText')]").  # Can be used as a backup if the text changes in the future.
-            cancelled = row.xpath("./td/span[contains(text(), 'Canceled')]")
+            cancelled = row.xpath("./td/span[contains(text(), 'Cancel')]")
             if cancelled:
                 print(f"Event on {date} at {time} is cancelled, skipping.")
+            pdf_links = row.xpath(".//td[@data-label='Hearing Notice']//a")
+            for link in pdf_links:
+                href = link.get("href", "")
+                if href.lower().endswith(".pdf"):
+                    pdf_href = href
+                    break
 
             events = row.xpath(".//a[contains(@href, 'schedules/html')]")
             for event in events:
@@ -209,6 +212,7 @@ class TXEventScraper(Scraper, LXMLMixin):
                     event.attrib["href"],
                     datetime,
                     status="cancelled" if cancelled else "confirmed",
+                    pdf_link=pdf_href
                 )
 
     def scrape_committee_upcoming(self, session, chamber):

--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -63,7 +63,7 @@ class TXEventScraper(Scraper, LXMLMixin):
         if event_count < 1:
             raise EmptyScrape
 
-    def scrape_event_page(self, session, chamber, url, datetime):
+    def scrape_event_page(self, session, chamber, url, datetime, status=None):
         try:
             page = self.lxmlize(url)
         except scrapelib.HTTPError:
@@ -95,9 +95,17 @@ class TXEventScraper(Scraper, LXMLMixin):
         bills = bill_re.findall(plaintext)
 
         event = Event(
-            name=committee, start_date=self._tz.localize(datetime), location_name=where
+            name=committee, start_date=self._tz.localize(datetime), location_name=where, status=status
         )
         event.dedupe_key = url
+
+        pdf_document = url.replace("html", "pdf").replace("HTM", "pdf")
+
+        event.add_document(
+            note="Agenda PDF",  
+            url=pdf_document,
+            media_type="application/pdf",        
+        )
 
         event.add_source(url)
 
@@ -106,8 +114,28 @@ class TXEventScraper(Scraper, LXMLMixin):
         if chair is not None:
             event.add_participant(chair, type="legislator", note="chair")
 
-        # add a single agenda item, attach all bills
-        agenda = event.add_agenda_item(plaintext)
+        # add a agenda item, attach all bills
+
+        xpath = """
+        .//b[following-sibling::span[starts-with(normalize-space(), ':') or starts-with(normalize-space(), '-')]]//span
+
+        |
+
+        .//b//span[substring(normalize-space(), string-length(normalize-space()))=':' or substring(normalize-space(), string-length(normalize-space()))='-']
+
+        |
+
+        .//span/b[substring(normalize-space(), string-length(normalize-space()))=':']
+        """
+        results = []
+        for p_element in page.xpath("//p"):
+            for span in p_element.xpath(xpath):
+                text = " ".join("".join(span.itertext()).split())
+                if text and text not in results:
+                    results.append(text.rstrip(" :"))
+
+        results = ", ".join(results)
+        agenda = event.add_agenda_item(results if results else 'Agenda Not found')
 
         for alpha, num in bills:
             bill_id = f"{alpha} {num}"
@@ -158,6 +186,11 @@ class TXEventScraper(Scraper, LXMLMixin):
             if time_elem:
                 time = time_elem[0].text_content()
 
+            # cancelled = row.xpath("./td/span[contains(@class, 'redText')]").  # Can be used as a backup if the text changes in the future.
+            cancelled = row.xpath("./td/span[contains(text(), 'Canceled')]")
+            if cancelled:
+                print(f"Event on {date} at {time} is cancelled, skipping.")
+
             events = row.xpath(".//a[contains(@href, 'schedules/html')]")
             for event in events:
                 # Ignore text after the datetime proper (ie, after "AM" or "PM")
@@ -170,7 +203,7 @@ class TXEventScraper(Scraper, LXMLMixin):
                 datetime = dt.datetime.strptime(datetime, "%A, %B %d, %Y %I:%M %p")
 
                 yield from self.scrape_event_page(
-                    session, chamber, event.attrib["href"], datetime
+                    session, chamber, event.attrib["href"], datetime, status="cancelled" if cancelled else "confirmed"
                 )
 
     def scrape_committee_upcoming(self, session, chamber):


### PR DESCRIPTION
Problem: 
1. The agenda was being added as one long text string that basically contains all of the text from the event page. Instead, we can capture main agenda text for that event.
2. Events are marked cancelled. However in the scraped data output these have a status property of “confirmed” (should be cancelled)
3. Every event listed on at least the has a link to a PDF document shown in the listing table. This PDF link should be added as a “document” on the event.

Fixes:
1. Added shorter format of agenda to the scraped data present in bold text on the website.
2. Correction of the events status.
3. Appended the PDF link to the scraped data as document.
