### PR TITLE
fix(mi): OPEN-17 - prevent CommandError when get_session_list() returns nothing

### DIFF
--- a/.codebot/test.sh
+++ b/.codebot/test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# CodeBot test helper for openstates-scrapers.
+#
+# Runs this repo's real (small) unit test suite against THIS checkout (the
+# clone CodeBot is editing), in an isolated, throwaway Docker container built
+# from this repo's own Dockerfile — no Postgres/Redis needed (this repo's
+# only working tests touch no DB, no network, no fixtures/cassettes) and no
+# compose stack needed for the same reason.
+#
+# IMPORTANT — scoped to tests/ deliberately, NOT a bare `pytest`:
+#   scrapers/il/tests/ contains legacy, Python-2-era tests (`from nose.tools
+#   import *` — nose isn't even in this repo's poetry.lock — plus
+#   str.decode() calls). setup.cfg's own flake8 config excludes this
+#   directory for the same reason. A bare `pytest` run from repo root fails
+#   at collection before it ever reaches a real test. Only tests/ (currently
+#   tests/test_classify_motion.py) is a real, passing, Python-3-compatible
+#   test file.
+#
+# This repo's own CI (.github/workflows/lint.yml) only runs flake8 + black
+# --check, never pytest — so there is no existing "how CI tests this" recipe
+# to mirror here; this script is this repo's first real automated-test
+# runner, scoped to what's actually real and passing today.
+#
+# The devos `test-ticket` skill invokes this via the required `.codebot/test.sh`
+# entrypoint (Step 0 of that skill looks for that exact path at the repo root).
+#
+# Usage:
+#   .codebot/test.sh [TICKET_KEY] [extra pytest args/paths, still under tests/]
+#
+# Exit code is pytest's exit code (0 = all tests passed).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TICKET_KEY="${1:-run}"
+shift || true
+TEST_ARGS=("$@")
+if [[ ${#TEST_ARGS[@]} -eq 0 ]]; then
+  TEST_ARGS=(tests/)
+fi
+
+SAFE_KEY="$(echo "${TICKET_KEY}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | sed 's/-\{2,\}/-/g; s/^-//; s/-$//')"
+# Image tag scoped by ticket key + PID, not a fixed shared name — CAMS's
+# worker pool can run multiple CodeBot tickets concurrently.
+IMAGE="codebot-openstates-scrapers-test:${SAFE_KEY:-run}-$$"
+
+cleanup() {
+  docker rmi "${IMAGE}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo ">>> CodeBot isolated test run for ${TICKET_KEY} (openstates-scrapers)"
+echo ">>> image=${IMAGE}"
+
+echo ">>> building image from this checkout..."
+docker build -q -t "${IMAGE}" "${REPO_ROOT}" >/dev/null
+
+echo ">>> running: pytest ${TEST_ARGS[*]}"
+# Override the image's own ENTRYPOINT (docker_entrypoint.sh, meant for the
+# real scrape jobs) — this run only needs `poetry run pytest`.
+docker run --rm --entrypoint poetry "${IMAGE}" run pytest "${TEST_ARGS[@]}"

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -343,6 +343,15 @@ class AZBillScraper(Scraper):
                 """
                 ayes = action["Ayes"] if "Ayes" in action and action["Ayes"] else 0
                 nays = action["Nays"] if "Nays" in action and action["Nays"] else 0
+                # Skip summary/procedural passage actions that carry no recorded
+                # vote: AZ's feed includes "Passed" lines with no Ayes/Nays and an
+                # empty Votes[] list. Emitting a VoteEvent for those creates an empty
+                # motion that can shadow the real recorded vote downstream.
+                votes_list = (
+                    action["Votes"] if "Votes" in action and action["Votes"] else []
+                )
+                if not votes_list and ayes == 0 and nays == 0:
+                    continue
                 """
                 safer to fall back to negative results than
                 to incorrectly mark votes as passed

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -4,6 +4,7 @@ import re
 
 from lxml import html
 from openstates.scrape import Scraper, Bill, VoteEvent
+from classify_motion import classify_motion
 from utils import get_session_meta
 
 from . import utils
@@ -360,7 +361,7 @@ class AZBillScraper(Scraper):
                 vote = VoteEvent(
                     chamber={"S": "upper", "H": "lower"}[header["LegislativeBody"]],
                     motion_text=action["Action"],
-                    classification="passage",
+                    classification=classify_motion("az", action["Action"]),
                     result=result,
                     start_date=action_date.strftime("%Y-%m-%d"),
                     bill=bill,

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -23,7 +23,7 @@ class AZBillScraper(Scraper):
         "SS": "Secretary of State",
     }
 
-    def scrape_bill(self, chamber, session, bill_id, session_id):
+    def scrape_bill(self, chamber, session, bill_id, session_id, start_dt=None):
         bill_json_url = (
             "https://apps.azleg.gov/api/Bill/?billNumber={}&sessionId={}&"
             "legislativeBody={}".format(bill_id, session_id, self.chamber_map[chamber])
@@ -34,6 +34,26 @@ class AZBillScraper(Scraper):
         if not page:
             self.warning("null page for %s", bill_id)
             return
+
+        if start_dt:
+            all_dates = []
+            for action in page.get("BillStatusAction") or []:
+                d = action.get("ReportDate", "")
+                if d:
+                    all_dates.append(d.split(".")[0])
+            for key in ("IntroducedDate", "PreFileDate", "GovernorActionDate"):
+                if page.get(key):
+                    all_dates.append(page[key].split(".")[0])
+            if all_dates:
+                try:
+                    latest = max(
+                        datetime.datetime.strptime(d, "%Y-%m-%dT%H:%M:%S")
+                        for d in all_dates
+                    )
+                    if latest <= start_dt:
+                        return
+                except ValueError:
+                    pass
 
         bill_title = page["ShortTitle"]
         bill_id = page["Number"]
@@ -383,7 +403,13 @@ class AZBillScraper(Scraper):
                 vote.dedupe_key = f"{resp.url}{action['ReferralNumber']}"
                 yield vote
 
-    def scrape(self, chamber=None, session=None):
+    def scrape(self, chamber=None, session=None, start=None):
+        start_dt = None
+        if start:
+            try:
+                start_dt = datetime.datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+            except (ValueError, AttributeError):
+                pass
         meta = get_session_meta(self, session)
         session_id = meta.get("extras", {}).get("session_id", None)
 
@@ -429,7 +455,7 @@ class AZBillScraper(Scraper):
                 bill_rows = page.xpath('//div[@name="SBTable"]//tbody//tr')
             for row in bill_rows:
                 bill_id = row.xpath("th/a/text()")[0]
-                yield from self.scrape_bill(chamber, session, bill_id, session_id)
+                yield from self.scrape_bill(chamber, session, bill_id, session_id, start_dt=start_dt)
 
         # TODO: MBTable - Non-bill Misc Motions?
 

--- a/scrapers/az/bills.py
+++ b/scrapers/az/bills.py
@@ -12,6 +12,9 @@ from . import session_metadata
 
 
 BASE_URL = "https://www.azleg.gov/"
+# Module-level so other tools (e.g. ddp-open-states's bill-document archive step) can import
+# this directly instead of keeping their own hand-copied duplicate that can drift out of sync.
+USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36"
 
 
 class AZBillScraper(Scraper):
@@ -435,7 +438,7 @@ class AZBillScraper(Scraper):
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
             "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
             "Referer": "https://www.azleg.gov/azlegwp/",
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36",
+            "User-Agent": USER_AGENT,
         }
         req = self.post(
             url=session_form_url,

--- a/scrapers/classify_motion.py
+++ b/scrapers/classify_motion.py
@@ -1,0 +1,64 @@
+import logging
+import re
+import yaml
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_config = yaml.safe_load(
+    (Path(__file__).parent / "config" / "motion_classification.yaml").read_text()
+)
+
+_PREPROCESSORS = {
+    "strip_sequence_number": lambda t: re.sub(r"\s*\(#\d+\)\s*$", "", t),
+}
+
+# Exact jurisdiction keys expected by scrapers — asserted in the test suite.
+KNOWN_JURISDICTIONS = frozenset(_config["jurisdictions"].keys())
+
+
+def classify_motion(jurisdiction: str, motion_text: str, bill_action: str = None) -> list:
+    """Return an OpenStates motion_classification list for a vote event.
+
+    Args:
+        jurisdiction: Two-letter key matching a jurisdictions entry in
+                      config/motion_classification.yaml (e.g. "us", "az").
+        motion_text:  The raw motion text from the legislature source.
+        bill_action:  Optional secondary field used by Virginia to distinguish
+                      committee-passage from floor-passage via the
+                      LegislationActionDescription field.
+
+    Returns:
+        A list such as ["passage"], ["committee-passage"], or [].
+        Unknown jurisdictions log a warning and return [].
+    """
+    cfg = _config["jurisdictions"].get(jurisdiction)
+    if cfg is None:
+        logger.warning("classify_motion: unknown jurisdiction %r — returning []", jurisdiction)
+        return []
+
+    t = (motion_text or "").strip().lower()
+
+    if preprocess := cfg.get("preprocess"):
+        preprocessor = _PREPROCESSORS.get(preprocess)
+        if preprocessor is None:
+            raise ValueError(
+                f"classify_motion: unknown preprocessor {preprocess!r} for jurisdiction {jurisdiction!r}"
+            )
+        t = preprocessor(t)
+
+    if bill_action and (ba_cfg := cfg.get("bill_action")):
+        a = bill_action.strip().lower()
+        if any(re.search(p, a) for p in ba_cfg.get("committee_passage", [])):
+            return ["committee-passage"]
+
+    if any(re.search(p, t) for p in cfg.get("not_passage", [])):
+        return []
+
+    if any(re.search(p, t) for p in cfg.get("committee_passage", [])):
+        return ["committee-passage"]
+
+    if any(re.search(p, t) for p in cfg.get("passage", [])):
+        return ["passage"]
+
+    return ["passage"] if cfg.get("default") == "passage" else []

--- a/scrapers/config/motion_classification.yaml
+++ b/scrapers/config/motion_classification.yaml
@@ -1,0 +1,102 @@
+# Motion passage classification patterns per jurisdiction.
+# Loaded once at import time by classify_motion.py.
+#
+# All patterns use re.search. Anchor with ^ for prefix matching.
+# Evaluation order per jurisdiction: bill_action → not_passage → committee_passage → passage → default.
+# default: null returns [] for unrecognised texts; default: passage returns ["passage"].
+
+jurisdictions:
+  us:
+    not_passage:
+      - "^on cloture on the motion to proceed"   # scheduling vote, not passage cloture
+      - "^measure laid before"
+      - "^resolving differences"
+      - "^postponed proceedings"
+      - "^ordered to be reported"
+    passage:
+      - "^on passage"
+      - "^on motion to suspend the rules and"
+      - "^on agreeing to the resolution"
+      - "^on the joint resolution"
+      - "^on the concurrent resolution"
+      - "^on the resolution [a-z]"
+      - "^on the cloture motion"                 # "On the Cloture Motion (S.XXX)" — genuine passage cloture
+      - "^passed senate"
+      - "^passed house"
+      - "^passage,"
+    default: null
+
+  az:
+    committee_passage:
+      - "^do pass"                               # "do pass", "do pass amended" — committee votes
+    passage:
+      - "^passed$"
+      - "^failed to pass$"
+    default: null
+
+  ut:
+    not_passage:
+      - "2nd reading"                            # advancement vote, not passage
+      - "second reading"
+      - "concurr"
+      - "concur"
+    passage:
+      - "^house/ passed 3rd reading"
+      - "^senate/ passed 3rd reading"
+      - "^house/ passed on 3rd reading"
+      - "^senate/ passed on 3rd reading"
+      - "^final passage"
+    default: null
+
+  fl:
+    # floor-vote site only — committee-passage sites are already correctly hardcoded
+    # the complete audit of this site found fewer than 12 non-passage texts
+    # unknown future floor texts default to passage and surface in validate_scorecards check #9
+    not_passage:
+      - "second reading"
+      - "2nd reading"
+      - "placed on"
+      - "amendment"
+    default: passage                             # catch-all for floor-vote site
+
+  mi:
+    not_passage:
+      - "concurr"
+      - "concur"
+      - "conference report"
+    passage:
+      - "^passed"                                # roll call# embedded after the verb
+      - "^passage"
+      - "^the bill"
+    default: null
+
+  ma:
+    not_passage:
+      - "^amendment"                             # amendment adopted/rejected
+      - "^item .+ passed over veto"              # budget line-item veto override
+    passage:
+      - "^passed to be engrossed"
+      - "^enacted"
+      - "^adopted"
+      - "^committee of conference report accepted"
+    default: null
+
+  wa:
+    preprocess: strip_sequence_number            # "Final Passage (#7)" → "final passage"
+    passage:
+      - "^3rd reading & final passage"
+      - "^final passage"
+    default: null
+    # NOTE: "Motion to Place Measure on 3rd Reading & Final Passage" starts with "Motion"
+    # and does NOT match these anchored patterns — confirmed by explicit test.
+
+  va:
+    bill_action:                                 # bill_action field is the reliable committee signal
+      committee_passage:
+        - "^reported from"
+        - "^subcommittee recommends"
+    passage:
+      - "^passage"                               # "Passage  R", "Passage-Enrolled Bill  R"
+      - "^h vote:"                               # House floor passage (VoteActionDescription fallback)
+      - "^s vote:"                               # Senate floor passage
+    default: null

--- a/scrapers/config/motion_classification.yaml
+++ b/scrapers/config/motion_classification.yaml
@@ -36,16 +36,18 @@ jurisdictions:
 
   ut:
     not_passage:
-      - "2nd reading"                            # advancement vote, not passage
-      - "second reading"
-      - "concurr"
-      - "concur"
+      - "passed 2nd reading$"                    # standalone 2nd-reading advancement vote (not final)
     passage:
       - "^house/ passed 3rd reading"
       - "^senate/ passed 3rd reading"
       - "^house/ passed on 3rd reading"
       - "^senate/ passed on 3rd reading"
-      - "^final passage"
+      - "^house/ passed 2nd & 3rd readings"      # suspension of rules = combined final passage
+      - "^senate/ passed 2nd & 3rd readings"
+      - "^house/ failed$"                        # failed passage vote
+      - "^senate/ failed$"
+      - "concurs with"                            # chamber concurrence = passage
+      - "conference committee - final passage"    # "House/Senate Conference Committee - Final Passage"
     default: null
 
   fl:
@@ -56,18 +58,17 @@ jurisdictions:
       - "second reading"
       - "2nd reading"
       - "placed on"
-      - "amendment"
+      - "^amendment"                             # anchored so "Favorable with 1 amendment" still defaults to passage
     default: passage                             # catch-all for floor-vote site
 
   mi:
-    not_passage:
-      - "concurr"
-      - "concur"
-      - "conference report"
     passage:
       - "^passed"                                # roll call# embedded after the verb
       - "^passage"
       - "^the bill"
+      - "concurred in"                           # chamber concurrence = passage
+      - "^conference report adopted"             # conference committee resolution
+      - "^senate adopted conference report"      # Senate variant
     default: null
 
   ma:
@@ -86,6 +87,8 @@ jurisdictions:
     passage:
       - "^3rd reading & final passage"
       - "^final passage"
+      - "^adoption"                              # "Adoption as Recommended by Conference Committee", "Adoption as Amended"
+      - "^concur in"                             # chamber concurrence in amendments
     default: null
     # NOTE: "Motion to Place Measure on 3rd Reading & Final Passage" starts with "Motion"
     # and does NOT match these anchored patterns — confirmed by explicit test.
@@ -95,8 +98,28 @@ jurisdictions:
       committee_passage:
         - "^reported from"
         - "^subcommittee recommends"
+    not_passage:
+      - "^constitutional reading dispensed"      # procedural reading waiver, not a vote on passage
+      - "^continued to next session"             # carried over to next session
+      - "^reconsider"                            # motion to reconsider
+      - "^insist"                                # insist & request = bicameral disagreement motion
+      - "^subcommittee recommends laying"        # laid on table = killed in committee
+      - "^subcommittee recommends striking"      # struck from docket = killed
+      - "^subcommittee recommends passing by"    # passed by indefinitely = killed
+      - "^subcommittee recommends continuing"    # continued = not passage
+      - "^subcommittee recommends referring"     # referred to another committee
+      - "^subcommittee recommends incorporating" # incorporated into another bill
+    committee_passage:
+      - "^subcommittee recommends reporting"     # reported out of subcommittee
+      - "^reported from"                         # reported out of full committee (motion_text fallback)
     passage:
       - "^passage"                               # "Passage  R", "Passage-Enrolled Bill  R"
       - "^h vote:"                               # House floor passage (VoteActionDescription fallback)
       - "^s vote:"                               # Senate floor passage
+      - "^adopt conference committee report"     # conference committee resolution
+      - "^adopt governor"                        # adopting governor's recommendation
+      - "^concur house"                          # concurrence in House amendments
+      - "^concur senate"                         # concurrence in Senate amendments
+      - "^accede conference committee"           # accepting conference committee recommendation
+      - "^agree to\b"                            # "Agree to R" = adopted recommendation
     default: null

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -431,7 +431,7 @@ class BillDetail(HtmlPage):
                 actor = None
 
             act_text = tr.xpath("string(td[3])").strip()
-            for action in act_text.split("\u2022"):
+            for action in act_text.split("•"):
                 action = action.strip()
                 if not action:
                     continue
@@ -583,7 +583,20 @@ class FloorVote(PdfPage):
                 nv_count -= 1
 
         if yes_count != 0 or no_count != 0:
-            raise ValueError("vote count incorrect: " + self.source.url)
+            # A vote PDF occasionally has font-encoding corruption or an
+            # unparsable row that throws the reconciled yes/no tally off by a
+            # few votes (seen live on FL 2024's HB 5001 vote #18). Previously
+            # this raised and crashed the entire multi-hour session scrape
+            # over one bad vote record. Matches the log-and-skip convention
+            # already used elsewhere in this file for other malformed FL PDF
+            # data (UpperComVote's missing-totals case, HouseSearchPage's
+            # WAF/404 handling).
+            self.logger.warning(
+                f"Vote count doesn't reconcile at {self.source.url} "
+                f"(yes={yes_count}, no={no_count} after subtracting parsed "
+                "votes); skipping this vote"
+            )
+            return
 
         if nv_count != 0:
             # On a rare occasion, a member won't have a vote code,

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -11,6 +11,7 @@ from urllib.parse import urlencode
 import lxml.html
 import requests
 from openstates.scrape import Bill, VoteEvent, Scraper
+from classify_motion import classify_motion
 from openstates.utils import format_datetime
 from requests.exceptions import ConnectionError, Timeout, RequestException
 from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage, URL, SkipItem
@@ -540,7 +541,7 @@ class FloorVote(PdfPage):
             bill=self.input["bill"],
             motion_text=motion,
             result=result,
-            classification="passage",
+            classification=classify_motion("fl", motion),
         )
         vote.add_source(self.source.url)
         vote.set_count("yes", yes_count)

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -706,6 +706,32 @@ class UpperComVote(PdfPage):
         yield vote
 
 
+class _FLHouseWAFSource(URL):
+    """Source for flhouse.gov, which sits behind an F5 BIG-IP ASM WAF.
+
+    The WAF hands out a ``session_cookie_mfhp`` cookie that is valid for only
+    ~1 hour. spatula runs an entire scrape on a single persistent scrapelib
+    session, so any scrape lasting longer than that hour (a full FL regular
+    session takes 26+ hrs) keeps presenting the now-expired cookie. The WAF then
+    answers with a "Request Rejected" block page — served with HTTP 200 — for
+    *every* subsequent request, silently dropping all remaining House committee
+    votes for the rest of the run.
+
+    Dropping the stale flhouse.gov cookies before each request forces a fresh
+    WAF session; a cold request is served real content plus a new cookie in a
+    single response, so House lookups keep working for the whole scrape.
+    """
+
+    def get_response(self, scraper):
+        # scrapelib.Scraper subclasses requests.Session, so .cookies is the jar.
+        for cookie in [c for c in scraper.cookies if "flhouse.gov" in (c.domain or "")]:
+            try:
+                scraper.cookies.clear(cookie.domain, cookie.path, cookie.name)
+            except KeyError:
+                pass
+        return super().get_response(scraper)
+
+
 class HouseSearchPage(HtmlListPage):
     """
     House committee roll calls are not available on the Senate's
@@ -738,7 +764,7 @@ class HouseSearchPage(HtmlListPage):
             ) from e
 
         form = {"Chamber": "B", "SessionId": session_number, "BillNumber": bill_number}
-        return URL(
+        return _FLHouseWAFSource(
             url + "?" + urlencode(form),
             method="GET",
             headers={
@@ -771,13 +797,16 @@ class HouseSearchPage(HtmlListPage):
             )
             return True
         elif len(request_rejected_msg) > 0:
-            # Bot detection triggered. Sleep to back off, then accept the page —
-            # process_page will find no bill links and yield nothing, keeping
-            # flhouse.gov off the critical path while the rest of the scrape continues.
+            # F5 WAF still rejected us despite the fresh session minted by
+            # _FLHouseWAFSource. Accept the empty page so the scrape continues
+            # (spatula would otherwise raise RejectedResponse and crash the run);
+            # House votes for this bill are skipped. This should now be rare —
+            # the stale-cookie case that used to make this fire on every request
+            # past the 1-hour mark is handled by dropping cookies per request.
             self.logger.warning(
-                f"flhouse.gov bot detection at {response.url}; backing off 60s"
+                f"flhouse.gov WAF rejection persists at {response.url}; "
+                "skipping house committee votes for this bill"
             )
-            time.sleep(60)
             return True
         else:
             return True

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -609,9 +609,13 @@ class UpperComVote(PdfPage):
             return
 
         motion_regex = re.compile(r"final action:", re.IGNORECASE)
+        motion = None
         for line in lines:
             if motion_regex.search(line):
-                (_, motion) = motion_regex.split(line)
+                # maxsplit=1: a line can contain "final action:" more than once,
+                # which made the 2-tuple unpack raise ValueError and abort the whole
+                # FL scrape. Take everything after the first occurrence as the motion.
+                (_, motion) = motion_regex.split(line, maxsplit=1)
                 motion = motion.strip()
         if not motion:
             self.logger.warning("Vote appears to be empty")

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -583,7 +583,7 @@ class FloorVote(PdfPage):
                 nv_count -= 1
 
         if yes_count != 0 or no_count != 0:
-            raise ValueError("vote count incorrect: " + self.url)
+            raise ValueError("vote count incorrect: " + self.source.url)
 
         if nv_count != 0:
             # On a rare occasion, a member won't have a vote code,

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -13,7 +13,7 @@ import requests
 from openstates.scrape import Bill, VoteEvent, Scraper
 from openstates.utils import format_datetime
 from requests.exceptions import ConnectionError, Timeout, RequestException
-from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage, URL
+from spatula import HtmlPage, HtmlListPage, XPath, SelectorError, PdfPage, URL, SkipItem
 
 from .actions import Categorizer
 from .utils import (
@@ -167,6 +167,18 @@ class BillList(HtmlListPage):
         bill_id = item.text.strip()
         title = item.xpath("string(../following-sibling::td[1])").strip()
         bill_url = item.attrib["href"] + "/ByCategory"
+
+        start = self.input.get("start")
+        if start is not None:
+            last_action_str = item.xpath("string(../following-sibling::td[3])").strip()
+            date_matches = re.findall(r"\d{1,2}/\d{1,2}/\d{4}", last_action_str)
+            if date_matches:
+                try:
+                    last_action = datetime.datetime.strptime(date_matches[0], "%m/%d/%Y")
+                    if last_action < start:
+                        raise SkipItem(f"{bill_id} last action {date_matches[0]} <= cutoff")
+                except ValueError:
+                    pass
 
         if bill_id.startswith(("SB ", "HB ", "SPB ", "HPB ")):
             bill_type = "bill"
@@ -893,11 +905,18 @@ class FlBillScraper(Scraper):
             "scrapers/fl/__init__.py"
         )
 
-    def scrape(self, session=None):
+    def scrape(self, session=None, start=None):
         self.raise_errors = False
         self.retry_attempts = 5
         self.retry_wait_seconds = 5
         house_session_number = self.get_house_session_number(session)
+
+        start_dt = None
+        if start:
+            try:
+                start_dt = datetime.datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self.warning(f"Invalid start= '{start}', doing full scrape")
 
         # Set up a circuit breaker to track consecutive failures
         self._consecutive_failures = 0
@@ -918,7 +937,7 @@ class FlBillScraper(Scraper):
 
         def do_scrape_with_retry():
             bill_list = BillList(
-                {"session": session, "house_session_number": house_session_number}
+                {"session": session, "house_session_number": house_session_number, "start": start_dt}
             )
             yield from self._process_bill_list(bill_list)
 

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -747,15 +747,21 @@ class HouseSearchPage(HtmlListPage):
             "//title[contains(text(), 'Request Rejected')]"
         )
         if len(text_not_found_msg) > 0:
+            # Bill simply doesn't exist on flhouse.gov — accept the empty page
+            # so process_page yields nothing rather than crashing the scrape.
             self.logger.info(
-                f"Encountered text-based Not Found message at {response.url}"
+                f"Bill not found on flhouse.gov at {response.url}; skipping house committee votes"
             )
-            return False
+            return True
         elif len(request_rejected_msg) > 0:
-            self.logger.info(
-                f"Encountered text-based Rejected message at {response.url}"
+            # Bot detection triggered. Sleep to back off, then accept the page —
+            # process_page will find no bill links and yield nothing, keeping
+            # flhouse.gov off the critical path while the rest of the scrape continues.
+            self.logger.warning(
+                f"flhouse.gov bot detection at {response.url}; backing off 60s"
             )
-            return False
+            time.sleep(60)
+            return True
         else:
             return True
 
@@ -896,7 +902,7 @@ class FlBillScraper(Scraper):
         # Set up a circuit breaker to track consecutive failures
         self._consecutive_failures = 0
         self._max_consecutive_failures = 3
-        self._circuit_breaker_timeout = 120  # 2 minutes
+        self._circuit_breaker_timeout = 300  # 5 minutes
 
         self.headers["User-Agent"] = get_random_user_agent()
 
@@ -977,7 +983,7 @@ class FlBillScraper(Scraper):
                 self._reset_connection_pool_if_needed()
 
                 # Add a random delay between processing items
-                add_random_delay(1, 3)
+                add_random_delay(5, 10)
 
                 # If we've had too many consecutive failures, pause for a while
                 if self._consecutive_failures >= self._max_consecutive_failures:

--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -982,18 +982,47 @@ class FlBillScraper(Scraper):
         # spatula's logging is better than scrapelib's
         logging.getLogger("scrapelib").setLevel(logging.WARNING)
 
-        def do_scrape_with_retry():
-            bill_list = BillList(
-                {"session": session, "house_session_number": house_session_number, "start": start_dt}
-            )
-            yield from self._process_bill_list(bill_list)
-
-        yield from retry_on_connection_error(
-            lambda: list(do_scrape_with_retry()),
-            max_retries=3,
-            initial_backoff=10,
-            max_backoff=120,
+        bill_list = BillList(
+            {"session": session, "house_session_number": house_session_number, "start": start_dt}
         )
+
+        # Retry the bill-list walk itself without collapsing every bill into a list first
+        # (fixed 2026-07-24 -- see PLAN-bill-document-provenance.md). The previous version wrapped
+        # the entire scrape in `retry_on_connection_error(lambda: list(do_scrape_with_retry()))`,
+        # which forced the whole session's bills to fully process in memory before any of them
+        # got yielded/saved -- a crash near the end of a long session lost all of its progress.
+        # That whole-session retry is no longer the primary safety net: _process_bill_list already
+        # catches and logs a failure on any ONE bill and moves on to the next (its own circuit
+        # breaker), and every individual HTTP request already retries via the patched_get_response
+        # monkeypatch above. This loop is now just a backstop for failures in the bill-list
+        # pagination walk itself (BillList.do_scrape()) -- retrying restarts that walk from the
+        # beginning, but bills already yielded/saved before the failure stay saved, and re-scraping
+        # them again is harmless (the importer already no-ops an unchanged bill).
+        retries = 0
+        max_retries, backoff, max_backoff = 3, 10, 120
+        while True:
+            try:
+                yield from self._process_bill_list(bill_list)
+                return
+            except (
+                ConnectionError,
+                RemoteDisconnected,
+                URLError,
+                Timeout,
+                RequestException,
+            ) as e:
+                retries += 1
+                if retries > max_retries:
+                    self.logger.error(
+                        f"Max retries ({max_retries}) exceeded scraping bill list: {e}"
+                    )
+                    raise
+                wait = min(backoff * (2 ** (retries - 1)), max_backoff)
+                self.logger.warning(
+                    f"Bill list scrape failed: {e}. Retrying in {wait}s "
+                    f"(attempt {retries}/{max_retries})"
+                )
+                time.sleep(wait)
 
     def _create_fresh_session(self):
         """

--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -6,6 +6,7 @@ import json
 from datetime import datetime
 import lxml.html
 from openstates.scrape import Scraper, Bill, VoteEvent
+from classify_motion import classify_motion
 from openstates.utils import convert_pdf
 
 from .actions import Categorizer
@@ -379,7 +380,7 @@ class MABillScraper(Scraper):
                     start_date=action_date,
                     motion_text=vote_action,
                     result="pass" if y > n else "fail",
-                    classification="passage",
+                    classification=classify_motion("ma", vote_action),
                     bill=bill,
                 )
                 cached_vote.set_count("yes", y)
@@ -426,7 +427,7 @@ class MABillScraper(Scraper):
                         start_date=action_date,
                         motion_text=vote_action,
                         result="pass" if y > n else "fail",
-                        classification="passage",
+                        classification=classify_motion("ma", vote_action),
                         bill=bill,
                     )
                     cached_vote.set_count("yes", y)

--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -65,9 +65,9 @@ class MABillScraper(Scraper):
     # os-update ma bills --scrape scrape_chunk_number=1
     # this trades off comprehensivity for limited scope of failure/faster time to recovery
     def scrape(
-        self, chamber=None, session=None, bill_no=None, scrape_chunk_number=None
+        self, chamber=None, session=None, bill_no=None, scrape_chunk_number=None, start=None
     ):
-        self.scrape_bill_list(session)
+        self.scrape_bill_list(session, start=start)
 
         # optionally scrape a single bill then exit
         if bill_no:
@@ -84,12 +84,19 @@ class MABillScraper(Scraper):
         else:
             yield from self.scrape_chamber(chamber, session, scrape_chunk_number)
 
-    def scrape_bill_list(self, session):
+    def scrape_bill_list(self, session, start=None):
         session_numeric = re.sub(r"[^0-9]", "", session)
         # note -- this returns XML to a browser, but json to curl/python
         api_url = (
             f"https://malegislature.gov/api/GeneralCourts/{session_numeric}/Documents"
         )
+
+        start_dt = None
+        if start:
+            try:
+                start_dt = datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                pass
 
         list_data = self.get(api_url, verify=False).content
         for row in json.loads(list_data):
@@ -103,6 +110,27 @@ class MABillScraper(Scraper):
                 self.error(
                     f"Unknown bill type - bill {row['BillNumber']} - docket {row['DocketNumber']}"
                 )
+
+            if start_dt:
+                response_dates = []
+                primary = row.get("PrimarySponsor") or {}
+                if primary.get("ResponseDate"):
+                    try:
+                        response_dates.append(
+                            datetime.fromisoformat(primary["ResponseDate"].split(".")[0])
+                        )
+                    except ValueError:
+                        pass
+                for cs in row.get("Cosponsors") or []:
+                    if cs.get("ResponseDate"):
+                        try:
+                            response_dates.append(
+                                datetime.fromisoformat(cs["ResponseDate"].split(".")[0])
+                            )
+                        except ValueError:
+                            pass
+                if response_dates and max(response_dates) <= start_dt:
+                    continue
 
             self.bill_list.append(
                 {"BillNumber": row["BillNumber"], "DocketNumber": row["DocketNumber"]}

--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -284,7 +284,7 @@ class MABillScraper(Scraper):
                 "Bill Text", version_url, media_type="application/pdf"
             )
 
-        self.scrape_actions(bill, bill_url, session)
+        yield from self.scrape_actions(bill, bill_url, session)
         yield bill
 
     def scrape_cosponsors(self, bill, bill_url):
@@ -323,8 +323,7 @@ class MABillScraper(Scraper):
         # scrape_action_page adds the actions, and also returns the Page xpath object
         # so that we can check for a paginator
         page = self.get_action_page(bill_url, 1)
-        # XXX: yield from
-        self.scrape_action_page(bill, page)
+        yield from self.scrape_action_page(bill, page)
 
         max_page = page.xpath(
             '//ul[contains(@class,"pagination-sm")]/li[last()]/a/@onclick'
@@ -333,8 +332,7 @@ class MABillScraper(Scraper):
             max_page = re.sub(r"[^\d]", "", max_page[0]).strip()
             for counter in range(2, int(max_page) + 1):
                 page = self.get_action_page(bill_url, counter)
-                # XXX: yield from
-                self.scrape_action_page(bill, page)
+                yield from self.scrape_action_page(bill, page)
                 # https://malegislature.gov/Bills/189/S3/BillHistory?pageNumber=2
 
     def get_action_page(self, bill_url, page_number):
@@ -397,9 +395,7 @@ class MABillScraper(Scraper):
 
                 cached_vote.dedupe_key = "{}#{}".format(housevote_pdf, n_supplement)
 
-                # XXX: disabled house votes on 8/1 to try to get MA importing again
-                # will leaving this in and commented out once we resolve the ID issue
-                # yield cached_vote
+                yield cached_vote
 
             # Senate votes
             if "Roll Call" in action_name:
@@ -409,7 +405,7 @@ class MABillScraper(Scraper):
                 # 2019 H86 Breaks our regex,
                 # Ordered to a third reading --
                 # see Senate   Roll Call #25 and House Roll Call 56
-                if "yeas" in action_name and "nays" in action_name:
+                if "yeas" in action_name.lower() and "nays" in action_name.lower():
                     try:
                         y, n = re.search(
                             r"(\d+) yeas .*? (\d+) nays", action_name.lower()
@@ -442,8 +438,7 @@ class MABillScraper(Scraper):
                     self.scrape_senate_vote(cached_vote, rollcall_pdf)
                     cached_vote.add_source(rollcall_pdf)
                     cached_vote.dedupe_key = rollcall_pdf
-                    # XXX: also disabled, see above note
-                    # yield cached_vote
+                    yield cached_vote
 
             attrs = self.categorizer.categorize(action_name)
             action = bill.add_action(

--- a/scrapers/mi/__init__.py
+++ b/scrapers/mi/__init__.py
@@ -103,10 +103,14 @@ class Michigan(State):
         url = "https://www.legislature.mi.gov/Search/LegDocSearch"
         sessions = []
         try:
-            # legislature.mi.gov's WAF blocks a generic/bare User-Agent (see
-            # bills.py's USER_AGENT) and returns a CAPTCHA challenge page with no
-            # <option> elements instead of the real session list, so this must
-            # send the same WAF-safe UA that bills.py already sends.
+            # A bare/generic User-Agent got a CAPTCHA challenge page here (zero
+            # <option> elements) rather than the real session list -- sending the
+            # same UA bills.py already uses helps sometimes, but legislature.mi.gov's
+            # bot-detection is inconsistent: live testing 2026-08-01 got a dropped
+            # connection (RemoteDisconnected) instead, the same symptom the MI
+            # archiver hits independently and often. This isn't a reliable fix for
+            # that blocking, just a best effort -- the fallback below, not this UA,
+            # is what actually keeps get_session_list() from raising CommandError.
             response = requests.get(url, headers={"User-Agent": USER_AGENT})
             response.raise_for_status()
             doc = lxml.html.fromstring(response.text)
@@ -117,7 +121,9 @@ class Michigan(State):
         if not sessions:
             logger.warning(
                 f"MI get_session_list(): live scrape of {url} failed or returned "
-                "nothing; falling back to Michigan.legislative_sessions identifiers"
+                "nothing; falling back to Michigan.legislative_sessions identifiers "
+                "(known-sessions safety net -- update this list when MI starts a "
+                "new session, since the live scrape can't be relied on to catch it)"
             )
             sessions = [
                 s.get("_scraped_name", s["identifier"])

--- a/scrapers/mi/__init__.py
+++ b/scrapers/mi/__init__.py
@@ -1,7 +1,13 @@
-from utils import url_xpath
+import logging
+
+import requests
+import lxml.html
+
 from openstates.scrape import State
-from .bills import MIBillScraper
+from .bills import MIBillScraper, USER_AGENT
 from .events import MIEventScraper
+
+logger = logging.getLogger("openstates")
 
 
 class Michigan(State):
@@ -94,11 +100,28 @@ class Michigan(State):
     ]
 
     def get_session_list(self):
-        return [
-            s.strip()
-            for s in url_xpath(
-                "https://www.legislature.mi.gov/Search/LegDocSearch",
-                "//option/text()",
+        url = "https://www.legislature.mi.gov/Search/LegDocSearch"
+        sessions = []
+        try:
+            # legislature.mi.gov's WAF blocks a generic/bare User-Agent (see
+            # bills.py's USER_AGENT) and returns a CAPTCHA challenge page with no
+            # <option> elements instead of the real session list, so this must
+            # send the same WAF-safe UA that bills.py already sends.
+            response = requests.get(url, headers={"User-Agent": USER_AGENT})
+            response.raise_for_status()
+            doc = lxml.html.fromstring(response.text)
+            sessions = [s.strip() for s in doc.xpath("//option/text()") if s.strip()]
+        except requests.exceptions.RequestException:
+            sessions = []
+
+        if not sessions:
+            logger.warning(
+                f"MI get_session_list(): live scrape of {url} failed or returned "
+                "nothing; falling back to Michigan.legislative_sessions identifiers"
             )
-            if s.strip()
-        ]
+            sessions = [
+                s.get("_scraped_name", s["identifier"])
+                for s in Michigan.legislative_sessions
+            ]
+
+        return sessions

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -283,6 +283,12 @@ class MIBillScraper(Scraper):
                                 if len(name.split()) < 5:
                                     vote.vote(pvr, name.strip())
 
+                    # Emit the parsed roll-call number so downstream consumers can
+                    # tell a real recorded vote from an empty/summary passage motion
+                    # (mirrors usa/votes.py's house/senate-rollcall-num extras).
+                    vote.extras[
+                        "senate-rollcall-num" if actor == "upper" else "house-rollcall-num"
+                    ] = rc_num
                     vote.add_source(vote_url)
                     yield vote
 

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -7,6 +7,7 @@ from datetime import date
 from utils.media import get_media_type
 
 from openstates.scrape import Scraper, Bill, VoteEvent
+from classify_motion import classify_motion
 
 _categorizers = {
     "approved by governor with line item(s) vetoed": "executive-veto-line-item",
@@ -247,7 +248,7 @@ class MIBillScraper(Scraper):
                         bill=bill,
                         motion_text=action,
                         result="pass" if vote_passed else "fail",
-                        classification="passage",
+                        classification=classify_motion("mi", action),
                     )
 
                     # Verify vote count matching the expected count in the action string

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -44,11 +44,18 @@ class MIBillScraper(Scraper):
         match = re.search(r"objectName=([^&]+)", url)
         return f"https://legislature.mi.gov/Bills/Bill?ObjectName={match.group(1)}"
 
-    def scrape(self, session):
+    def scrape(self, session, start=None):
         self.headers = {
             "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0"
         }
-        search_url = f"https://legislature.mi.gov/Search/ExecuteSearch?chamber=&docTypesList=HB%2CSB&docTypesList=HR%2CSR&docTypesList=HCR%2CSCR&docTypesList=HJR%2CSJR&sessions={session}&sponsor=&number=&dateFrom=&dateTo=&contentFullText="
+        date_from = ""
+        if start:
+            try:
+                dt = dateutil.parser.parse(start)
+                date_from = dt.strftime("%Y-%m-%d")
+            except ValueError:
+                pass
+        search_url = f"https://legislature.mi.gov/Search/ExecuteSearch?chamber=&docTypesList=HB%2CSB&docTypesList=HR%2CSR&docTypesList=HCR%2CSCR&docTypesList=HJR%2CSJR&sessions={session}&sponsor=&number=&dateFrom={date_from}&dateTo=&contentFullText="
         page = self.get(search_url, headers=self.headers).content
         page = lxml.html.fromstring(page)
         page.make_links_absolute(search_url)

--- a/scrapers/mi/bills.py
+++ b/scrapers/mi/bills.py
@@ -29,6 +29,11 @@ _categorizers = {
     "vetoed by governor": "executive-veto",
 }
 BASE_URL = "https://legislature.mi.gov"
+# legislature.mi.gov's WAF blocks a generic/bare User-Agent (found 2026-07-28, via
+# ddp-open-states's bill-document archive step -- see that repo's PLAN-bill-document-
+# provenance.md). Module-level so it's a single source of truth other tools can import
+# directly instead of keeping their own hand-copied duplicate that can drift out of sync.
+USER_AGENT = "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0"
 
 
 def categorize_action(action: str) -> str:
@@ -46,9 +51,7 @@ class MIBillScraper(Scraper):
         return f"https://legislature.mi.gov/Bills/Bill?ObjectName={match.group(1)}"
 
     def scrape(self, session, start=None):
-        self.headers = {
-            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0"
-        }
+        self.headers = {"User-Agent": USER_AGENT}
         date_from = ""
         if start:
             try:

--- a/scrapers/mi/tests/test_session_list.py
+++ b/scrapers/mi/tests/test_session_list.py
@@ -1,0 +1,70 @@
+import requests
+
+from mi import Michigan
+
+
+SUCCESS_HTML = """
+<html><body>
+<select name="sessions" id="session_B">
+<option value="All">All</option>
+<option value="2025-2026" selected="selected">2025-2026</option>
+<option value="2023-2024">2023-2024</option>
+<option value="2011-2012">2011-2012</option>
+</select>
+</body></html>
+"""
+
+# legislature.mi.gov's WAF returns a page like this (no <option> elements)
+# instead of the real search page when it challenges a request.
+CAPTCHA_HTML = """
+<html><body style="font-family:times;color:white;font-size:15px;" bgcolor="#405f8d">
+<title>Validation request</title>
+<h3 align="center">User validation required to continue..</h3>
+</body></html>
+"""
+
+
+class FakeResponse:
+    def __init__(self, text, status_code=200):
+        self.text = text
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"{self.status_code} error")
+
+
+def test_get_session_list_returns_scraped_sessions_on_success(monkeypatch):
+    monkeypatch.setattr(
+        "mi.requests.get", lambda url, headers=None: FakeResponse(SUCCESS_HTML)
+    )
+
+    sessions = Michigan().get_session_list()
+
+    assert sessions
+    assert "2025-2026" in sessions
+
+
+def test_get_session_list_falls_back_when_request_fails(monkeypatch):
+    def raise_connection_error(url, headers=None):
+        raise requests.exceptions.ConnectionError("could not connect")
+
+    monkeypatch.setattr("mi.requests.get", raise_connection_error)
+
+    sessions = Michigan().get_session_list()
+
+    assert sessions
+    assert "2025-2026" in sessions
+
+
+def test_get_session_list_falls_back_when_waf_challenge_page_returned(monkeypatch):
+    # Reproduces the actual OPEN-17 failure: a 200 response whose body is a
+    # CAPTCHA challenge page with zero <option> elements.
+    monkeypatch.setattr(
+        "mi.requests.get", lambda url, headers=None: FakeResponse(CAPTCHA_HTML)
+    )
+
+    sessions = Michigan().get_session_list()
+
+    assert sessions
+    assert "2025-2026" in sessions

--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -8,6 +8,7 @@ import requests
 import xml.etree.ElementTree as ET
 
 from openstates.scrape import Bill, Scraper, VoteEvent, Event
+from classify_motion import classify_motion
 
 
 # NOTE: This is a US federal bill scraper designed to output bills in the
@@ -725,7 +726,7 @@ class USBillScraper(Scraper):
             start_date=when,
             bill_chamber="lower" if doc_type[0] == "H" else "upper",
             motion_text=motion,
-            classification="passage",  # TODO
+            classification=classify_motion("us", motion),
             result=result,
             legislative_session=session,
             identifier=vote_id,
@@ -802,7 +803,7 @@ class USBillScraper(Scraper):
             start_date=when,
             bill_chamber="lower" if bill_id[0] == "H" else "upper",
             motion_text=motion,
-            classification="passage",  # TODO
+            classification=classify_motion("us", motion),
             result=result,
             legislative_session=session,
             identifier=vote_id,

--- a/scrapers/usa/bills.py
+++ b/scrapers/usa/bills.py
@@ -96,10 +96,10 @@ class USBillScraper(Scraper):
         "SCONRES": "resolution",
     }
 
-    # to scrape everything UPDATED after a given date/time, start="2020-01-01 22:01:01"
+    # to scrape everything UPDATED after a given date/time, start="2020-01-01T22:01:01"
     def scrape(self, chamber=None, session=None, start=None, hearings=True):
         if start:
-            start = datetime.datetime.strptime(start, "%Y-%m-%d %H:%I:%S")
+            start = datetime.datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
         else:
             start = datetime.datetime(1980, 1, 1, 0, 0, 1)
 

--- a/scrapers/usa/tests/roll205_fixture.xml
+++ b/scrapers/usa/tests/roll205_fixture.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<rollcall-vote>
+  <vote-metadata>
+    <majority>D</majority>
+    <congress>119</congress>
+    <session>2nd</session>
+    <chamber>U.S. House of Representatives</chamber>
+    <rollcall-num>205</rollcall-num>
+    <legis-num>H R 8646</legis-num>
+    <vote-question>On Passage</vote-question>
+    <vote-type>RECORDED VOTE</vote-type>
+    <vote-result>Passed</vote-result>
+    <action-date>4-Jun-2026</action-date>
+    <action-time time-etz="22:08">10:08 PM</action-time>
+    <vote-totals>
+      <totals-by-party-header>
+        <party-header>Party</party-header>
+        <yea-header>Yeas</yea-header>
+        <nay-header>Nays</nay-header>
+        <present-header>Answered "Present"</present-header>
+        <not-voting-header>Not Voting</not-voting-header>
+      </totals-by-party-header>
+      <totals-by-vote>
+        <yea-total>213</yea-total>
+        <nay-total>210</nay-total>
+        <present-total>0</present-total>
+        <not-voting-total>7</not-voting-total>
+      </totals-by-vote>
+    </vote-totals>
+  </vote-metadata>
+  <vote-data>
+    <recorded-vote>
+      <legislator name-id="A000370" sort-field="Adams" unaccented-name="Adams" party="D" state="NC" role="legislator">Adams</legislator>
+      <vote>Nay</vote>
+    </recorded-vote>
+    <recorded-vote>
+      <legislator name-id="G000598" sort-field="Garcia (CA)" unaccented-name="Garcia (CA)" party="D" state="CA" role="legislator">Garcia (CA)</legislator>
+      <vote>Yea</vote>
+    </recorded-vote>
+    <recorded-vote>
+      <legislator name-id="G000587" sort-field="Garcia (TX)" unaccented-name="Garcia (TX)" party="D" state="TX" role="legislator">Garcia (TX)</legislator>
+      <vote>Nay</vote>
+    </recorded-vote>
+  </vote-data>
+</rollcall-vote>

--- a/scrapers/usa/tests/senate_vote_fixture.xml
+++ b/scrapers/usa/tests/senate_vote_fixture.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<roll_call_vote>
+  <vote_date>June 4, 2026, 05:30 PM</vote_date>
+  <vote_number>150</vote_number>
+  <document>
+    <document_type>S. 100</document_type>
+    <document_name>S. 100</document_name>
+  </document>
+  <vote_question_text>On Passage of the Bill</vote_question_text>
+  <vote_result>Passed</vote_result>
+  <count>
+    <yeas>60</yeas>
+    <nays>39</nays>
+    <absent>1</absent>
+    <present>0</present>
+  </count>
+  <members>
+    <member>
+      <lis_member_id>S307</lis_member_id>
+      <member_full>Smith (D-MN)</member_full>
+      <vote_cast>Yea</vote_cast>
+    </member>
+    <member>
+      <lis_member_id>S308</lis_member_id>
+      <member_full>Frankel, Lois (D-FL)</member_full>
+      <vote_cast>Nay</vote_cast>
+    </member>
+  </members>
+</roll_call_vote>

--- a/scrapers/usa/tests/test_votes.py
+++ b/scrapers/usa/tests/test_votes.py
@@ -1,0 +1,61 @@
+import os
+
+from openstates.utils import get_pseudo_id
+
+from usa.votes import USVoteScraper
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__))
+
+
+class FakeResponse:
+    def __init__(self, path):
+        with open(path, "rb") as f:
+            self.content = f.read()
+
+
+def make_scraper():
+    return USVoteScraper(jurisdiction="usa", datadir="/tmp")
+
+
+def test_scrape_house_vote_passes_bioguide_as_identifier():
+    scraper = make_scraper()
+    scraper.get = lambda url: FakeResponse(
+        os.path.join(FIXTURE_DIR, "roll205_fixture.xml")
+    )
+
+    vote = scraper.scrape_house_vote("https://clerk.house.gov/evs/2026/roll205.xml")
+
+    assert vote.bill_identifier == "HR 8646"
+    votes_by_name = {v["voter_name"]: v for v in vote.votes}
+
+    # a legislator with a unique surname resolves on name alone
+    adams_pid = get_pseudo_id(votes_by_name["Adams"]["voter_id"])
+    assert adams_pid == {"name": "Adams", "id": "A000370"}
+
+    # legislators disambiguated only by the House's "(ST)" suffix still carry
+    # their bioguide id through, so resolve_person() isn't left doing a plain
+    # name match that would collide/miss between the two Garcias
+    garcia_ca_pid = get_pseudo_id(votes_by_name["Garcia (CA)"]["voter_id"])
+    assert garcia_ca_pid == {"name": "Garcia (CA)", "id": "G000598"}
+    garcia_tx_pid = get_pseudo_id(votes_by_name["Garcia (TX)"]["voter_id"])
+    assert garcia_tx_pid == {"name": "Garcia (TX)", "id": "G000587"}
+    assert garcia_ca_pid != garcia_tx_pid
+
+    assert votes_by_name["Garcia (CA)"]["option"] == "yes"
+    assert votes_by_name["Garcia (TX)"]["option"] == "no"
+
+
+def test_scrape_senate_vote_passes_lis_id_as_identifier():
+    scraper = make_scraper()
+    scraper.get = lambda url: FakeResponse(
+        os.path.join(FIXTURE_DIR, "senate_vote_fixture.xml")
+    )
+
+    votes = list(scraper.scrape_senate_vote("119", 2, "150"))
+    assert len(votes) == 1
+    vote = votes[0]
+
+    votes_by_name = {v["voter_name"]: v for v in vote.votes}
+    frankel_pid = get_pseudo_id(votes_by_name["Frankel, Lois (D-FL)"]["voter_id"])
+    assert frankel_pid == {"name": "Frankel, Lois (D-FL)", "id": "S308"}

--- a/scrapers/usa/votes.py
+++ b/scrapers/usa/votes.py
@@ -4,6 +4,7 @@ import pytz
 import re
 
 from openstates.scrape import VoteEvent, Scraper
+from classify_motion import classify_motion
 
 
 class USVoteScraper(Scraper):
@@ -177,7 +178,7 @@ class USVoteScraper(Scraper):
             start_date=when,
             bill_chamber="lower" if bill_id[0] == "H" else "upper",
             motion_text=motion,
-            classification="passage",  # TODO
+            classification=classify_motion("us", motion),
             result=result,
             legislative_session=session,
             identifier=vote_id,
@@ -280,7 +281,7 @@ class USVoteScraper(Scraper):
             start_date=when,
             bill_chamber="lower" if doc_type[0] == "H" else "upper",
             motion_text=motion,
-            classification="passage",  # TODO
+            classification=classify_motion("us", motion),
             result=result,
             legislative_session=session,
             identifier=vote_id,

--- a/scrapers/usa/votes.py
+++ b/scrapers/usa/votes.py
@@ -213,7 +213,7 @@ class USVoteScraper(Scraper):
             name = row.xpath("legislator/@sort-field")[0]
             choice = row.xpath("vote/text()")[0]
 
-            vote.vote(self.vote_codes[choice], name, note=bioguide)
+            vote.vote(self.vote_codes[choice], name, note=bioguide, id=bioguide)
         return vote
 
     def scrape_senate_votes(self, session, start, year):
@@ -316,6 +316,6 @@ class USVoteScraper(Scraper):
             name = row.xpath("member_full/text()")[0]
             choice = row.xpath("vote_cast/text()")[0]
 
-            vote.vote(self.vote_codes[choice], name, note=lis_id)
+            vote.vote(self.vote_codes[choice], name, note=lis_id, id=lis_id)
 
         yield vote

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -36,7 +36,8 @@ class UTBillScraper(Scraper, LXMLMixin):
     categorizer = Categorizer()
     _TZ = pytz.timezone("America/Denver")
 
-    def scrape(self, session=None, chamber=None):
+    def scrape(self, session=None, chamber=None, start=None):
+        self._start = start
         if session in SPECIAL_SLUGS:
             session_slug = SPECIAL_SLUGS[session]
         elif "S" in session:
@@ -216,6 +217,15 @@ class UTBillScraper(Scraper, LXMLMixin):
         )
         response = self.get(api_url, verify=False)
         data = json.loads(response.content)
+
+        if self._start and data.get("actionHistoryList"):
+            try:
+                start_dt = datetime.datetime.strptime(self._start, "%Y-%m-%dT%H:%M:%S")
+                most_recent_date = parser.parse(data["actionHistoryList"][0]["actionDate"])
+                if most_recent_date.replace(tzinfo=None) <= start_dt:
+                    return
+            except (ValueError, TypeError, KeyError):
+                pass
 
         # Sponsorships
         if "primeSponsorName" in data and data["primeSponsorName"]:

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -3,6 +3,7 @@ import datetime
 from dateutil import parser
 
 from openstates.scrape import Scraper, Bill, VoteEvent as Vote
+from classify_motion import classify_motion
 from .actions import Categorizer
 from utils import LXMLMixin
 
@@ -507,7 +508,7 @@ class UTBillScraper(Scraper, LXMLMixin):
             motion_text=motion,
             identifier=str(uniqid),
             result="pass" if (yes_count > no_count) else "fail",
-            classification="passage",
+            classification=classify_motion("ut", motion),
             bill=bill,
         )
         vote.extras = {"_vote_id": uniqid}
@@ -587,7 +588,7 @@ class UTBillScraper(Scraper, LXMLMixin):
             motion_text=motion,
             result="pass" if passed else "fail",
             bill=bill,
-            classification="passage",
+            classification=classify_motion("ut", motion),
             identifier=str(uniqid),
         )
         vote.set_count("yes", vdict["Yeas"]["count"])
@@ -634,7 +635,7 @@ class UTBillScraper(Scraper, LXMLMixin):
             motion_text=motion,
             result="pass" if passed else "fail",
             identifier=str(uniqid),
-            classification="passage",
+            classification=classify_motion("ut", motion),
             bill=bill,
         )
         vote.add_source(url)

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -132,7 +132,18 @@ class UTBillScraper(Scraper, LXMLMixin):
             # starting 2025 seems UT is rendering bill data from an API/JSON
             # but prior years seem to have static-ish HTML
             # so we have two logic branches here
-            yield from self.scrape_bill_details_from_api(bill, url, session_slug)
+            #
+            # scrape_bill_details_from_api() returns True when it decided to skip this bill
+            # because nothing's changed since our incremental start= cutoff -- in that case it
+            # never populated versions/documents/actions/sponsorships. Found 2026-07-28: falling
+            # through to `yield bill` anyway handed the importer a bill with none of those, and
+            # the importer treats "scrape found zero of these" as "delete whatever's already in
+            # the database" -- silently wiping every UT bill's versions/documents/actions/
+            # sponsorships back out across incremental runs ever since this start= filtering was
+            # added (2026-06-30). Returning here instead leaves the existing data alone.
+            skip = yield from self.scrape_bill_details_from_api(bill, url, session_slug)
+            if skip:
+                return
         else:
             yield from self.parse_bill_details_from_html(
                 bill, bill_id, chamber, page, primary_info
@@ -224,7 +235,7 @@ class UTBillScraper(Scraper, LXMLMixin):
                 start_dt = datetime.datetime.strptime(self._start, "%Y-%m-%dT%H:%M:%S")
                 most_recent_date = parser.parse(data["actionHistoryList"][0]["actionDate"])
                 if most_recent_date.replace(tzinfo=None) <= start_dt:
-                    return
+                    return True
             except (ValueError, TypeError, KeyError):
                 pass
 

--- a/scrapers/va/__init__.py
+++ b/scrapers/va/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from openstates.scrape import State
 from .csv_bills import VaCSVBillScraper
 from .events import VaEventScraper
@@ -317,5 +318,32 @@ class Virginia(State):
         ).json()
         session_list = []
         for row in response["Sessions"]:
+            # Skip sessions that haven't started yet. VA lists an upcoming regular
+            # session (with a future "Session Start" date) months before it
+            # convenes. Reporting it here would force it to be declared/ignored in
+            # metadata prematurely — and until then openstates-core aborts the whole
+            # VA scrape with a "session not found" CommandError. A future session
+            # reappears here automatically once its start date passes, at which
+            # point it can be added to legislative_sessions normally.
+            if self._session_not_started(row):
+                continue
             session_list.append(f"{row['SessionYear']} {row['DisplayName']}")
         return session_list
+
+    @staticmethod
+    def _session_not_started(row):
+        """True only when the session's "Session Start" date is in the future.
+
+        Fail open: if no start date is present or it can't be parsed, treat the
+        session as started so a genuinely active session is never dropped.
+        """
+        for event in row.get("SessionEvents", []):
+            if event.get("DisplayName") == "Session Start":
+                raw = event.get("ActualDate") or event.get("ProjectedDate")
+                if not raw:
+                    return False
+                try:
+                    return datetime.fromisoformat(raw) > datetime.now()
+                except ValueError:
+                    return False
+        return False

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -264,6 +264,17 @@ class VaBillScraper(Scraper):
 
         page = response.json()
 
+        # The API occasionally returns an unexpected shape (e.g. a bare string or
+        # error body) instead of the expected object. Guard so one malformed
+        # response skips versions for this bill instead of aborting the whole
+        # VA scrape with `TypeError: string indices must be integers`.
+        if not isinstance(page, dict) or not isinstance(page.get("TextsList"), list):
+            self.warning(
+                f"unexpected legislation-text response for {legislation_id}; "
+                f"skipping versions"
+            )
+            return
+
         for row in page["TextsList"]:
             if (row["PDFFile"] and len(row["PDFFile"]) > 1) or (
                 row["HTMLFile"] and len(row["HTMLFile"]) > 1

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -43,7 +43,13 @@ class VaBillScraper(Scraper):
     # chunks are available to split up this long, slow scrape into 12 smaller scrapes
     # os-update ma bills --scrape scrape_chunk_number=1
     # this trades off comprehensivity for limited scope of failure/faster time to recovery
-    def scrape(self, session=None, scrape_chunk_number=None):
+    def scrape(self, session=None, scrape_chunk_number=None, start=None):
+        start_dt = None
+        if start:
+            try:
+                start_dt = dateutil.parser.parse(start).replace(tzinfo=None)
+            except Exception:
+                self.warning(f"Invalid start= '{start}', doing full scrape")
 
         for i in self.jurisdiction.legislative_sessions:
             if i["identifier"] == session:
@@ -111,7 +117,22 @@ class VaBillScraper(Scraper):
                 classification=self.classify_bill(row),
             )
 
-            self.add_actions(bill, row["LegislationID"])
+            events = self._fetch_events(row["LegislationID"])
+            self.add_actions(bill, events)
+
+            if start_dt:
+                event_dates = [e["EventDate"] for e in events if e.get("EventDate")]
+                if event_dates:
+                    latest = max(
+                        dateutil.parser.parse(d).replace(tzinfo=None) for d in event_dates
+                    )
+                    if latest <= start_dt:
+                        bill.add_source(
+                            f"https://lis.virginia.gov/bill-details/{self.session_code}/{row['LegislationNumber']}"
+                        )
+                        yield bill
+                        continue
+
             self.add_versions(bill, row["LegislationID"])
             self.add_carryover_related_bill(bill)
             self.add_sponsors(bill, row["LegislationID"])
@@ -129,20 +150,21 @@ class VaBillScraper(Scraper):
 
             yield bill
 
-    def add_actions(self, bill: Bill, legislation_id: str):
+    def _fetch_events(self, legislation_id: str):
         body = {
             "sessionCode": self.session_code,
             "legislationID": legislation_id,
         }
-
         page = requests.get(
             f"{self.base_url}/LegislationEvent/api/getlegislationeventbylegislationidasync",
             params=body,
             headers=self.headers,
             verify=False,
         ).json()
+        return page["LegislationEvents"]
 
-        for row in page["LegislationEvents"]:
+    def add_actions(self, bill: Bill, events: list):
+        for row in events:
             when = dateutil.parser.parse(row["EventDate"]).date()
             description = row["Description"]
             if not description and row["VoteTally"]:

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -96,7 +96,15 @@ class VaBillScraper(Scraper):
 
             bill_list = bill_chunks[chunk_number - 1]
 
+        seen_bill_ids = set()
         for row in bill_list:
+            if row["LegislationNumber"] in seen_bill_ids:
+                self.warning(
+                    f"Duplicate bill {row['LegislationNumber']} in API response, skipping"
+                )
+                continue
+            seen_bill_ids.add(row["LegislationNumber"])
+
             # the short title on the VA site is 'description',
             # LegislationTitle is on top of all the versions
             title = row["Description"]

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -9,6 +9,7 @@ import requests
 import urllib3
 
 from openstates.scrape import Scraper, Bill, VoteEvent
+from classify_motion import classify_motion
 from .actions import Categorizer
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -343,7 +344,9 @@ class VaBillScraper(Scraper):
                     result="fail",  # placeholder for now
                     chamber=self.chamber_map[row["ChamberCode"]],
                     bill=bill,
-                    classification=[],
+                    classification=classify_motion(
+                        "va", motion_text, bill_action=row["LegislationActionDescription"]
+                    ),
                 )
 
                 if not row["VoteID"]:

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -136,10 +136,16 @@ class VaBillScraper(Scraper):
                         dateutil.parser.parse(d).replace(tzinfo=None) for d in event_dates
                     )
                     if latest <= start_dt:
-                        bill.add_source(
-                            f"https://lis.virginia.gov/bill-details/{self.session_code}/{row['LegislationNumber']}"
-                        )
-                        yield bill
+                        # Nothing's changed since our cutoff -- skip this bill entirely rather
+                        # than yielding a partially-populated one. Found 2026-07-28: yielding it
+                        # anyway (with only actions + source set) handed the importer a bill
+                        # with zero versions/sponsors/votes/abstracts, and openstates-core's
+                        # importer treats "scrape found zero of these" as "delete whatever's
+                        # already in the database" for that bill -- silently wiping every
+                        # unchanged VA bill's already-good data on each incremental run (same
+                        # bug as ut/bills.py, fixed the same way; see
+                        # ddp-open-states/PLAN-open-states.md for the full writeup). Not
+                        # yielding at all leaves the existing database row untouched.
                         continue
 
             self.add_versions(bill, row["LegislationID"])

--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -647,6 +647,12 @@ class WABillScraper(Scraper, LXMLMixin):
             vote.set_count("yes", yes_count)
             vote.set_count("no", no_count)
             vote.set_count("other", other_count)
+            # Emit the roll-call sequence number so downstream consumers can tell a
+            # real recorded vote from an empty/summary passage motion (mirrors
+            # usa/votes.py's house/senate-rollcall-num extras).
+            vote.extras[
+                "senate-rollcall-num" if chamber == "upper" else "house-rollcall-num"
+            ] = seq_no
             vote.add_source(url)
             for sv in xpath(rc, "wa:Votes/wa:Vote"):
                 name = xpath(sv, "string(wa:Name)")

--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from .actions import Categorizer
 from .utils import xpath
 from openstates.scrape import Scraper, Bill, VoteEvent as Vote
+from classify_motion import classify_motion
 from utils import LXMLMixin
 
 import lxml.etree
@@ -641,7 +642,7 @@ class WABillScraper(Scraper, LXMLMixin):
                 motion_text="{} (#{})".format(motion, seq_no),
                 result="pass" if yes_count > non_yes_count else "fail",
                 bill=bill,
-                classification=[],
+                classification=classify_motion("wa", "{} (#{})".format(motion, seq_no)),
             )
             vote.set_count("yes", yes_count)
             vote.set_count("no", no_count)

--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -238,7 +238,13 @@ class WABillScraper(Scraper, LXMLMixin):
 
         return self._bill_id_list
 
-    def scrape(self, chamber=None, session=None):
+    def scrape(self, chamber=None, session=None, start=None):
+        self._start_dt = None
+        if start:
+            try:
+                self._start_dt = datetime.datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self.warning(f"Invalid start= '{start}', doing full scrape")
         chambers = [chamber] if chamber else ["upper", "lower"]
 
         year = int(session[0:4])
@@ -317,6 +323,16 @@ class WABillScraper(Scraper, LXMLMixin):
         page = self.get(url)
         page = lxml.etree.fromstring(page.content)
         page = xpath(page, "//wa:Legislation")[0]
+
+        if self._start_dt:
+            action_date_str = xpath(page, "string(wa:CurrentStatus/wa:ActionDate)")
+            if action_date_str:
+                try:
+                    action_dt = datetime.datetime.fromisoformat(action_date_str.rstrip("Z"))
+                    if action_dt <= self._start_dt:
+                        return
+                except ValueError:
+                    pass
 
         xml_chamber = xpath(page, "string(wa:OriginalAgency)")
         chamber = self._chamber_map[xml_chamber]

--- a/scrapers/wa/bills.py
+++ b/scrapers/wa/bills.py
@@ -649,10 +649,13 @@ class WABillScraper(Scraper, LXMLMixin):
             vote.set_count("other", other_count)
             # Emit the roll-call sequence number so downstream consumers can tell a
             # real recorded vote from an empty/summary passage motion (mirrors
-            # usa/votes.py's house/senate-rollcall-num extras).
-            vote.extras[
-                "senate-rollcall-num" if chamber == "upper" else "house-rollcall-num"
-            ] = seq_no
+            # usa/votes.py's house/senate-rollcall-num extras). Guard against an
+            # empty SequenceNumber (xpath string() returns "") so we never write a
+            # falsey presence signal.
+            if seq_no:
+                vote.extras[
+                    "senate-rollcall-num" if chamber == "upper" else "house-rollcall-num"
+                ] = seq_no
             vote.add_source(url)
             for sv in xpath(rc, "wa:Votes/wa:Vote"):
                 name = xpath(sv, "string(wa:Name)")

--- a/tests/test_classify_motion.py
+++ b/tests/test_classify_motion.py
@@ -1,0 +1,243 @@
+"""Tests for classify_motion() and config/motion_classification.yaml integrity."""
+import logging
+import re
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scrapers"))
+from classify_motion import classify_motion, KNOWN_JURISDICTIONS, _config, _PREPROCESSORS
+
+
+# ---------------------------------------------------------------------------
+# YAML config integrity
+# ---------------------------------------------------------------------------
+
+def test_yaml_loads_without_error():
+    assert "jurisdictions" in _config
+
+
+def test_all_expected_jurisdiction_keys_present():
+    expected = {"us", "az", "ut", "fl", "mi", "ma", "wa", "va"}
+    assert expected == KNOWN_JURISDICTIONS
+
+
+def test_all_preprocess_values_are_known():
+    for jur, cfg in _config["jurisdictions"].items():
+        preprocess = cfg.get("preprocess")
+        if preprocess:
+            assert preprocess in _PREPROCESSORS, (
+                f"{jur}: unknown preprocessor {preprocess!r}"
+            )
+
+
+def test_all_patterns_are_valid_regex():
+    for jur, cfg in _config["jurisdictions"].items():
+        for key in ("not_passage", "passage", "committee_passage"):
+            for pattern in cfg.get(key, []):
+                try:
+                    re.compile(pattern)
+                except re.error as e:
+                    raise AssertionError(
+                        f"{jur}.{key}: invalid regex {pattern!r}: {e}"
+                    )
+        for pattern in cfg.get("bill_action", {}).get("committee_passage", []):
+            re.compile(pattern)
+
+
+# ---------------------------------------------------------------------------
+# Loader behaviour
+# ---------------------------------------------------------------------------
+
+def test_unknown_jurisdiction_returns_empty_and_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        result = classify_motion("xx", "some motion text")
+    assert result == []
+    assert "unknown jurisdiction" in caplog.text
+
+
+def test_unknown_preprocessor_raises():
+    _config["jurisdictions"]["_test"] = {"preprocess": "nonexistent"}
+    try:
+        with pytest.raises(ValueError, match="unknown preprocessor"):
+            classify_motion("_test", "text")
+    finally:
+        del _config["jurisdictions"]["_test"]
+
+
+def test_preprocessor_strips_sequence_number():
+    assert classify_motion("wa", "3rd Reading & Final Passage (#7)") == ["passage"]
+    assert classify_motion("wa", "Final Passage (#3)") == ["passage"]
+    assert classify_motion("wa", "Final Passage as Amended (#3)") == ["passage"]
+
+
+def test_va_bill_action_drives_committee_passage():
+    assert classify_motion("va", "some motion", bill_action="Reported from Finance") == ["committee-passage"]
+    assert classify_motion("va", "some motion", bill_action="Subcommittee recommends reporting") == ["committee-passage"]
+    assert classify_motion("va", "some motion", bill_action=None) == []
+
+
+def test_fl_default_catches_unknown_floor_text():
+    assert classify_motion("fl", "Third Reading En Bloc") == ["passage"]
+    assert classify_motion("fl", "Second Reading") == []
+
+
+# ---------------------------------------------------------------------------
+# Per-jurisdiction true positives
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text,expected", [
+    ("On Passage", ["passage"]),
+    ("On motion to suspend the rules and pass HR 1", ["passage"]),
+    ("Passed Senate by Unanimous Consent", ["passage"]),
+    ("On the Cloture Motion (S.1234)", ["passage"]),
+    ("Passage, Senate Amendment", ["passage"]),
+])
+def test_us_passage(text, expected):
+    assert classify_motion("us", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "On Cloture on the Motion to Proceed (S.1234)",
+    "Measure laid before Senate",
+    "Resolving differences",
+    "Postponed Proceedings",
+    "Ordered to be reported",
+])
+def test_us_not_passage(text):
+    assert classify_motion("us", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("Passed", ["passage"]),
+    ("failed to pass", ["passage"]),
+    ("do pass", ["committee-passage"]),
+    ("do pass amended", ["committee-passage"]),
+])
+def test_az_classification(text, expected):
+    assert classify_motion("az", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "Retained on the Calendar",
+    "Tabled",
+])
+def test_az_not_passage(text):
+    assert classify_motion("az", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("House/ passed 3rd reading", ["passage"]),
+    ("Senate/ passed 3rd reading", ["passage"]),
+    ("House/ passed on 3rd reading", ["passage"]),
+    ("Senate/ passed on 3rd reading", ["passage"]),
+    ("Final Passage", ["passage"]),
+])
+def test_ut_passage(text, expected):
+    assert classify_motion("ut", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "House/ passed 2nd reading",
+    "Senate/ passed 2nd reading",
+    "Senate/ concurs with House amendment",
+    "House/ second reading",
+])
+def test_ut_not_passage(text):
+    assert classify_motion("ut", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("Third Reading", ["passage"]),
+    ("Passage on Third Reading", ["passage"]),
+    ("Third Reading En Bloc", ["passage"]),
+])
+def test_fl_passage(text, expected):
+    assert classify_motion("fl", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "Second Reading Amendment",
+    "2nd Reading",
+    "Placed on Calendar",
+    "Amendment No. 1",
+])
+def test_fl_not_passage(text):
+    assert classify_motion("fl", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("PASSED ROLL CALL # 120 YEAS 107 NAYS 0", ["passage"]),
+    ("The bill passed", ["passage"]),
+    ("PASSAGE ROLL CALL # 88 YEAS 62 NAYS 40", ["passage"]),
+    ("Passed as Amended ROLL CALL # 5 YEAS 57 NAYS 50", ["passage"]),
+])
+def test_mi_passage(text, expected):
+    assert classify_motion("mi", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "HOUSE AMENDMENT(S) CONCURRED IN ROLL CALL # 116",
+    "Conference Report adopted ROLL CALL # 5",
+    "SENATE CONCURRED WITH HOUSE AMENDMENTS ROLL CALL # 200",
+])
+def test_mi_not_passage(text):
+    assert classify_motion("mi", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("Passed to be engrossed", ["passage"]),
+    ("Enacted", ["passage"]),
+    ("Adopted", ["passage"]),
+    ("Committee of conference report accepted", ["passage"]),
+])
+def test_ma_passage(text, expected):
+    assert classify_motion("ma", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "Amendment #1 (Tarr) rejected",
+    "Amendment #22 adopted",
+    "Item 7004-0109 passed over veto",
+])
+def test_ma_not_passage(text):
+    assert classify_motion("ma", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("3rd Reading & Final Passage (#7)", ["passage"]),
+    ("Final Passage as Amended (#3)", ["passage"]),
+    ("3rd Reading & Final Passage (#12)", ["passage"]),
+])
+def test_wa_passage(text, expected):
+    assert classify_motion("wa", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    # The classic WA false-positive — starts with "Motion", not "3rd" or "final"
+    "Motion to Place Measure on 3rd Reading & Final Passage (#1)",
+    "Amendment (H-1234.1)",
+    "2nd Reading",
+])
+def test_wa_not_passage(text):
+    assert classify_motion("wa", text) == []
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("Passage  R", ["passage"]),
+    ("H VOTE:", ["passage"]),
+    ("S VOTE:", ["passage"]),
+    ("Passage-Enrolled Bill  R", ["passage"]),
+])
+def test_va_passage(text, expected):
+    assert classify_motion("va", text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "Reported from Finance and Appropriations",
+    "Subcommittee recommends reporting",
+    "Constitutional reading dispensed (on 2nd reading)",
+])
+def test_va_not_passage(text):
+    assert classify_motion("va", text) == []


### PR DESCRIPTION
## Summary
- Fixes [OPEN-17](https://digitaldemocracyproject.atlassian.net/browse/OPEN-17): `openstates.exceptions.CommandError: no sessions from Michigan.get_session_list()`, hit twice in production (2026-07-31, 2026-08-01), both times failing fast (~20-70s) before any bill scraping starts.
- `Michigan.get_session_list()` previously used a bare `url_xpath()` call with no custom headers against `legislature.mi.gov/Search/LegDocSearch`. Sends the same `USER_AGENT` `bills.py` already uses successfully for per-bill fetches — this helps in some cases, but **is not a reliable fix**: live-tested 2026-08-01 and got a dropped connection (`RemoteDisconnected`) instead of a response either way, the same intermittent bot-detection symptom the MI archiver hits independently and often.
- The real fix is the fallback: when the live scrape fails or returns an empty list (for any reason — connection drop, CAPTCHA challenge page, timeout), falls back to the existing static `Michigan.legislative_sessions` list, which already has `identifier`/`_scraped_name` for all known sessions through 2025-2026. This is what actually prevents the `CommandError` from being raised, regardless of whether the UA-spoofing helps.
- Maintenance note added in the fallback's log line: this static list needs a manual entry added whenever MI starts a new session, since the live scrape can't be relied on to catch it automatically given how inconsistent the site's blocking is.

## Test plan
- [x] 3 new unit tests (`scrapers/mi/tests/test_session_list.py`), all passing under this repo's own venv: success path, generic `RequestException` fallback, and — reproducing the actual observed failure — a 200 response whose body is a CAPTCHA challenge page with zero `<option>` elements.
- [x] Live-verified against the real site (2026-08-01): `get_session_list()` no longer raises `CommandError`; currently exercises the fallback path and correctly returns all 8 known sessions.
- [x] Confirmed via production log history that today's and yesterday's `CommandError` failures are identical/reproducible, not a one-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)