### PR TITLE
fix(fl): refresh flhouse.gov WAF session so long scrapes keep collecting House votes

### DIFF
--- a/scrapers/fl/bills.py
+++ b/scrapers/fl/bills.py
@@ -689,6 +689,32 @@ class UpperComVote(PdfPage):
         yield vote
 
 
+class _FLHouseWAFSource(URL):
+    """Source for flhouse.gov, which sits behind an F5 BIG-IP ASM WAF.
+
+    The WAF hands out a ``session_cookie_mfhp`` cookie that is valid for only
+    ~1 hour. spatula runs an entire scrape on a single persistent scrapelib
+    session, so any scrape lasting longer than that hour (a full FL regular
+    session takes 26+ hrs) keeps presenting the now-expired cookie. The WAF then
+    answers with a "Request Rejected" block page — served with HTTP 200 — for
+    *every* subsequent request, silently dropping all remaining House committee
+    votes for the rest of the run.
+
+    Dropping the stale flhouse.gov cookies before each request forces a fresh
+    WAF session; a cold request is served real content plus a new cookie in a
+    single response, so House lookups keep working for the whole scrape.
+    """
+
+    def get_response(self, scraper):
+        # scrapelib.Scraper subclasses requests.Session, so .cookies is the jar.
+        for cookie in [c for c in scraper.cookies if "flhouse.gov" in (c.domain or "")]:
+            try:
+                scraper.cookies.clear(cookie.domain, cookie.path, cookie.name)
+            except KeyError:
+                pass
+        return super().get_response(scraper)
+
+
 class HouseSearchPage(HtmlListPage):
     """
     House committee roll calls are not available on the Senate's
@@ -721,7 +747,7 @@ class HouseSearchPage(HtmlListPage):
             ) from e
 
         form = {"Chamber": "B", "SessionId": session_number, "BillNumber": bill_number}
-        return URL(
+        return _FLHouseWAFSource(
             url + "?" + urlencode(form),
             method="GET",
             headers={


### PR DESCRIPTION
## Problem

`flhouse.gov` (the source for Florida **House committee votes** — the Senate's
site doesn't carry these; see `HouseSearchPage`'s docstring) sits behind an F5
BIG-IP ASM WAF that issues a `session_cookie_mfhp` session cookie valid for
only ~1 hour. `spatula` runs an entire scrape on a single persistent
`scrapelib` session, and a full FL regular-session scrape takes 26+ hours on
one connection. Once that cookie expires, the WAF starts returning a
"Request Rejected" block page — served with **HTTP 200**, so no exception is
raised and nothing retries — for every subsequent request. In practice this
silently drops all remaining House committee votes for the rest of the run.

Verified independently against the live public API (`v3.openstates.org`):
comparing local DB records to the public API for several 2026-session FL
bills (e.g. HB 559, HB 1175, HB 1137) shows the public API is missing exactly
the committee-level votes and nothing else — every non-committee vote matches
byte-for-byte on `start_date` + `motion_text`. That's consistent with the
public API's own (unpatched) scraper hitting this same WAF-session-expiry gap.

## Fix

Add `_FLHouseWAFSource`, a `URL` source that drops any stale `flhouse.gov`
cookies from the scraper's session before each request. A cold request (no
session cookie) gets served real content plus a fresh cookie in a single
response, so every House committee-vote lookup starts its own WAF session
instead of inheriting an hour-old one. This keeps House committee votes
flowing for the entire scrape instead of only the first ~hour.

`HouseSearchPage.get_source_from_input` is updated to use
`_FLHouseWAFSource` instead of the plain `URL` source; `accept_response`'s
existing graceful-fallback handling for a persistent rejection is left
unchanged.

This has been running in production in our fork since 2026-07-18 with no
regressions.