### PR TITLE
OK: guard against null title/datetime in events scraper

### DIFF
--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -87,7 +87,6 @@ class OKEventScraper(Scraper):
         page.make_links_absolute(url)
 
         title_nodes = page.xpath("//span[contains(@class,'field--name-title')]/text()")
-        
         if not title_nodes or not title_nodes[0].strip():
             self.warning(f"Skipping senate event with no title: {url}")
             return
@@ -241,4 +240,3 @@ class OKEventScraper(Scraper):
         current_max = offset + limit
         if page["events"]["meta"]["pagination"]["total"] > current_max:
             yield from self.scrape_page(start, end, offset + limit, limit)
-

--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -86,7 +86,14 @@ class OKEventScraper(Scraper):
         page = lxml.html.fromstring(self.get(url, verify=False).content)
         page.make_links_absolute(url)
 
-        title = page.xpath("//span[contains(@class,'field--name-title')]/text()")[0]
+        title_nodes = page.xpath(
+            "//span[contains(@class,'field--name-title')]/text()"
+        )
+        if not title_nodes or not title_nodes[0].strip():
+            self.warning(f"Skipping senate event with no title: {url}")
+            return
+        title = title_nodes[0]
+
         try:
             location = page.xpath(
                 "//a[contains(@class,'events_custom_timetable')]/text()"
@@ -100,10 +107,13 @@ class OKEventScraper(Scraper):
         if location.lower()[0:4] == "room":
             location = f"2300 N Lincoln Blvd., Oklahoma City, OK 73105 {location}"
 
-        when = page.xpath(
+        when_nodes = page.xpath(
             "//div[contains(@class,'pageIn__infoIt')]/strong/time/@datetime"
-        )[0]
-        when = dateutil.parser.parse(when)
+        )
+        if not when_nodes:
+            self.warning(f"Skipping senate event with no start datetime: {url}")
+            return
+        when = dateutil.parser.parse(when_nodes[0])
 
         event = Event(title, when, location)
         for row in page.xpath("//article//ol/li"):
@@ -151,6 +161,22 @@ class OKEventScraper(Scraper):
         for row in page["events"]["data"]:
             meta = row["attributes"]
 
+            # Upstream API occasionally returns events with null/empty title or
+            # startDatetime. Without these we can't build a valid Event, and
+            # attempting to would crash the whole scrape (e.g. Event.__str__
+            # calls self.name.strip() during save, raising AttributeError when
+            # name is None). Skip such records and log a warning instead.
+            if not meta.get("title"):
+                self.warning(
+                    f"Skipping house event with no title (slug={meta.get('slug')!r})"
+                )
+                continue
+            if not meta.get("startDatetime"):
+                self.warning(
+                    f"Skipping house event {meta.get('title')!r} with no startDatetime"
+                )
+                continue
+
             status = "tentative"
 
             if meta["isCancelled"] is True:
@@ -165,7 +191,7 @@ class OKEventScraper(Scraper):
                         f"{location} 2300 N Lincoln Blvd, Oklahoma City, OK 73105"
                     )
             else:
-                meta["location"] = "See agenda"
+                location = "See agenda"
 
             when = dateutil.parser.parse(meta["startDatetime"])
 
@@ -185,7 +211,7 @@ class OKEventScraper(Scraper):
                     meta["committee"]["data"]["attributes"]["name"], note="host"
                 )
 
-            for link in meta["links"]:
+            for link in meta["links"] or []:
                 event.add_document(
                     link["label"], link["route"], media_type="application/pdf"
                 )
@@ -198,7 +224,9 @@ class OKEventScraper(Scraper):
                 for bill in Agenda(source=URL(link["route"])).do_scrape():
                     event.add_bill(bill)
 
-            for agenda in meta["agenda"]:
+            for agenda in meta["agenda"] or []:
+                if not agenda.get("info"):
+                    continue
                 agenda_text = lxml.html.fromstring(agenda["info"])
                 agenda_text = " ".join(agenda_text.xpath("//text()"))
                 event.add_agenda_item(agenda_text)

--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -86,9 +86,8 @@ class OKEventScraper(Scraper):
         page = lxml.html.fromstring(self.get(url, verify=False).content)
         page.make_links_absolute(url)
 
-        title_nodes = page.xpath(
-            "//span[contains(@class,'field--name-title')]/text()"
-        )
+        title_nodes = page.xpath("//span[contains(@class,'field--name-title')]/text()")
+        
         if not title_nodes or not title_nodes[0].strip():
             self.warning(f"Skipping senate event with no title: {url}")
             return

--- a/scrapers/ok/events.py
+++ b/scrapers/ok/events.py
@@ -241,3 +241,4 @@ class OKEventScraper(Scraper):
         current_max = offset + limit
         if page["events"]["meta"]["pagination"]["total"] > current_max:
             yield from self.scrape_page(start, end, offset + limit, limit)
+


### PR DESCRIPTION
The OK House API sometimes returns a null title field. Pushing a fix that skips events where title/date is missing. Output - [ok.zip](https://github.com/user-attachments/files/30792814/ok.zip)

Details from Claude:
The OK events scraper was crashing whenever the upstream House API or Senate meeting pages returned records with missing fields. This PR adds defensive guards so that malformed records are skipped with a warning instead of taking down the whole scrape.
On the Senate side, the scraper previously assumed every meeting page would have both a title and a start datetime. When a page loaded without either of those fields, it would raise an error. The scraper now checks for those fields before using them and logs a warning if they are missing.
On the House side, the API occasionally returns event records where the title or start datetime is null. Without those fields, a valid event cannot be built, and even attempting to save such a record causes the whole scrape to fail. The new guards catch these records early and skip them with a descriptive warning.
There was also a small latent bug in how missing locations were handled. The fallback string "See agenda" was being written into the wrong place, so events with no location weren't actually getting the fallback — it was silently overwritten. That is now fixed.
Finally, a few other fields returned by the House API (such as document links and agenda items) were assumed to always be lists, but the API sometimes returns null instead. And individual agenda items were sometimes missing their HTML content, which crashed the HTML parser. Both of these are now handled defensively.