### PR TITLE
MO: Bills: Index Error issue

### DIFF
--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -235,21 +235,21 @@ class MOBillScraper(Scraper, LXMLMixin):
         if bill_lr:
             bill.extras["MO_BILL_LR"] = bill_lr
 
-        for cosponsor_link in bill_page.xpath(
-            '//div[contains(@class, "detail-grid__item") and contains(string(.), "Co-Sponsors")]/div[1]/a'
-        ):
-            if "Senators" in cosponsor_link.xpath("@href")[0]:
-                chamber = "upper"
-            else:
-                chamber = None
-
-            bill.add_sponsorship(
-                cosponsor_link.text_content(),
-                entity_type="person",
-                classification="cosponsor",
-                primary=False,
-                chamber=chamber,
-            )
+        # Based on the analysis of the MO website, co-sponsors are typically Senators,
+        # so we assume the chamber is "upper" for co-sponsor entities.
+        chamber = "upper"
+        co_spons = '//div[contains(@class, "detail-grid__item") and contains(string(.), "Co-Sponsors")]/div/span'
+        co_sponsors_elements = bill_page.xpath(co_spons)
+        if co_sponsors_elements:
+            for element in co_sponsors_elements:
+                name = element.text_content()
+                bill.add_sponsorship(
+                    name,
+                    entity_type="person",
+                    classification="cosponsor",
+                    primary=False,
+                    chamber=chamber
+                )
 
         # get the actions
         actions_url = f"{bill_url}&handler=Actions"
@@ -344,7 +344,7 @@ class MOBillScraper(Scraper, LXMLMixin):
         index_page = lxml.html.fromstring(index_page)
 
         for card_header in index_page.cssselect("div.bill-card-header"):
-            bill_sponsor_handler = None
+            bill_sponsor_link = None
             bill_identifier_element = card_header.cssselect("div.bill-number a")
             if not bill_identifier_element:
                 self.warning("Missing bill identifier element. Skipping.")
@@ -357,7 +357,7 @@ class MOBillScraper(Scraper, LXMLMixin):
             # Extract sponsor handler link if present
             sponsor_elements = card_header.cssselect("div.bill-sponsor-handler div a")
             if sponsor_elements:
-                bill_sponsor_handler = sponsor_elements[0].get("href")
+                bill_sponsor_link = sponsor_elements[0].get("href")
 
             if bill_identifier_link is None:
                 self.warning(
@@ -366,7 +366,7 @@ class MOBillScraper(Scraper, LXMLMixin):
                 continue
 
             yield from self._parse_senate_billpage(
-                bill_identifier_link, bill_identifier, bill_sponsor_handler, session
+                bill_identifier_link, bill_identifier, bill_sponsor_link, session
             )
 
     def _scrape_lower_chamber(self, session):

--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -248,7 +248,7 @@ class MOBillScraper(Scraper, LXMLMixin):
                     entity_type="person",
                     classification="cosponsor",
                     primary=False,
-                    chamber=chamber
+                    chamber=chamber,
                 )
 
         # get the actions

--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -147,7 +147,9 @@ class MOBillScraper(Scraper, LXMLMixin):
                 bill_id = bill_id.text_content().strip()
                 self._subjects[bill_id].append(subject)
 
-    def _parse_senate_billpage(self, bill_url, bill_identifier, year):
+    def _parse_senate_billpage(
+        self, bill_url, bill_identifier, bill_sponsor_link, year
+    ):
         try:
             bill_page = self.get(bill_url).content
         except HTTPError:
@@ -216,9 +218,6 @@ class MOBillScraper(Scraper, LXMLMixin):
         bill_sponsor = bill_page.xpath(
             '//div[contains(@class, "detail-grid__item") and contains(string(.), "Sponsor")]/div[1]'
         )[0].text_content()
-        bill_sponsor_link = bill_page.xpath(
-            '//div[contains(@class, "detail-grid__item") and contains(string(.), "Sponsor")]/div[1]/a/@href'
-        )[0]
 
         if "Senators" in bill_sponsor_link:
             chamber = "upper"
@@ -344,10 +343,30 @@ class MOBillScraper(Scraper, LXMLMixin):
         index_page = self.get(index_url).text
         index_page = lxml.html.fromstring(index_page)
 
-        for link in index_page.cssselect("div.bill-number a"):
-            bill_identifier = link.text_content().strip()
+        for card_header in index_page.cssselect("div.bill-card-header"):
+            bill_sponsor_handler = None
+            bill_identifier_element = card_header.cssselect("div.bill-number a")
+            if not bill_identifier_element:
+                self.warning("Missing bill identifier element. Skipping.")
+                continue
+
+            link_el = bill_identifier_element[0]
+            bill_identifier = link_el.text_content().strip()
+            bill_identifier_link = link_el.get("href")  # None-safe, no IndexError
+
+            # Extract sponsor handler link if present
+            sponsor_elements = card_header.cssselect("div.bill-sponsor-handler div a")
+            if sponsor_elements:
+                bill_sponsor_handler = sponsor_elements[0].get("href")
+
+            if bill_identifier_link is None:
+                self.warning(
+                    f"Missing bill identifier link for bill {bill_identifier}. Skipping."
+                )
+                continue
+
             yield from self._parse_senate_billpage(
-                link.xpath("@href")[0], bill_identifier, session
+                bill_identifier_link, bill_identifier, bill_sponsor_handler, session
             )
 
     def _scrape_lower_chamber(self, session):

--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -235,8 +235,7 @@ class MOBillScraper(Scraper, LXMLMixin):
         if bill_lr:
             bill.extras["MO_BILL_LR"] = bill_lr
 
-        # Based on the analysis of the MO website, co-sponsors are typically Senators,
-        # so we assume the chamber is "upper" for co-sponsor entities.
+        # MO Senate website lists Senate sponsors, so we assume chamber is upper
         chamber = "upper"
         co_spons = '//div[contains(@class, "detail-grid__item") and contains(string(.), "Co-Sponsors")]/div/span'
         co_sponsors_elements = bill_page.xpath(co_spons)


### PR DESCRIPTION
Problem:
The bill_sponsor_link selector no longer returns any data. The expected anchor (<a href>) no longer exists at the  location in the updated page structure, so the resulting list is empty and hence the error.

Fixes:
Extracting the sponsor link at the same point where we extract the bill identifier, since both values are available in that section of the page.