### PR TITLE
MT: move inline regex flag to position 0 (Python 3.11+ compatibility)

### DIFF
--- a/scrapers/mt/actions.py
+++ b/scrapers/mt/actions.py
@@ -127,7 +127,7 @@ _actions = {
         "mappings": ["executive-veto-line-item"],
     },
     # An amendment has been offered on the bill
-    "^(?i)amendment.{,200}introduced": {
+    "(?i)^amendment.{,200}introduced": {
         "type": "regex",
         "mappings": ["amendment-introduction"],
     },


### PR DESCRIPTION
### What breaks

The Montana bill scraper fails to run on Python 3.11 and later. `scrapers/mt/actions.py` defines an action pattern with the inline `(?i)` flag placed *after* the `^` anchor:

```python
"^(?i)amendment.{,200}introduced": {
```

### The error

Python 3.11 turned a non-leading inline flag group from a `DeprecationWarning` into a hard error, so the module raises on import:

```
re.error: global flags not at the start of the expression at position 1
```

This takes down the whole scraper — it fails before any bill is fetched.

### The fix

Move `(?i)` to position 0:

```python
"(?i)^amendment.{,200}introduced": {
```

### Semantics preserved

Behaviour is identical: the pattern is still anchored to the start and still case-insensitive. `(?i)` was always global to the entire pattern regardless of where it appeared — which is precisely why Python now requires it to lead. Verified matching is unchanged against `"Amendment introduced"`, `"AMENDMENT was introduced in House"`, and `"amendment introduced"`.

### Testing

Ran the MT bills scraper against the live site on Python 3.12: **11 bills scraped in ~150s**, where it previously raised on import.

I also grepped the repository for the same construct elsewhere (an inline flag group preceded by anything inside the pattern) — **this is the only occurrence**, so no other scraper needs the same change.

Thanks for maintaining this project.
