### PR TITLE
MO: make the Senate sponsor link optional (fixes IndexError on every upper-chamber bill)

### DIFF
--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -216,14 +216,20 @@ class MOBillScraper(Scraper, LXMLMixin):
         bill_sponsor = bill_page.xpath(
             '//div[contains(@class, "detail-grid__item") and contains(string(.), "Sponsor")]/div[1]'
         )[0].text_content()
+        # The Senate site formerly rendered the sponsor as a hyperlink; it now
+        # renders a bare <span>, so this xpath legitimately matches nothing.
+        # Indexing [0] unconditionally raised IndexError and took down the whole
+        # upper-chamber scrape.
         bill_sponsor_link = bill_page.xpath(
             '//div[contains(@class, "detail-grid__item") and contains(string(.), "Sponsor")]/div[1]/a/@href'
-        )[0]
+        )
 
-        if "Senators" in bill_sponsor_link:
-            chamber = "upper"
+        if bill_sponsor_link:
+            chamber = "upper" if "Senators" in bill_sponsor_link[0] else None
         else:
-            chamber = None
+            # No link left to classify from. This is _parse_senate_billpage, so
+            # the sponsor of a Senate bill is a Senator.
+            chamber = "upper"
 
         bill.add_sponsorship(
             bill_sponsor,


### PR DESCRIPTION
### What breaks

`_parse_senate_billpage` reads the sponsor's chamber out of a hyperlink:

```python
bill_sponsor_link = bill_page.xpath(
    '//div[contains(@class, "detail-grid__item") and contains(string(.), "Sponsor")]/div[1]/a/@href'
)[0]
```

The Missouri Senate site no longer renders the sponsor as a link — the value is now a bare `<span>`. The xpath legitimately matches nothing, `[0]` raises `IndexError`, and because it raises before `add_sponsorship` the exception takes down the **entire upper-chamber scrape**, not just one bill.

### Why this fix

The sponsor **name** xpath was never broken — only the link was. That link fed nothing except the chamber assignment, and this is `_parse_senate_billpage`, so a Senate bill's sponsor is a Senator.

So the link becomes optional and `chamber` defaults to `"upper"` when it is absent. When the link *is* present the behaviour is byte-for-byte what it was, so this is safe if MO restores the markup.

### Verification

Run live against the current site: **52 bills scraped**, where the scrape previously died on the first one.