### PR TITLE
UT: identify scraper via useragent per source request

### DIFF
--- a/scrapers/ut/__init__.py
+++ b/scrapers/ut/__init__.py
@@ -1,8 +1,11 @@
+import os
 import re
 from utils import url_xpath
 from openstates.scrape import State
 from .events import UTEventScraper
 from .bills import UTBillScraper
+
+user_agent = os.getenv("USER_AGENT", "openstates.org <contact@openstates.org>")
 
 
 class Utah(State):
@@ -463,5 +466,6 @@ class Utah(State):
             "https://le.utah.gov/bills/billSearch.jsp",
             "//select[@id='sess']/option/text()",
             verify=False,
+            user_agent=user_agent,
         )
         return [re.sub(r"\s+", " ", session.strip()) for session in sessions]

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -1,3 +1,4 @@
+import os
 import re
 import datetime
 from dateutil import parser
@@ -31,6 +32,12 @@ SPONSOR_HOUSE_TO_CHAMBER = {
     "S": "upper",
 }
 
+user_agent = os.getenv("USER_AGENT", "openstates.org <contact@openstates.org>")
+
+headers = {
+    "User-Agent": user_agent,
+}
+
 
 class UTBillScraper(Scraper, LXMLMixin):
     categorizer = Categorizer()
@@ -55,7 +62,7 @@ class UTBillScraper(Scraper, LXMLMixin):
         session_url = "https://le.utah.gov/billlist.jsp?session={}".format(session_slug)
 
         # For some sessions the link doesn't go straight to the bill list
-        doc = self.lxmlize(session_url)
+        doc = self.lxmlize(session_url, headers=headers)
 
         # Get all of the show/hide bill list elements
         # in order to get the IDs of the actual bill lists
@@ -93,9 +100,15 @@ class UTBillScraper(Scraper, LXMLMixin):
                     )
 
     def scrape_bill(self, chamber, session, url, session_slug):
-        page = self.lxmlize(url)
+        response = self.get(url, headers=headers)
+        page = lxml.html.fromstring(response.text)
+        page.make_links_absolute(url)
 
-        bill_id = page.cssselect("#breadcrumb li")[-1].text
+        bill_id = page.cssselect("#breadcrumb li")
+        if len(bill_id) > 0:
+            bill_id = bill_id[-1].text
+        else:
+            raise Exception(f"Unexpected bill page content at {url}, truncated content {response.text[:500]}")
 
         (header,) = page.xpath(
             '//h3[@class="heading"]/text() | //h1[@class="heading"]/text()'
@@ -214,7 +227,7 @@ class UTBillScraper(Scraper, LXMLMixin):
         api_url = (
             f"https://le.utah.gov/data/{session_slug}/{bill_filename}.json?_={now}"
         )
-        response = self.get(api_url, verify=False)
+        response = self.get(api_url, verify=False, headers=headers)
         data = json.loads(response.content)
 
         # Sponsorships
@@ -513,20 +526,28 @@ class UTBillScraper(Scraper, LXMLMixin):
 
     def parse_html_vote(self, bill, actor, date, motion, url, uniqid):
         try:
-            page = self.get(url, verify=False).text
+            page_text = self.get(url, verify=False, headers=headers).text
         except scrapelib.HTTPError:
             self.warning("A vote page not found for bill {}".format(bill.identifier))
             return
         try:
-            page = lxml.html.fromstring(page)
+            page = lxml.html.fromstring(page_text)
         except ParserError:
             self.logger.warning(f"Could not parse HTML vote page {url}")
 
         page.make_links_absolute(url)
-        descr = page.xpath("//b")[0].text_content()
-        if descr == "":
-            # New page method
-            descr = page.xpath("//center")[0].text
+        descr = page.xpath("//b")
+        if len(descr) > 0:
+            descr = descr[0].text_content()
+        else:
+            # Try new page method
+            descr = page.xpath("//center")
+            if len(descr) > 0:
+                descr = descr[0].text
+
+        if len(descr) < 1:
+            # neither element is present, might have an unexpected page response
+            raise Exception(f"Unexpected vote page content at {url}, truncated content {page_text[:500]}")
 
         if "on voice vote" in descr:
             return
@@ -595,7 +616,7 @@ class UTBillScraper(Scraper, LXMLMixin):
         yield vote
 
     def parse_vote(self, bill, actor, date, motion, url, uniqid):
-        page = self.get(url, verify=False).text
+        page = self.get(url, verify=False, headers=headers).text
         bill.add_source(url)
         vote_re = re.compile(
             r"YEAS -?\s?(\d+)(.*)NAYS -?\s?(\d+)"

--- a/scrapers/ut/bills.py
+++ b/scrapers/ut/bills.py
@@ -108,7 +108,9 @@ class UTBillScraper(Scraper, LXMLMixin):
         if len(bill_id) > 0:
             bill_id = bill_id[-1].text
         else:
-            raise Exception(f"Unexpected bill page content at {url}, truncated content {response.text[:500]}")
+            raise Exception(
+                f"Unexpected bill page content at {url}, truncated content {response.text[:500]}"
+            )
 
         (header,) = page.xpath(
             '//h3[@class="heading"]/text() | //h1[@class="heading"]/text()'
@@ -547,7 +549,9 @@ class UTBillScraper(Scraper, LXMLMixin):
 
         if len(descr) < 1:
             # neither element is present, might have an unexpected page response
-            raise Exception(f"Unexpected vote page content at {url}, truncated content {page_text[:500]}")
+            raise Exception(
+                f"Unexpected vote page content at {url}, truncated content {page_text[:500]}"
+            )
 
         if "on voice vote" in descr:
             return

--- a/scrapers/utils/lxmlize.py
+++ b/scrapers/utils/lxmlize.py
@@ -26,7 +26,7 @@ def url_xpath(url, path, verify=None, user_agent=None):
 class LXMLMixin(object):
     """Mixin for adding LXML helper functions to Open States code."""
 
-    def lxmlize(self, url, raise_exceptions=False, verify=None):
+    def lxmlize(self, url, raise_exceptions=False, verify=None, headers=None):
         """Parses document into an LXML object and makes links absolute.
 
         Args:
@@ -40,13 +40,13 @@ class LXMLMixin(object):
         try:
             # This class is always mixed into subclasses of `Scraper`,
             # which have a `get` method defined.
-            response = self.get(url, verify=verify)
+            response = self.get(url, verify=verify, headers=headers)
         except requests.exceptions.SSLError:
             self.warning(
                 "`self.lxmlize()` failed due to SSL error, trying "
                 "an unverified `self.get()` (i.e. `requests.get()`)"
             )
-            response = self.get(url, verify=False)
+            response = self.get(url, verify=False, headers=headers)
 
         if raise_exceptions:
             response.raise_for_status()


### PR DESCRIPTION
UT sent an email requesting the following:

> 1. Identify the client with a unique User-Agent string that includes a contact URL or email address.
> 2. Limit request rates to approximately one request per second from a given client, and avoid large concurrent connection pools across many source addresses.
> 3. Prefer static document resources (for example JSON and XML files) rather than issuing high volumes of requests to dynamically generated pages.

I believe we are already honoring 2 and 3. So this change honors 1.