### PR TITLE
NC: Events: Missing events and incorrect time

### DIFF
--- a/scrapers/nc/events.py
+++ b/scrapers/nc/events.py
@@ -65,21 +65,13 @@ class NCEventScraper(Scraper, LXMLMixin):
                         'span[contains(@class, "text-dark font-weight-bold")]/text()'
                     )[0].strip()
                     chamber = chamber.replace(":", "")
-                committee_links = event_row.xpath('a[contains(@href,"/Committees/")]')
-                is_committee = bool(committee_links)
-                if is_committee:
-                    com_link = committee_links[0]
-                    com_name = com_link.text_content().strip()
-                    com_name = f"{chamber} {com_name}".strip()
-                    com_url = com_link.xpath("@href")[0]
-                else:
-                    details_links = row.xpath('.//a[@title="Event details"]')
-                    if not details_links:
-                        continue
-                    com_link = details_links[0]
-                    com_name = event_row.text_content().strip()
-                    com_name = f"{chamber} {com_name}".strip()
-                    com_url = com_link.get("href")
+                if not event_row.xpath('a[contains(@href,"/Committees/")]'):
+                    continue
+
+                com_link = event_row.xpath('a[contains(@href,"/Committees/")]')[0]
+                com_name = com_link.text_content().strip()
+                com_name = f"{chamber} {com_name}".strip()
+                com_url = com_link.xpath("@href")[0]
 
                 where = (
                     row.xpath('div[contains(@class,"col-12 offset-sm-3")]')[0]

--- a/scrapers/nc/events.py
+++ b/scrapers/nc/events.py
@@ -39,9 +39,13 @@ class NCEventScraper(Scraper, LXMLMixin):
             for row in day_row.xpath('.//div[contains(@class, "cal-event row")]'):
                 status = "tentative"
                 # first cal-event-row sometimes contains full date, skip that
-                time = row.xpath(
-                    'div[contains(@class,"col-12 text-left col-sm-3 text-sm-right")]/text()'
-                )[0].strip()
+                time = (
+                    row.xpath(
+                        'div[contains(@class,"col-12 text-left col-sm-3 text-sm-right")]'
+                    )[0]
+                    .text_content()
+                    .strip()
+                )
 
                 event_row = row.xpath(
                     'div[contains(@class,"col-12 col-sm-9 col-md-12 ")]'
@@ -62,22 +66,32 @@ class NCEventScraper(Scraper, LXMLMixin):
                     )[0].strip()
                     chamber = chamber.replace(":", "")
 
-                # sometimes there are unlinked events, usually just press conferences
-                if not event_row.xpath('a[contains(@href,"/Committees/")]'):
-                    continue
-
-                com_link = event_row.xpath('a[contains(@href,"/Committees/")]')[0]
-                com_name = com_link.text_content().strip()
-                com_name = f"{chamber} {com_name}".strip()
-
-                com_url = com_link.xpath("@href")[0]
+                
+                committee_links = event_row.xpath('a[contains(@href,"/Committees/")]')
+                is_committee = bool(committee_links)
+                if is_committee:
+                    com_link = committee_links[0]
+                    com_name = com_link.text_content().strip()
+                    com_name = f"{chamber} {com_name}".strip()
+                    com_url = com_link.xpath("@href")[0]
+                else:
+                    details_links = row.xpath(
+                        './/a[@title="Event details"]'
+                    )
+                    if not details_links:
+                        continue
+                    com_link = details_links[0]
+                    com_name = event_row.text_content().strip()
+                    com_name = f"{chamber} {com_name}".strip()
+                    com_url = com_link.get("href")
 
                 where = (
                     row.xpath('div[contains(@class,"col-12 offset-sm-3")]')[0]
                     .text_content()
                     .strip()
                 )
-                where = where.replace("STREAM", "")
+                where = where.replace("STREAM", "").replace("Stream", "")
+                where = where.replace("Ended", "").strip()
 
                 when = f"{date} {time}"
                 try:
@@ -87,7 +101,7 @@ class NCEventScraper(Scraper, LXMLMixin):
                 except (ParserError, ValueError):
                     self.warning(f"Unable to parse {time}, only using day component")
                     when = dateutil.parser.parse(date)
-                    when = self._tz.localize(when).date()
+                    when = self._tz.localize(when)
 
                 if when < self._tz.localize(datetime.datetime.now()):
                     status = "passed"

--- a/scrapers/nc/events.py
+++ b/scrapers/nc/events.py
@@ -65,8 +65,6 @@ class NCEventScraper(Scraper, LXMLMixin):
                         'span[contains(@class, "text-dark font-weight-bold")]/text()'
                     )[0].strip()
                     chamber = chamber.replace(":", "")
-
-                
                 committee_links = event_row.xpath('a[contains(@href,"/Committees/")]')
                 is_committee = bool(committee_links)
                 if is_committee:
@@ -75,9 +73,7 @@ class NCEventScraper(Scraper, LXMLMixin):
                     com_name = f"{chamber} {com_name}".strip()
                     com_url = com_link.xpath("@href")[0]
                 else:
-                    details_links = row.xpath(
-                        './/a[@title="Event details"]'
-                    )
+                    details_links = row.xpath('.//a[@title="Event details"]')
                     if not details_links:
                         continue
                     com_link = details_links[0]


### PR DESCRIPTION
Time defaulting to midnight: Time extraction used /text() which returned empty when the time was wrapped in an <a> tag. This caused events to fall back to midnight. Switched to .text_content() to handle this.

Certain event types being dropped: The scraper only processed events with a /Committees/ link and skipped anything using an /LegislativeCalendarEvent/ "Event details" link. The current live month only had the latter type, resulting in zero scraped events. Added a fallback to handle these.

Badge text leaking into location: Strip logic was only catching "STREAM" (uppercase). The actual badge text is "Stream", and "Ended" badges were also slipping through. Fixed both.

Type mismatch in time parsing fallback: When time couldn't be parsed normally, the fallback returned a date-only value while the rest of the code worked with full date-and-time values. Fixed to ensure both paths return the same type.