### PR TITLE
NH: capture version links for bills carried over from prior session year

### DIFF
--- a/scrapers/nh/bills.py
+++ b/scrapers/nh/bills.py
@@ -104,6 +104,91 @@ class NHBillScraper(Scraper):
             except ValueError:
                 continue
 
+    def scrape_versions_from_docket(self, bill, lsr, session):
+        """
+        Fetch version/document links from the legacy bs2016 docket page.
+
+        Bills carried over from a prior session year keep that year's LSR
+        prefix (e.g. "25-0059" while being scraped as part of the "2026"
+        session) and so never appear in the current session's LsrsOnly.txt
+        bulk-data dump, leaving versions_by_lsr with no numeric billinfo.aspx
+        id for them. The docket page can be queried directly with just the
+        LSR + session year, so it works as a fallback in that case.
+        """
+        docket_url = f"https://gc.nh.gov/bill_status/legacy/bs2016/bill_docket.aspx?lsr={lsr}&sy={session}&sortoption=&txtsessionyear={session}"
+        docket_content = None
+        try_num = 1
+        tries = 3
+        # we have to be prepared to retry, because sometimes NH responds with a basically empty HTML response
+        # (contains only some inline Javascript snippet)
+        while try_num < tries and (
+            docket_content is None or "<head></head>" in docket_content
+        ):
+            if try_num > 1:
+                self.logger.info(f"Retrying fetch of docket page, try number {try_num}")
+            docket_content = self.get(
+                docket_url,
+                verify=False,
+                allow_redirects=True,
+                headers={
+                    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+                },
+            ).content.decode("utf-8")
+            try_num += 1
+
+        docket_page = lxml.html.fromstring(docket_content)
+        version_elems = docket_page.xpath(
+            "//table[@id='Table1']//a[contains(@href, 'billtext.aspx') or contains(@href, 'billText.aspx')]"
+        )
+        version_urls_seen = []
+        for version_elem in version_elems:
+            version_url = version_elem.attrib["href"]
+            if version_url in version_urls_seen:
+                # do not add duplicates
+                continue
+            else:
+                version_urls_seen.append(version_url)
+            version_text = version_elem.xpath(".//text()")[0]
+            if "txtFormat=html" in version_url:
+                # "normal" version (maybe always Introduced?)
+                bill.add_version_link(
+                    note=version_text,
+                    url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
+                    media_type="text/html",
+                )
+                pdf_version_url = version_url.replace("txtFormat=html", "txtFormat=pdf")
+                bill.add_version_link(
+                    note=version_text,
+                    url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{pdf_version_url}",
+                    media_type="application/pdf",
+                )
+            elif "txtFormat=amend" in version_url:
+                # Amendment version
+                # pretty sure this is always a PDF
+                bill.add_version_link(
+                    note=f"Amendment: {version_text}",
+                    url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
+                    media_type="application/pdf",
+                )
+            elif "v=HP" in version_url or "v=SP" in version_url:
+                # This is the House Passed or Senate Passed version
+                # pretty sure this is always HTML, but PDF is available
+                bill.add_version_link(
+                    note=version_text,
+                    url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
+                    media_type="text/html",
+                )
+                pdf_version_url = f"{version_url}&txtFormat=pdf"
+                bill.add_version_link(
+                    note=version_text,
+                    url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{pdf_version_url}",
+                    media_type="application/pdf",
+                )
+            else:
+                self.logger.warning(
+                    f"Found an unexpected version URL on {docket_url}, version URL: {version_url}"
+                )
+
     def scrape_sponsors_from_bill_page(self, bill, bill_page):
         """
         Parse sponsors from a NH bill status page (billinfo.aspx).
@@ -182,83 +267,7 @@ class NHBillScraper(Scraper):
             if lsr not in self.versions_by_lsr:
                 # Try to get the bill versions from the bill page
                 # since no version was found in the bulk data (for unknown reason)
-                docket_url = f"https://gc.nh.gov/bill_status/legacy/bs2016/bill_docket.aspx?lsr={lsr}&sy={session}&sortoption=&txtsessionyear={session}"
-                docket_content = None
-                try_num = 1
-                tries = 3
-                # we have to be prepared to retry, because sometimes NH responds with a basically empty HTML response
-                # (contains only some inline Javascript snippet)
-                while try_num < tries and (
-                    docket_content is None or "<head></head>" in docket_content
-                ):
-                    if try_num > 1:
-                        self.logger.info(
-                            f"Retrying fetch of docket page, try number {try_num}"
-                        )
-                    docket_content = self.get(
-                        docket_url,
-                        verify=False,
-                        allow_redirects=True,
-                        headers={
-                            "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-                        },
-                    ).content.decode("utf-8")
-                    try_num += 1
-
-                docket_page = lxml.html.fromstring(docket_content)
-                version_elems = docket_page.xpath(
-                    "//table[@id='Table1']//a[contains(@href, 'billtext.aspx') or contains(@href, 'billText.aspx')]"
-                )
-                version_urls_seen = []
-                for version_elem in version_elems:
-                    version_url = version_elem.attrib["href"]
-                    if version_url in version_urls_seen:
-                        # do not add duplicates
-                        continue
-                    else:
-                        version_urls_seen.append(version_url)
-                    version_text = version_elem.xpath(".//text()")[0]
-                    if "txtFormat=html" in version_url:
-                        # "normal" version (maybe always Introduced?)
-                        bills[lsr].add_version_link(
-                            note=version_text,
-                            url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
-                            media_type="text/html",
-                        )
-                        pdf_version_url = version_url.replace(
-                            "txtFormat=html", "txtFormat=pdf"
-                        )
-                        bills[lsr].add_version_link(
-                            note=version_text,
-                            url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{pdf_version_url}",
-                            media_type="application/pdf",
-                        )
-                    elif "txtFormat=amend" in version_url:
-                        # Amendment version
-                        # pretty sure this is always a PDF
-                        bills[lsr].add_version_link(
-                            note=f"Amendment: {version_text}",
-                            url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
-                            media_type="application/pdf",
-                        )
-                    elif "v=HP" in version_url or "v=SP" in version_url:
-                        # This is the House Passed or Senate Passed version
-                        # pretty sure this is always HTML, but PDF is available
-                        bills[lsr].add_version_link(
-                            note=version_text,
-                            url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{version_url}",
-                            media_type="text/html",
-                        )
-                        pdf_version_url = f"{version_url}&txtFormat=pdf"
-                        bills[lsr].add_version_link(
-                            note=version_text,
-                            url=f"https://gc.nh.gov/bill_status/legacy/bs2016/{pdf_version_url}",
-                            media_type="application/pdf",
-                        )
-                    else:
-                        self.logger.warning(
-                            f"Found an unexpected version URL on {docket_url}, version URL: {version_url}"
-                        )
+                self.scrape_versions_from_docket(bills[lsr], lsr, session)
 
             if lsr in self.versions_by_lsr:
                 version_id = self.versions_by_lsr[lsr]
@@ -456,6 +465,11 @@ class NHBillScraper(Scraper):
                         self.bills[lsr].add_source(
                             "https://gc.nh.gov/bill_Status/advanced.aspx"
                         )
+                        # Bill's LSR is missing from the bulk-data dump (e.g. a
+                        # carryover bill from a prior session year) — fall back
+                        # to the docket page, which can be queried by LSR + session
+                        # year directly, to still capture version/document links.
+                        self.scrape_versions_from_docket(self.bills[lsr], lsr, session)
 
         # load legislators
         self.legislators = {}


### PR DESCRIPTION
## Summary
- NH bills carried over from a prior session year (LSR keeps that year's prefix, e.g. `25-0059` while being scraped as part of session `2026`) never appear in NH's `LsrsOnly.txt` bulk-data dump for the current session, so `versions_by_lsr` had no id to build a `billinfo.aspx` page from — the scraper fell into a warn-only branch, leaving these bills with zero version/document links, including bills that became law (HB113, HB565, SB564, HB661, SB522, SB49, SB189, HB348 were the reported examples).
- `scrape_from_web` already had a working fallback for exactly this case: query the legacy docket page directly by LSR + session year (no numeric id required). Extracted that logic into `scrape_versions_from_docket` and wired it into the main bulk-data path's missing-id branch, instead of just logging a warning.
- This is a distinct failure mode from PR #3508 (which fixed a required time-based query param on GET requests) — that fix is intact and unrelated; this gap was simply never wired up in the primary bulk-data path.

## Verification
Reproduced against NH's live site: all 8 reported became_law examples had LSRs entirely absent from `LsrsOnly.txt` (or, for SB564/SB522, already had a version id but that's a separate/already-working path). Confirmed `bill_status/legacy/bs2016/bill_docket.aspx?lsr=<lsr>&sy=<session>` returns real version links for these bills directly.

Ran a full 2026-session scrape before and after the fix (same code otherwise):

| | bills | zero versions + zero documents |
|---|---|---|
| before | 1387 | 232 |
| after | 1387 | 1 (HR48 — genuinely has no text filed on NH's site) |

All 8 reported example bills have version links after the fix.

### Example: HB113

**Before** — `versions: []`, only the generic search-page source:
```json
{
  "identifier": "HB113",
  "versions": [],
  "documents": [],
  "sources": [
    { "url": "https://gc.nh.gov/bill_Status/advanced.aspx", "note": "" }
  ]
}
```

**After** — introduced, amendment, and engrossed versions all captured, each with HTML/PDF links:
```json
{
  "identifier": "HB113",
  "versions": [
    {
      "note": "Introduced",
      "links": [
        { "url": "https://gc.nh.gov/bill_status/legacy/bs2016/billText.aspx?sy=2026&v=HI&id=65&txtFormat=html", "media_type": "text/html" },
        { "url": "https://gc.nh.gov/bill_status/legacy/bs2016/billText.aspx?sy=2026&v=HI&id=65&txtFormat=pdf", "media_type": "application/pdf" }
      ]
    },
    {
      "note": "Amendment: #2026-0541h",
      "links": [
        { "url": "https://gc.nh.gov/bill_status/legacy/bs2016/billtext.aspx?sy=2026&txtFormat=amend&id=2026-0541H", "media_type": "application/pdf" }
      ]
    },
    {
      "note": "Ought to Pass",
      "links": [
        { "url": "https://gc.nh.gov/bill_status/legacy/bs2016/billText.aspx?sy=2026&v=SP&id=65", "media_type": "text/html" },
        { "url": "https://gc.nh.gov/bill_status/legacy/bs2016/billText.aspx?sy=2026&v=SP&id=65&txtFormat=pdf", "media_type": "application/pdf" }
      ]
    }
  ],
  "documents": [],
  "sources": [
    { "url": "https://gc.nh.gov/bill_Status/advanced.aspx", "note": "" }
  ]
}
```

### Before/after scrape output
Full NH 2026-session scrape output, before and after the fix:

- [`nh_before.zip`](https://github.com/user-attachments/files/31393082/nh_before.zip)
- [`nh_after.zip`](https://github.com/user-attachments/files/31393081/nh_after.zip)

## Test plan
- [x] `python3 -m py_compile scrapers/nh/bills.py`
- [x] Full NH 2026-session scrape run before and after the fix, compared bill counts and zero-version/document counts
- [x] Confirmed all 8 reported became_law example bills now have version links
