### PR TITLE
Data 5715/de missing bills fix

### DIFF
--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -355,6 +355,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         ).content
 
         page = json.loads(page)
@@ -381,6 +382,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         )
         page = self.decode_and_retry_request(
             "scrape_votes", request_method, retries=1, raise_exception=False
@@ -403,6 +405,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         )
         page = self.decode_and_retry_request(
             "scrape_vote", request_method, retries=1, raise_exception=False
@@ -509,6 +512,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         )
         page = self.decode_and_retry_request(
             "scrape_actions", request_method, raise_exception=False
@@ -641,6 +645,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         )
         page = self.decode_and_retry_request("scrape_amendments", request_method)
 
@@ -721,6 +726,7 @@ class DEBillScraper(Scraper, LXMLMixin):
             allow_redirects=True,
             verify=False,
             headers=self.headers,
+            timeout=self.timeout,
         )
         return response
 

--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -592,14 +592,27 @@ class DEBillScraper(Scraper, LXMLMixin):
                 status_date = self._parse_de_short_date(match.group(1))
                 description = status_text[: match.start()].strip()
                 if status_date and description:
-                    if "Senate" in description:
+                    # Status text is "{Chamber} {Committee Name}". Rewrite it to
+                    # match the categorizer's referral-committee rule.
+                    chamber_word = None
+                    if description.startswith("Senate"):
                         action_chamber = "upper"
-                    elif "House" in description:
+                        chamber_word = "Senate"
+                    elif description.startswith("House"):
                         action_chamber = "lower"
+                        chamber_word = "House"
                     elif "Governor" in description:
                         action_chamber = "executive"
                     else:
                         action_chamber = home_chamber
+
+                    if chamber_word:
+                        committee_name = description[len(chamber_word):].strip()
+                        if committee_name:
+                            description = (
+                                f"Assigned to {committee_name} "
+                                f"Committee in {chamber_word}"
+                            )
 
                     categorization = self.categorizer.categorize(description)
                     action = bill.add_action(

--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -607,7 +607,7 @@ class DEBillScraper(Scraper, LXMLMixin):
                         action_chamber = home_chamber
 
                     if chamber_word:
-                        committee_name = description[len(chamber_word):].strip()
+                        committee_name = description[len(chamber_word) :].strip()
                         if committee_name:
                             description = (
                                 f"Assigned to {committee_name} "

--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -291,12 +291,7 @@ class DEBillScraper(Scraper, LXMLMixin):
 
         self.scrape_actions(bill, row["LegislationId"])
 
-        # DE's actions API is sometimes empty even for bills that have clearly
-        # been introduced and referred to committee (see PR #5737 discussion).
-        # When that happens, fall back to the two data points that are still
-        # rendered on the bill detail HTML page: "Introduced on:" and "Status:".
-        # Doing this only when the API returned zero actions avoids duplicating
-        # anything the API already provided.
+        # Fall back to the bill detail HTML when the actions API is empty.
         if not bill.actions:
             self.scrape_fallback_actions_from_html(bill, html)
 
@@ -518,10 +513,6 @@ class DEBillScraper(Scraper, LXMLMixin):
         page = self.decode_and_retry_request(
             "scrape_actions", request_method, raise_exception=False
         )
-        # DE sometimes returns an empty body for a bill's actions (notably for
-        # very recently introduced bills). Treat that as "no actions yet" rather
-        # than a fatal failure, so the bill is still imported. Actions will
-        # backfill automatically once DE's endpoint returns data.
         if not page:
             self.warning(f"No actions returned for {bill.identifier}")
             return
@@ -559,22 +550,13 @@ class DEBillScraper(Scraper, LXMLMixin):
                 action.add_related_entity(c, "organization")
 
     def scrape_fallback_actions_from_html(self, bill, html):
-        """Add actions inferred from the bill detail HTML when the API is empty.
-
-        DE's ``GetRecentReportsByLegislationId`` endpoint occasionally returns
-        no rows for bills that have obviously been introduced and referred to a
-        committee. The bill detail page itself still shows this information
-        under the "Introduced on:" and "Status:" fields, so scrape those as a
-        fallback so users can at least see when the bill was introduced and
-        where it currently sits.
+        """Add actions from the bill detail HTML when the actions API is empty.
 
         Only called when ``scrape_actions()`` did not add anything.
         """
         home_chamber = "upper" if bill.identifier.startswith("S") else "lower"
 
         # "Introduced on: 6/30/26" -> description="Introduced", date=6/30/26
-        # Scope to class="info-label" so we don't accidentally pick up the
-        # hidden modal template on the page, which uses class="info-label-sm".
         introduced_values = html.xpath(
             '//label[@class="info-label" and '
             'starts-with(normalize-space(text()), "Introduced on")]'
@@ -593,8 +575,6 @@ class DEBillScraper(Scraper, LXMLMixin):
 
         # "Status: House Natural Resources & Energy 6/30/26"
         # -> description="House Natural Resources & Energy", date=6/30/26
-        # The status may not always end in a date (e.g. "In Committee"),
-        # in which case we skip it because Bill.add_action() requires a date.
         status_values = html.xpath(
             '//label[@class="info-label" and '
             'normalize-space(text())="Status:"]'
@@ -602,16 +582,12 @@ class DEBillScraper(Scraper, LXMLMixin):
         )
         if status_values:
             status_text = status_values[0].strip()
-            # Split off a trailing M/D/YY (or M/D/YYYY). We only need the last
-            # whitespace-separated token to be a date.
+            # Split off a trailing M/D/YY (or M/D/YYYY) date.
             match = re.search(r"\s+(\d{1,2}/\d{1,2}/\d{2,4})\s*$", status_text)
             if match:
                 status_date = self._parse_de_short_date(match.group(1))
                 description = status_text[: match.start()].strip()
                 if status_date and description:
-                    # Mirror the chamber-inference logic used in scrape_actions
-                    # so a status like "Senate Judiciary" is attributed to the
-                    # right chamber.
                     if "Senate" in description:
                         action_chamber = "upper"
                     elif "House" in description:

--- a/scrapers/de/bills.py
+++ b/scrapers/de/bills.py
@@ -4,6 +4,7 @@ import json
 from json.decoder import JSONDecodeError
 from requests.exceptions import JSONDecodeError as RequestsJSONDecodeError
 import random
+import re
 import time
 
 import requests
@@ -290,6 +291,15 @@ class DEBillScraper(Scraper, LXMLMixin):
 
         self.scrape_actions(bill, row["LegislationId"])
 
+        # DE's actions API is sometimes empty even for bills that have clearly
+        # been introduced and referred to committee (see PR #5737 discussion).
+        # When that happens, fall back to the two data points that are still
+        # rendered on the bill detail HTML page: "Introduced on:" and "Status:".
+        # Doing this only when the API returned zero actions avoids duplicating
+        # anything the API already provided.
+        if not bill.actions:
+            self.scrape_fallback_actions_from_html(bill, html)
+
         if row["HasAmendments"] is True:
             self.scrape_amendments(bill, row["LegislationId"])
 
@@ -547,6 +557,98 @@ class DEBillScraper(Scraper, LXMLMixin):
                 action.add_related_entity(leg, "person")
             for c in categorization["committees"]:
                 action.add_related_entity(c, "organization")
+
+    def scrape_fallback_actions_from_html(self, bill, html):
+        """Add actions inferred from the bill detail HTML when the API is empty.
+
+        DE's ``GetRecentReportsByLegislationId`` endpoint occasionally returns
+        no rows for bills that have obviously been introduced and referred to a
+        committee. The bill detail page itself still shows this information
+        under the "Introduced on:" and "Status:" fields, so scrape those as a
+        fallback so users can at least see when the bill was introduced and
+        where it currently sits.
+
+        Only called when ``scrape_actions()`` did not add anything.
+        """
+        home_chamber = "upper" if bill.identifier.startswith("S") else "lower"
+
+        # "Introduced on: 6/30/26" -> description="Introduced", date=6/30/26
+        # Scope to class="info-label" so we don't accidentally pick up the
+        # hidden modal template on the page, which uses class="info-label-sm".
+        introduced_values = html.xpath(
+            '//label[@class="info-label" and '
+            'starts-with(normalize-space(text()), "Introduced on")]'
+            "/following-sibling::div[1]/text()"
+        )
+        if introduced_values:
+            intro_text = introduced_values[0].strip()
+            intro_date = self._parse_de_short_date(intro_text)
+            if intro_date:
+                bill.add_action(
+                    description="Introduced",
+                    date=intro_date,
+                    chamber=home_chamber,
+                    classification=["introduction"],
+                )
+
+        # "Status: House Natural Resources & Energy 6/30/26"
+        # -> description="House Natural Resources & Energy", date=6/30/26
+        # The status may not always end in a date (e.g. "In Committee"),
+        # in which case we skip it because Bill.add_action() requires a date.
+        status_values = html.xpath(
+            '//label[@class="info-label" and '
+            'normalize-space(text())="Status:"]'
+            "/following-sibling::div[1]/text()"
+        )
+        if status_values:
+            status_text = status_values[0].strip()
+            # Split off a trailing M/D/YY (or M/D/YYYY). We only need the last
+            # whitespace-separated token to be a date.
+            match = re.search(r"\s+(\d{1,2}/\d{1,2}/\d{2,4})\s*$", status_text)
+            if match:
+                status_date = self._parse_de_short_date(match.group(1))
+                description = status_text[: match.start()].strip()
+                if status_date and description:
+                    # Mirror the chamber-inference logic used in scrape_actions
+                    # so a status like "Senate Judiciary" is attributed to the
+                    # right chamber.
+                    if "Senate" in description:
+                        action_chamber = "upper"
+                    elif "House" in description:
+                        action_chamber = "lower"
+                    elif "Governor" in description:
+                        action_chamber = "executive"
+                    else:
+                        action_chamber = home_chamber
+
+                    categorization = self.categorizer.categorize(description)
+                    action = bill.add_action(
+                        description=description,
+                        date=status_date,
+                        chamber=action_chamber,
+                        classification=categorization["classification"],
+                    )
+                    for leg in categorization["legislators"]:
+                        action.add_related_entity(leg, "person")
+                    for c in categorization["committees"]:
+                        action.add_related_entity(c, "organization")
+
+    def _parse_de_short_date(self, text):
+        """Parse DE's short date strings (e.g. "6/30/26") into YYYY-MM-DD.
+
+        Returns ``None`` if the string can't be parsed, so callers can skip
+        adding a malformed action rather than crashing the whole scrape.
+        """
+        text = (text or "").strip()
+        if not text:
+            return None
+        for fmt in ("%m/%d/%y", "%m/%d/%Y"):
+            try:
+                return dt.datetime.strptime(text, fmt).strftime("%Y-%m-%d")
+            except ValueError:
+                continue
+        self.warning(f"Could not parse DE fallback action date: {text!r}")
+        return None
 
     def scrape_amendments(self, bill, legislation_id):
         # http://legis.delaware.gov/json/BillDetail/GetRelatedAmendmentsByLegislationId?legislationId=47185


### PR DESCRIPTION
Some Delaware bills show no action history because the state's actions API returns no data for them, even though the bill detail page clearly shows an introduction date and current committee status. This change adds a fallback that pulls those data points from the bill detail page and records them as actions whenever the API comes back empty, ensuring users always see at least the bill's introduction and current status.

Output - 
[de_25_08_26.zip](https://github.com/user-attachments/files/314
Updated output - 
[de_26_08_26.zip](https://github.com/user-attachments/files/31479550/de_26_08_26.zip)
15606/de_25_08_26.zip)
