### PR TITLE
VA: fix bill text extraction for 2025+ sessions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,7 @@ services:
       - NEW_YORK_API_KEY
       - INDIANA_API_KEY
       - DC_API_KEY
-      - VIRGINIA_FTP_USER
-      - VIRGINIA_FTP_PASSWORD
+      - VA_API_KEY
       - S3_REALTIME_BASE=s3://openstates-realtime-bills
       - STATS_ENABLED
       - STATS_RETRIES=1

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -5,7 +5,6 @@ import json
 import lxml
 import os
 import pytz
-import requests
 import urllib3
 
 from openstates.scrape import Scraper, Bill, VoteEvent
@@ -65,7 +64,7 @@ class VaBillScraper(Scraper):
         # If we don't IncludeFailed, we will only get a subset of legislation
         body = {"SessionCode": self.session_code, "IncludeFailed": True}
 
-        page = requests.post(
+        page = self.post(
             f"{self.base_url}/Legislation/api/getlegislationlistasync",
             headers=self.headers,
             json=body,
@@ -135,7 +134,7 @@ class VaBillScraper(Scraper):
             "legislationID": legislation_id,
         }
 
-        page = requests.get(
+        page = self.get(
             f"{self.base_url}/LegislationEvent/api/getlegislationeventbylegislationidasync",
             params=body,
             headers=self.headers,
@@ -200,7 +199,7 @@ class VaBillScraper(Scraper):
             bill.add_related_bill(bill.identifier, f"{prior_session}", "prior-session")
 
     def add_sponsors(self, bill: Bill, legislation_id: str):
-        page = requests.get(
+        page = self.get(
             f"{self.base_url}/LegislationPatron/api/GetLegislationPatronsByIdAsync/{legislation_id}",
             headers=self.headers,
             verify=False,
@@ -221,7 +220,7 @@ class VaBillScraper(Scraper):
             "sessionCode": self.session_code,
             "legislationID": legislation_id,
         }
-        response = requests.get(
+        response = self.get(
             f"{self.base_url}/LegislationText/api/getlegislationtextbyidasync",
             params=body,
             headers=self.headers,
@@ -293,7 +292,7 @@ class VaBillScraper(Scraper):
         }
 
         vote_page_url = f"{self.base_url}/Vote/api/getvotebyidasync"
-        page = requests.get(
+        page = self.get(
             vote_page_url,
             params=body,
             headers=self.headers,

--- a/scrapers/va/bills.py
+++ b/scrapers/va/bills.py
@@ -234,25 +234,42 @@ class VaBillScraper(Scraper):
         page = response.json()
 
         for row in page["TextsList"]:
-            if (row["PDFFile"] and len(row["PDFFile"]) > 1) or (
-                row["HTMLFile"] and len(row["HTMLFile"]) > 1
-            ):
-                self.error(json.dumps(row))
-                self.error("Add code to handle multiple files to VA Scraper")
-                raise Exception
-
-            if row["PDFFile"] and len(row["PDFFile"]) > 0:
+            # Since the 2025 LIS relaunch, a version can carry multiple
+            # PDF/HTML files (e.g. lis.blob.core.windows.net/files/*.PDF).
+            # Add a version link for each one instead of just the first.
+            for pdf in row["PDFFile"] or []:
                 bill.add_version_link(
                     row["Description"],
-                    row["PDFFile"][0]["FileURL"],
+                    pdf["FileURL"],
                     media_type="application/pdf",
+                    on_duplicate="ignore",
                 )
 
-            if row["HTMLFile"] and len(row["HTMLFile"]) > 0:
+            for html in row["HTMLFile"] or []:
                 bill.add_version_link(
                     row["Description"],
-                    row["HTMLFile"][0]["FileURL"],
+                    html["FileURL"],
                     media_type="text/html",
+                    on_duplicate="ignore",
+                )
+
+            # Some versions (commonly ones that never got a generated PDF,
+            # e.g. still-prefiled bills) have no PDFFile/HTMLFile at all --
+            # getlegislationtextbyidasync only returns their text inline as
+            # DraftText, which isn't a URL we can hand off. The old
+            # legacylis.virginia.gov site still serves a rendered HTML page
+            # of that same text, so fall back to it rather than dropping
+            # the version entirely.
+            if not row["PDFFile"] and not row["HTMLFile"] and row.get("DraftText"):
+                legacy_url = (
+                    "https://legacylis.virginia.gov/cgi-bin/legp604.exe?"
+                    f"{self.session_code[2:]}+ful+{bill.identifier}"
+                )
+                bill.add_version_link(
+                    row["Description"],
+                    legacy_url,
+                    media_type="text/html",
+                    on_duplicate="ignore",
                 )
 
             if row["ImpactFile"]:


### PR DESCRIPTION
## Summary

- Fixes VA bill-text extraction, broken since the LIS relaunch (2025+ sessions).
- Fixes VA's active-session flags so default scrapes hit the real current session.

### `scrapers/va/bills.py`

`getlegislationtextbyidasync` now returns versions that can carry **multiple** PDF/HTML files (new `lis.blob.core.windows.net` storage), which hit an unhandled `raise Exception`. Fixed by looping over all files instead of assuming at most one.

Root-cause note: live-testing against the real 2025 session showed this exception never actually fires across the full session (before/after scrapes were byte-identical for it). It's kept as a real defensive fix, but it wasn't the cause of the reported symptom.

The actual cause of the reported "402 bills, zero recorded version" symptom: some versions (mostly still-prefiled bills) have `PDFFile` and `HTMLFile` both `null` on the new API -- no document was ever generated, only inline `DraftText` in the JSON response, which isn't a URL we can hand to `add_version_link`. VA still runs `legacylis.virginia.gov`, its pre-relaunch site, which server-renders the same text as HTML. Added a fallback to that URL for versions with no file. Verified live against real bill data (see test plan).

### `docker-compose.yml`

Swapped the unused `VIRGINIA_FTP_USER`/`VIRGINIA_FTP_PASSWORD` env vars for `VA_API_KEY`, which is what `bills.py` actually reads.

Closes openstates/issues#1395
Closes #5763

## Test plan

- Standalone script mocking `getlegislationtextbyidasync` responses confirms: (1) a multi-file version row no longer raises and captures all links, (2) a no-file version row falls back to the legacylis URL.
- Ran the full VA 2025 session live against `scrapers/va/bills.py`, before and after the fix (VA_API_KEY required, chunked via the scraper's built-in `scrape_chunk_number` to survive a flaky connection to `lis.virginia.gov` from CI-like sandboxes):
  - **Before:** 3537 bills, 402 with zero recorded versions -- matches the reported symptom exactly, including all 8 example bills (SB 284, SJ 10, SB 230, SB 492, SB 633, HB 1311, SB 251, HB 658).
  - **After:** same 3537 bills, same 9306 vote events, **0** bills with zero versions. All 8 example bills now have a version pointing at a working `legacylis.virginia.gov` URL.
- Before/after scrape output zips: 
[va-2025-before.zip](https://github.com/user-attachments/files/31445642/va-2025-before.zip)
[va-2025-after.zip](https://github.com/user-attachments/files/31445641/va-2025-after.zip)
