### PR TITLE
MO: fix vote result string comparison bug

### DIFF
--- a/scrapers/mo/bills.py
+++ b/scrapers/mo/bills.py
@@ -535,7 +535,7 @@ class MOBillScraper(Scraper, LXMLMixin):
                 vote = VoteEvent(
                     chamber=actor,
                     motion_text=action_title,
-                    result="pass" if rc_yes > rc_no else "fail",
+                    result="pass" if int(rc_yes or 0) > int(rc_no or 0) else "fail",
                     classification="passage",
                     start_date=TIMEZONE.localize(action_date),
                     bill=bill,


### PR DESCRIPTION
## Summary
- `parse_house_actions` in `scrapers/mo/bills.py` compared `rc_yes`/`rc_no` as raw strings pulled from XML `text()`, not ints, so `result` was decided by lexicographic string comparison (`"112" < "20"`) instead of numeric comparison.
- This produced wrong `result="fail"` on House VoteEvents with a clearly passing tally, e.g. `AYES: 112 NOES: 20` -> `fail`, non-deterministically depending on digit count/leading digit of the two numbers.
- Fix: cast both to `int` (defaulting missing/empty values to 0) before comparing.

## Verification
Ran a full MO bills+votes scrape against this fix (`os-update mo bills --scrape`): 3139 bills, 1477 vote_events.
- 1474 vote_events with an AYES/NOES tally now resolve `result="pass"` where ayes > noes.
- The only 3 `result="fail"` cases left are genuine defeats (e.g. `AYES: 55 NOES: 95` -> fail, `AYES: 2 NOES: 131` -> fail).

## Backfill note
This bug is order-dependent on the string values, not a fixed misclassification, so historical `result` values can't be filtered after the fact — a backfill/reprocess of stored `motion_text` (re-parsing `AYES: N NOES: M`) or a rescrape is warranted for existing MO House VoteEvent rows.

## Test plan
- [x] Full MO scrape run locally with the fix; spot-checked AYES/NOES vs result on all vote_event JSON output.

Zip file of full scrape with fix: [mo_full_scrape.zip](https://github.com/user-attachments/files/31488867/mo_full_scrape.zip)
