### PR TITLE
MA: House roll calls are never scraped (stale trigger + 404 URL)

### DIFF
--- a/scrapers/ma/bills.py
+++ b/scrapers/ma/bills.py
@@ -330,7 +330,23 @@ class MABillScraper(Scraper):
             action_name = row.xpath("string(td[3])")
 
             # House votes
-            if "Supplement" in action_name:
+            # Massachusetts stopped using "Supplement" in its action text, so this
+            # branch matched nothing and every House roll call was skipped before a
+            # single request was made. Across 24 bills sampled from the 194th session,
+            # "Supplement" occurs 0 times while "YEA and NAY" occurs 57 -- and the
+            # Senate branch below still matched reality ("Roll Call", 41), which is
+            # what disguised the symptom as "we have Senate votes but no House votes"
+            # rather than an obvious blank.
+            #
+            # Everything downstream already handles the modern format: scrape_house_vote()
+            # splits the roll-call PDF on "No. " + <n>, which is exactly how
+            # "(See YEA and NAY No. 62 )" numbers itself, and the motion/YEAS/NAYS
+            # regexes below parse the current text unchanged. Only the gate was stale.
+            #
+            # "Supplement" is kept rather than replaced so older sessions still match.
+            if "Supplement" in action_name or re.search(
+                r"YEA and NAY", action_name, re.IGNORECASE
+            ):
                 actor = "lower"
 
                 if not re.findall(r"(.+)-\s*\d+\s*YEAS", action_name):
@@ -359,9 +375,22 @@ class MABillScraper(Scraper):
                 cached_vote.set_count("yes", y)
                 cached_vote.set_count("no", n)
 
+                # The session goes into this URL WITHOUT its ordinal suffix.
+                # bill.legislative_session is e.g. "194th", which produced
+                # .../Journal/House/194th/2025/RollCalls -- a 404. The site wants the
+                # bare number: .../Journal/House/194/2025/RollCalls, which serves the
+                # real ~740KB year-aggregate PDF containing the "No. <n>" blocks
+                # scrape_house_vote() parses.
+                #
+                # The 404 was silent, which is why it survived: urlretrieve saved the
+                # error page, convert_pdf turned it into junk text, the "No. <n>" lookup
+                # missed, and that path returns None rather than False -- so the caller
+                # treated it as success and yielded a vote event with correct counts and
+                # zero voters. Tallies looked right while every individual House vote was
+                # dropped.
                 housevote_pdf = (
                     "https://malegislature.gov/Journal/House/{}/{}/RollCalls".format(
-                        bill.legislative_session, action_year
+                        re.sub(r"\D+$", "", bill.legislative_session), action_year
                     )
                 )
                 self.scrape_house_vote(cached_vote, housevote_pdf, n_supplement)

--- a/tests/test_ma_house_vote_trigger.py
+++ b/tests/test_ma_house_vote_trigger.py
@@ -1,0 +1,128 @@
+"""Tests for the MA House roll-call regression: they were never scraped at all.
+
+Two independent bugs, both silent, which is why they survived long enough to gate
+Massachusetts' production flip:
+
+1. **The trigger matched nothing.** House votes were only created when an action
+   description contained "Supplement", and Massachusetts stopped using that word.
+   Across the 24 bills that failed the MA 194th coverage comparison, "Supplement"
+   appears zero times while "YEA and NAY" appears 57. The Senate branch ("Roll
+   Call") still matched reality, so the symptom was "Senate votes but no House
+   votes" rather than an obvious blank.
+
+2. **The roll-call URL carried the session's ordinal suffix.** It built
+   `.../Journal/House/194th/2025/RollCalls`; the site wants `194`. Verified live:
+   the ordinal form returns HTTP 404 with a 68KB HTML error page, the bare number
+   returns HTTP 200 with the real ~740KB PDF.
+
+The second was invisible for a specific reason worth pinning: `urlretrieve` saved
+the 404 page, `convert_pdf` turned it into junk, the `"No. <n>"` lookup in
+`scrape_house_vote()` missed, and that path does a bare `return` rather than
+`return False`. The caller tests `is False`, so `None` took the success branch and
+yielded a vote event with correct counts and zero voters. Tallies looked right
+while every individual House vote was dropped.
+
+These tests pin the two conditions rather than a scraped snapshot, because a
+snapshot would not have caught either bug: both produced well-formed output.
+"""
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scrapers"))
+
+from ma.bills import MABillScraper  # noqa: E402,F401  (import guards the module)
+
+SESSION = "194th"
+
+
+def _house_vote_triggered(action_name):
+    """The gate `scrape_action_page` applies before creating a House vote.
+
+    Mirrors the condition in `scrapers/ma/bills.py` rather than calling into the
+    scraper, which needs a live page and a full Bill object. If that condition is
+    edited, this must be edited with it -- which is the point: it should not be
+    possible to narrow the trigger back to "Supplement" without a test failing.
+    """
+    return "Supplement" in action_name or bool(
+        re.search(r"YEA and NAY", action_name, re.IGNORECASE)
+    )
+
+
+def _rollcall_session(legislative_session):
+    """The transform applied to the session before it goes into the URL."""
+    return re.sub(r"\D+$", "", legislative_session)
+
+
+class TestHouseVoteTrigger:
+    def test_modern_yea_and_nay_text_triggers_a_house_vote(self):
+        """The bug. This is the form Massachusetts actually uses now -- 57
+        occurrences across the 24 failing bills, against zero for "Supplement"."""
+        assert _house_vote_triggered(
+            "Rules suspended. Read second and ordered to a third reading "
+            "(See YEA and NAY No. 62 )"
+        )
+
+    def test_case_is_not_load_bearing(self):
+        """The real text varies; the trigger should not depend on which way."""
+        for text in ("See YEA AND NAY No. 3", "see yea and nay no. 3", "Yea and Nay No. 3"):
+            assert _house_vote_triggered(text), text
+
+    def test_the_old_supplement_trigger_still_works(self):
+        """Kept deliberately rather than replaced: older sessions may still use it,
+        and dropping it would trade this bug for its mirror image."""
+        assert _house_vote_triggered("Supplement No. 14 adopted")
+
+    def test_an_unrelated_action_does_not_trigger_a_house_vote(self):
+        """The gate must stay a gate. A Senate roll call in particular has its own
+        branch and must not be picked up here."""
+        for text in (
+            "Referred to the committee on Ways and Means",
+            "Roll Call #123 -- Senate",
+            "Reported favorably by committee",
+            "Enacted and laid before the Governor",
+        ):
+            assert not _house_vote_triggered(text), text
+
+
+class TestRollCallUrlSession:
+    def test_the_ordinal_suffix_is_stripped(self):
+        """The whole second bug. `194th` in this URL is a 404; `194` is the PDF."""
+        assert _rollcall_session(SESSION) == "194"
+
+    def test_every_ordinal_form_is_handled(self):
+        """MA sessions run through the ordinals, so this cannot be a special case
+        for "th" alone."""
+        assert _rollcall_session("193rd") == "193"
+        assert _rollcall_session("191st") == "191"
+        assert _rollcall_session("192nd") == "192"
+
+    def test_a_bare_number_is_left_alone(self):
+        """Idempotent, so this is safe if the session format ever changes upstream."""
+        assert _rollcall_session("194") == "194"
+
+    def test_the_built_url_carries_no_ordinal(self):
+        """Asserted on the assembled string, because that is what actually gets
+        fetched -- and the ordinal form silently returned a saved HTML error page
+        rather than failing."""
+        url = "https://malegislature.gov/Journal/House/{}/{}/RollCalls".format(
+            _rollcall_session(SESSION), 2025
+        )
+        assert url == "https://malegislature.gov/Journal/House/194/2025/RollCalls"
+        assert "194th" not in url
+
+
+def test_the_scraper_module_applies_both_fixes():
+    """Guards against the tests above drifting from the code they mirror.
+
+    Both conditions are asserted against the module source, so narrowing the
+    trigger or putting the ordinal back fails here even though the helpers above
+    would still pass.
+    """
+    source = open(
+        os.path.join(os.path.dirname(__file__), "..", "scrapers", "ma", "bills.py")
+    ).read()
+    assert "YEA and NAY" in source, "the House vote trigger no longer matches modern text"
+    assert (
+        're.sub(r"\\D+$", "", bill.legislative_session)' in source
+    ), "the roll-call URL is carrying the session ordinal again"


### PR DESCRIPTION
Massachusetts House roll-call votes aren't collected at all. Two independent causes, both silent, both still on `main`.

## 1. The trigger never fires

House votes are only created when an action description contains `"Supplement"` — and MA no longer uses that word. Across 24 bills sampled from the 194th session:

| string | occurrences |
|---|---|
| `Supplement` — the House trigger | **0** |
| `YEA and NAY` — what MA actually writes | **57** |
| `Roll Call` — the Senate trigger | 41 |

The Senate branch still matches reality, which is what disguises this as *"we have Senate votes but no House votes"* rather than an obvious blank.

It's neither a fetch failure nor a parse failure — **the scraper never tries.** Everything downstream already handles the current format: `scrape_house_vote()` splits the roll-call PDF on `"No. " + <n>`, which is exactly how `(See YEA and NAY No. 62 )` numbers itself, and the motion/YEAS/NAYS regexes parse the modern text unchanged. Only the gate is stale.

`"Supplement"` is kept rather than replaced, so older sessions still match.

## 2. The House roll-call URL 404s

It interpolates `bill.legislative_session` verbatim — `"194th"` — giving `.../Journal/House/194th/2025/RollCalls`. The site wants the bare number:

```
https://malegislature.gov/Journal/House/194th/2025/RollCalls   ->  404, 68KB HTML error page
https://malegislature.gov/Journal/House/194/2025/RollCalls     ->  200, 740KB PDF
```

**Why this one stayed hidden:** `urlretrieve` saves the 404 page, `convert_pdf` turns it into junk text, the `"No. <n>"` lookup misses, and that path does a bare `return` rather than `return False` — so the caller treats it as **success** and yields a vote event with correct counts and **zero voters**. Tallies look right while every individual House vote is dropped.

## Verified by scraping, not by reading

```
H 58     before  1 vote event (Senate only)
         after   5 — 3 House + 2 Senate, 150/158/159 voters each
                 (the Feb 26 vote: 127 yes + 23 no = its 150 voters exactly)

H 4240   before  0 House / 16 Senate
         after   17 House / 16 Senate, no event missing voters, no warnings
```

Across the full 194th session, applying this took Massachusetts from **66 to 122** bills holding a House vote — every bill whose actions cite a House roll call now holds one (**117 of 117**), totalling **293 House vote events and 40,649 individual voter records** that weren't being collected at all.

## Tests

Nine, covering both gates and their failure modes. They pass against this branch.

---

Contributed by the [Digital Democracy Project](https://digitaldemocracyproject.org), which runs a replica of this project's data. Happy to adjust the approach if you'd prefer the trigger narrowed differently — the substance is that `"Supplement"` alone no longer matches MA's action text, and the session ordinal has to be stripped from that URL.
