### PR TITLE
NJ: fix duplicate vote events and doubled vote rolls

### DIFF
--- a/scrapers/nj/bills.py
+++ b/scrapers/nj/bills.py
@@ -394,6 +394,9 @@ class NJBillScraper(Scraper, MDBMixin):
         ]
         # keep votes clean globally, a few votes show up in multiple files
         votes = {}
+        # track (vote_id, leg) pairs already recorded so a legislator's vote
+        # isn't re-appended if the same vote_id recurs in a later file
+        recorded_votes = set()
 
         for filename in vote_info_list:
             s_vote_url = f"https://pub.njleg.state.nj.us/votes/{filename}.zip"
@@ -469,40 +472,43 @@ class NJBillScraper(Scraper, MDBMixin):
                                 bill=bill_dict[bill_id],
                             )
                             votes[vote_id].dedupe_key = vote_id
-                        if leg_vote == "Y":
-                            votes[vote_id].vote("yes", leg)
-                        elif leg_vote == "N":
-                            votes[vote_id].vote("no", leg)
-                        else:
-                            votes[vote_id].vote("other", leg)
+                        leg_key = (vote_id, leg)
+                        if leg_key not in recorded_votes:
+                            recorded_votes.add(leg_key)
+                            if leg_vote == "Y":
+                                votes[vote_id].vote("yes", leg)
+                            elif leg_vote == "N":
+                                votes[vote_id].vote("no", leg)
+                            else:
+                                votes[vote_id].vote("other", leg)
 
             # remove temp file
             os.remove(s_vote_zip)
 
-            # Counts yes/no/other votes and saves overall vote
-            for vote in votes.values():
-                counts = collections.defaultdict(int)
-                for count in vote.votes:
-                    counts[count["option"]] += 1
-                vote.set_count("yes", counts["yes"])
-                vote.set_count("no", counts["no"])
-                vote.set_count("other", counts["other"])
+        # Counts yes/no/other votes and saves overall vote
+        for vote in votes.values():
+            counts = collections.defaultdict(int)
+            for count in vote.votes:
+                counts[count["option"]] += 1
+            vote.set_count("yes", counts["yes"])
+            vote.set_count("no", counts["no"])
+            vote.set_count("other", counts["other"])
 
-                # Veto override.
-                if vote.motion_text == "OVERRIDE":
-                    # Per the NJ leg's glossary, a veto override requires
-                    # 2/3ds of each chamber. 27 in the senate, 54 in the house.
-                    # http://www.njleg.state.nj.us/legislativepub/glossary.asp
-                    if "lower" in vote.bill:
-                        vote.result = "pass" if counts["yes"] >= 54 else "fail"
-                    elif "upper" in vote.bill:
-                        vote.result = "pass" if counts["yes"] >= 27 else "fail"
-                else:
-                    # Regular vote.
-                    vote.result = "pass" if counts["yes"] > counts["no"] else "fail"
+            # Veto override.
+            if vote.motion_text == "OVERRIDE":
+                # Per the NJ leg's glossary, a veto override requires
+                # 2/3ds of each chamber. 27 in the senate, 54 in the house.
+                # http://www.njleg.state.nj.us/legislativepub/glossary.asp
+                if "lower" in vote.bill:
+                    vote.result = "pass" if counts["yes"] >= 54 else "fail"
+                elif "upper" in vote.bill:
+                    vote.result = "pass" if counts["yes"] >= 27 else "fail"
+            else:
+                # Regular vote.
+                vote.result = "pass" if counts["yes"] > counts["no"] else "fail"
 
-                vote.add_source("https://www.njleg.state.nj.us/downloads.asp")
-                yield vote
+            vote.add_source("https://www.njleg.state.nj.us/downloads.asp")
+            yield vote
 
         # Actions
         bill_action_csv = self.to_csv("BILLHIST.TXT")


### PR DESCRIPTION
## Summary

`scrapers/nj/bills.py`'s vote-scraping block (around lines 385-505) had two bugs:

1. The same legislator could be voted twice on the same `vote_id` if that `vote_id` recurred across a session's vote-info files (the base `.txt` and its companion `End.txt`, or other files in `vote_info_list`), since `vote_id` has no date component and `.vote()` was called unconditionally.
2. The `for vote in votes.values(): ... yield vote` block that counts and yields each `VoteEvent` was nested *inside* the outer `for filename in vote_info_list:` loop instead of after it, so every already-yielded VoteEvent got re-yielded again on each later filename iteration — producing literal duplicate vote-event records.

## Fix

- Moved the count/yield block to run once, after the outer `for filename` loop completes.
- Added a `recorded_votes` set of `(vote_id, leg)` pairs to guard `.vote()` calls against re-recording the same legislator's vote on the same vote_id.

Fixes #5778

## Verification

Ran a full real scrape of NJ session 221 (2024-2025 Regular Session) with the fix applied:

```
poetry run os-update nj bills session=221 --scrape --fastmode
```

Result: 12074 bills, 5235 vote events. Post-scrape check of every vote_event JSON output confirmed:
- 0 vote events with a voter appearing more than once (doubled roll)
- 0 dedupe_keys yielded more than once (duplicate vote-event records)

Verification scrape output (all `_data/nj` JSON from that run) is attached here as a release asset:
https://github.com/alexkost819/openstates-scrapers/releases/download/nj-vote-fix-verify-a023dbe58/nj-vote-fix-verification.zip

## Test plan

- [x] Full real scrape of NJ session 221 exercising the vote-scraping path
- [x] Verified no doubled rolls and no duplicate vote-event records in output JSON

Done with Claude Code