### PR TITLE
CO: restore vote count reporting lost in scraper rewrite

### DIFF
--- a/scrapers/co/bills.py
+++ b/scrapers/co/bills.py
@@ -345,6 +345,9 @@ class COBillScraper(Scraper, LXMLMixin):
                 bill=bill,
                 classification="passage",
             )
+            vote.set_count("yes", ct_yes)
+            vote.set_count("no", ct_no)
+            vote.set_count("other", ct_other)
 
             votes_url = row.xpath("td[5]/span/a/@href")[0]
             votes_page = self.get(votes_url, headers=HEADERS).content


### PR DESCRIPTION
## Summary

The CO bill scraper (`scrapers/co/bills.py`) parses `ct_yes`/`ct_no`/`ct_other` from the chamber vote-summary row but never calls `vote.set_count(...)`, so every CO `VoteEvent` currently ships an empty `counts` array. This was lost in the Nov 2025 scraper rewrite (5b5bf40f8, #5502) — the pre-rewrite scraper did call `vote.set_count(...)` for each category.

This PR adds the missing calls right after the vote object is built, using the same `yes`/`no`/`other` labels already used elsewhere in the file for `vote.vote(...)`.

Fixes #5780

## Verification

Ran a live scrape of `co bills` for the 2025A session and confirmed vote events now have populated, non-empty `counts` arrays that match the itemized roll (yes/no counts match exactly; `other` shows the same small header-vs-roll mismatch already documented as a known, unrelated CO data issue).

Verification output (scraped JSON, before/after comparable): https://github.com/alexkost819/openstates-scrapers/releases/download/co-vote-fix-verify-1ccbcb1/co-vote-fix-verification.zip

## Test plan
- [x] Ran `os-update co bills session=2025A --scrape --fastmode` against the fix
- [x] Confirmed `vote_event_*.json` output files have non-empty `counts` arrays
- [x] Confirmed `yes`/`no` counts match the itemized roll counts

Done with Claude Code