### PR TITLE
HI: fix vote-parsing bugs that create fake voter records

### DIFF
--- a/scrapers/hi/bills.py
+++ b/scrapers/hi/bills.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import logging
 import lxml.html
 import re
 from openstates.scrape import Scraper, Bill, VoteEvent
@@ -68,6 +69,17 @@ def create_bill_report_url(chamber, year, bill_type):
     )
 
 
+logger = logging.getLogger(__name__)
+
+# A voter-name token that's really just a middle initial (e.g. "C." in
+# "Lee, C.") stranded by the blind ", ".split() below.
+MIDDLE_INITIAL_RE = re.compile(r"^[A-Z]\.?$")
+# A "Senator(s)"/"Representative(s)" role-prefix with no name attached,
+# including the garbled/truncated form missing the closing paren
+# (e.g. "Senator(s" with no name and no ")").
+PLACEHOLDER_VOTER_RE = re.compile(r"^(Senator|Representative)\(s\)?$", re.IGNORECASE)
+
+
 def split_specific_votes(voters):
     if voters is None or voters.startswith("none") or voters == "":
         return []
@@ -75,8 +87,31 @@ def split_specific_votes(voters):
         voters = voters.replace("Senator(s) ", "")
     elif voters.startswith("Representative(s)"):
         voters = voters.replace("Representative(s)", "")
+    elif voters.startswith("Senator(s"):
+        # malformed/truncated source data, e.g. "Senator(s" with no name and
+        # no closing paren -- nothing usable to parse out
+        voters = voters[len("Senator(s") :]
+    elif voters.startswith("Representative(s"):
+        voters = voters[len("Representative(s") :]
+
     # Remove trailing spaces and semicolons
-    return (v.rstrip(" ;") for v in voters.split(", "))
+    tokens = [v.rstrip(" ;") for v in voters.split(", ")]
+
+    # Re-merge middle-initial fragments (e.g. "Lee", "C." -> "Lee, C.") that
+    # the blind ", ".split() above breaks apart, and drop any leftover
+    # unparseable role placeholders instead of treating them as voters.
+    merged = []
+    for token in tokens:
+        token = token.strip()
+        if not token:
+            continue
+        if MIDDLE_INITIAL_RE.match(token) and merged:
+            merged[-1] = f"{merged[-1]}, {token}"
+        elif PLACEHOLDER_VOTER_RE.match(token):
+            logger.warning("Dropping unparseable placeholder voter name: %r", token)
+        else:
+            merged.append(token)
+    return merged
 
 
 class HIBillScraper(Scraper):


### PR DESCRIPTION
## Summary

`split_specific_votes()` in `scrapers/hi/bills.py` blindly splits comma-joined voter-name strings on `", "`, which mangles two real source-data shapes and creates fake voter records:

- **Middle-initial split (#5782):** Hawaii disambiguates legislators sharing a surname with a trailing initial, e.g. `"Lee, C."`. The blind split breaks this into `"Lee"` and `"C."`, recording the initial as its own fake voter. Confirmed live against 2025/2026 session data (`"...Kim, Lee, C., Wakai..."`).
- **Garbled placeholder leak (#5783):** the code only strips a `"Senator(s)"`/`"Representative(s)"` prefix on an exact match (closing paren required). When the source field is itself malformed — literally `"Senator(s"` with no name and no closing paren — nothing strips it, so the garbled residual leaks through as a fake voter name.

## Fix

Post-process the `", "`-split tokens:
- Re-merge a bare-initial fragment (`^[A-Z]\.?$`) back onto the immediately preceding token as `"Surname, Initial."`.
- Drop any token matching the unparseable placeholder pattern (`^(Senator|Representative)\(s\)?$`, case-insensitive) instead of recording it as a voter, logging a warning.

## Verification

Ran a real `os-update` scrape of the HI `bills` scraper against the 2026 session (live `data.capitol.hawaii.gov` data). Output: 11 bills, 24 vote events, 63 distinct voter names — `"Lee, C"` and `"Lee, M"` are correctly merged as single voters, and no bare-initial fragments or `"Senator(s"`/`"Representative(s"`-style placeholders appear as `voter_name`. Verification output zipped and attached to a release: https://github.com/alexkost819/openstates-scrapers/releases/download/hi-vote-fix-verify-bee046ddd/hi-vote-fix-verification.zip

Fixes #5782
Fixes #5783

## Test plan
- [x] Unit-level assertions on `split_specific_votes()` covering both bugs and existing well-formed cases
- [x] Live `os-update --scrape` run against HI bills, 2026 session, output inspected for absence of both defects

Done with Claude Code