### PR TITLE
IL: replace hardcoded vote-dupe allowlist with general per-bill dedup

### DIFF
--- a/scrapers/il/bills.py
+++ b/scrapers/il/bills.py
@@ -251,11 +251,6 @@ COMMITTEE_CORRECTIONS = {
     "Community College Access & Affordability": "Community College Access & Afford.",
 }
 
-DUPE_VOTES = {
-    f"{BASE_URL}/legislation/votehistory/100/house/committeevotes/"
-    "10000HB2457_16401.pdf"
-}
-
 
 def group(lst, n):
     # from http://code.activestate.com/recipes/303060-group-a-list-into-sequential-n-tuples/
@@ -677,9 +672,12 @@ class IlBillScraper(Scraper):
         doc = lxml.html.fromstring(html)
         doc.make_links_absolute(votes_url)
 
+        seen_votes = set()
         for link in doc.xpath('//a[contains(@href, "votehistory")]'):
-            if link.get("href") in DUPE_VOTES:
+            href = link.get("href")
+            if href in seen_votes:
                 continue
+            seen_votes.add(href)
 
             pieces = link.text.split(" - ")
             date = pieces[-1]

--- a/scrapers/il/tests/test_scrape_votes_dedup.py
+++ b/scrapers/il/tests/test_scrape_votes_dedup.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest import mock
+
+from il.bills import IlBillScraper
+
+
+DUPE_HTML = """
+<html><body><table><tr>
+<td>Third Reading</td>
+<td>
+  <a href="/legislation/votehistory/104/house/thirdreading/10400HB0001_1.pdf">HB1 - May 1, 2025</a>
+  <a href="/legislation/votehistory/104/house/thirdreading/10400HB0001_1.pdf">HB1 - May 1, 2025</a>
+</td>
+<td>HOUSE</td>
+</tr></table></body></html>
+"""
+
+
+class TestScrapeVotesDedup(unittest.TestCase):
+    def test_duplicate_vote_link_scraped_once(self):
+        scraper = IlBillScraper.__new__(IlBillScraper)
+        scraper.get = mock.Mock(return_value=mock.Mock(text=DUPE_HTML))
+        scraper.scrape_pdf_for_votes = mock.Mock(return_value=None)
+
+        list(
+            scraper.scrape_votes("104th", mock.Mock(), "http://example.com/votehistory")
+        )
+
+        # the vote-history page lists the same href twice; scrape_votes must
+        # only act on it once, without relying on a hardcoded allowlist.
+        self.assertEqual(scraper.scrape_pdf_for_votes.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

IL's `bills.py` had a `DUPE_VOTES` set of hardcoded hrefs to skip because the state's vote-history page sometimes lists the same vote link twice. This only caught previously manually-discovered cases, so any new recurring duplicate link produced a literal duplicate vote-event record (see `KNOWN_DATA_ISSUES.md`).

- Replaces `DUPE_VOTES` with a `seen_votes` set scoped to each `scrape_votes()` call, matching the pattern already used in `scrapers/wi/bills.py`.
- Any href already processed for the current bill is skipped, regardless of whether it's a previously-known offender.
- Adds `scrapers/il/tests/test_scrape_votes_dedup.py`, a synthetic reproduction proving the guard skips a genuine duplicate href without relying on an allowlist.

Fixes #5787

## Verification

Ran a real scrape (`os-update il bills session=104th chamber=lower --fastmode`), scoped to the lower chamber and stopped early after ~250 bills for practicality (a full-chamber scrape is impractically slow in this environment). Result: 112 vote-event records produced, all with distinct source hrefs — no duplicate vote-event records. Full scrape output and log: https://github.com/alexkost819/openstates-scrapers/releases/download/il-vote-fix-verify-7ea024349/il-vote-fix-verification.zip

## Test plan

- [x] `pytest scrapers/il/tests/test_scrape_votes_dedup.py` passes
- [x] Real IL scrape run; verified no duplicate vote-event records in output

Done with Claude Code