### PR TITLE
MA: include not-voting total in declared vote counts

### DIFF
--- a/scrapers/ma/votes.py
+++ b/scrapers/ma/votes.py
@@ -487,6 +487,7 @@ class HouseVoteRecordParser:
 
         vote.set_count("yes", self.total_yea)
         vote.set_count("no", self.total_nay)
+        vote.set_count("not voting", self.total_nv)
 
         vote_dictionary = {
             "Y": "yes",


### PR DESCRIPTION
## Summary

`HouseVoteRecordParser` in `scrapers/ma/votes.py` already parses the House journal's declared not-voting total (e.g. `7 N/V`) into `self.total_nv`, but `createVoteEvent()` never applied it via `vote.set_count()` — only yes/no counts were set. Meanwhile individual not-voting legislators are itemized in the roll as `"not voting"`. Result: the declared `counts` on the VoteEvent always showed 0 for not-voting even when the itemized roll had several.

Fix is a one-line addition:

```python
vote.set_count("not voting", self.total_nv)
```

using the same `"not voting"` label the roll parsing already uses, so the declared count and itemized roll stay consistent.

Fixes #5791

## Verification

Ran a full live scrape of MA votes for the 194th (current) session: `os-update ma votes session=194th --scrape`. Result: 323 vote events scraped; 212 have not-voting members; declared not-voting counts matched the itemized roll count in all 212 cases (0 mismatches).

Verification output (scraped JSON) is attached here: https://github.com/alexkost819/openstates-scrapers/releases/download/ma-vote-fix-verify-bcf2c8745/ma-vote-fix-verification.zip

Done with Claude Code