### PR TITLE
OK: fix vote-roll name parsing to stop dropping/glomming voters

### DIFF
--- a/scrapers/ok/bills.py
+++ b/scrapers/ok/bills.py
@@ -12,6 +12,34 @@ from urllib import parse
 from openstates.scrape import Scraper, Bill, VoteEvent as Vote
 from .actions import Categorizer
 
+# Matches one legislator name in a vote roll line: a word, optionally
+# followed by a parenthetical disambiguator ("West (T)"), or the special
+# "Mr. Speaker" entry (which spans two words).
+NAME_RE = re.compile(r"Mr\.\s+Speaker|[A-Za-z][\w'\-]*(?:\s+\([^)]+\))?")
+
+
+def extract_names(line, limit):
+    """Extract up to `limit` legislator names from a vote-roll line.
+
+    Names are rendered with single spaces between them (Word's
+    mso-spacerun columns collapse to one space each once lxml pulls
+    string()), so a fixed-width split is unreliable -- tokenize on name
+    shape instead. Stopping at `limit` (the declared count for this vote
+    type, read from the same block) keeps trailing free text -- e.g. a
+    "STRIKE THE TITLE - ADOPTED" outcome line that sometimes follows a
+    zero-count section before the "*****" separator -- from being
+    mistaken for votes.
+    """
+    names = []
+    for match in NAME_RE.finditer(line.replace("\n", " ")):
+        if len(names) >= limit:
+            break
+        name = match.group(0).strip()
+        if not name or "HOUSE" in name or "SENATE" in name:
+            continue
+        names.append(name)
+    return names
+
 
 class OKBillScraper(Scraper):
     verify = False
@@ -423,7 +451,7 @@ class OKBillScraper(Scraper):
                 if "*****" in line or "motion by" in line:
                     break
                 regex = (
-                    r"(YEAS|AYES|NAYS|EXCUSED|VACANT|CONSTITUTIONAL "
+                    r"(YEAS|AYES|NAYS|EXCUSED|VACANT|VACANCY|CONSTITUTIONAL "
                     r"PRIVILEGE|NOT VOTING|N/V)\s*:\s*(\d+)(.*)"
                 )
                 match = re.match(regex, line)
@@ -437,7 +465,7 @@ class OKBillScraper(Scraper):
                         vtype = "excused"
                     elif match.group(1) in ["NOT VOTING", "N/V"] and seen_yes:
                         vtype = "not voting"
-                    elif match.group(1) == "VACANT":
+                    elif match.group(1) in ["VACANT", "VACANCY"]:
                         continue  # skip these
                     elif seen_yes:
                         vtype = "other"
@@ -446,12 +474,9 @@ class OKBillScraper(Scraper):
                         bad_vote = True
                     counts[vtype] += int(match.group(2))
                 elif seen_yes:
-                    for name in line.split("   "):
-                        if not name:
-                            continue
-                        if "HOUSE" in name or "SENATE " in name:
-                            continue
-                        votes[vtype].append(name.strip())
+                    remaining = counts[vtype] - len(votes[vtype])
+                    if remaining > 0:
+                        votes[vtype].extend(extract_names(line, remaining))
 
             if bad_vote:
                 continue

--- a/scrapers/ok/tests/test_vote_name_parsing.py
+++ b/scrapers/ok/tests/test_vote_name_parsing.py
@@ -1,0 +1,65 @@
+"""
+Regression test for the OK vote-roll name tokenizer.
+
+Real OK vote pages render names separated by single spaces (Word's
+mso-spacerun columns collapse to one space each once lxml pulls string()),
+not the 3-space runs the old `line.split("   ")` heuristic assumed. That
+heuristic silently glommed whole lines of 4 names into a single garbage
+"name", producing itemized counts far below the declared count.
+`extract_names` fixes this by tokenizing on name shape instead of
+whitespace width, and by stopping at the declared count so trailing free
+text (e.g. "STRIKE THE TITLE - ADOPTED" after a zero-count section) never
+gets mistaken for a vote.
+"""
+
+from ..bills import NAME_RE, extract_names
+
+
+def test_plain_names():
+    assert NAME_RE.findall("Baker Bashore Bennett Blancett") == [
+        "Baker",
+        "Bashore",
+        "Bennett",
+        "Blancett",
+    ]
+
+
+def test_parenthetical_disambiguator_stays_attached():
+    line = "Caldwell (C) Humphrey Pae Turner"
+    assert NAME_RE.findall(line) == ["Caldwell (C)", "Humphrey", "Pae", "Turner"]
+
+
+def test_mr_speaker_is_one_token():
+    line = "Dobrinski Martinez Sims Mr. Speaker"
+    assert NAME_RE.findall(line) == ["Dobrinski", "Martinez", "Sims", "Mr. Speaker"]
+
+
+def test_apostrophe_and_hyphen_names():
+    line = "O'Donnell Alonso-Sandoval"
+    assert NAME_RE.findall(line) == ["O'Donnell", "Alonso-Sandoval"]
+
+
+def test_extract_names_stops_at_declared_limit():
+    # Real example: a zero-count "CONSTITUTIONAL PRIVILEGE" section is
+    # sometimes followed by trailing outcome text before the "*****"
+    # separator. A declared limit of 0 must yield zero fake "votes".
+    assert extract_names("STRIKE THE TITLE - ADOPTED", 0) == []
+
+
+def test_extract_names_caps_at_limit_not_line_contents():
+    # If a line has more name-shaped tokens than the declared count still
+    # needs, only take what's left -- this is what keeps a stray extra
+    # entry (e.g. "Mr. Speaker" voting without being in the declared
+    # total) from inflating the itemized count past what's expected.
+    line = "Dobrinski Martinez Sims Mr. Speaker"
+    assert extract_names(line, 3) == ["Dobrinski", "Martinez", "Sims"]
+
+
+if __name__ == "__main__":
+    test_plain_names()
+    test_parenthetical_disambiguator_stays_attached()
+    test_mr_speaker_is_one_token()
+    test_apostrophe_and_hyphen_names()
+    test_extract_names_stops_at_declared_limit()
+    test_extract_names_caps_at_limit_not_line_contents()
+    print("ok")


### PR DESCRIPTION
## Summary

`scrapers/ok/bills.py`'s vote-roll parser itemized each YEAS/NAYS/etc. roll
by splitting the printed name line on three spaces (`line.split("   ")`),
assuming fixed-width columns. Real OK vote pages are a Word HTML export
where each inter-name gap is a single literal space once `lxml`'s
`string()` pulls the text out -- so that heuristic didn't split at all: it
glomped each printed line (typically 4 names) into one garbage "name"
string, itemizing far fewer voters than the declared count on the same
page.

Fixes #5793, which has a full write-up including a real before/after JSON
example from a live 2025 session vote page.

## Fix

- Replace the whitespace-split with `NAME_RE`, a regex tokenizer matching
  name shape (plain names, parenthetical disambiguators like `"West (T)"`,
  and the two-word `"Mr. Speaker"` entry).
- New `extract_names(line, limit)` helper stops once it has pulled as many
  names as the declared count for that vote type -- this also prevents
  trailing outcome text (e.g. `"STRIKE THE TITLE - ADOPTED"` after a
  zero-count section) from being misparsed as votes.
- Recognize `"VACANCY"` alongside the existing `"VACANT"` header line,
  which previously fell through to name-tokenization instead of being
  skipped as a count line.
- Added `scrapers/ok/tests/test_vote_name_parsing.py` covering the
  tokenizer and the count-driven capping behavior.

## Verification

Ran the exact parsing logic (old heuristic vs. new) against real
2025-2026 session vote pages fetched live from oklegislature.gov (HB1001,
HB1002, HB1003, HB1005, HB1007, HB1008 -- House and Senate). Across 29
sampled recorded-vote blocks, itemized-vs-declared count mismatches
dropped from 57 (old) to 0 (new).

Full verification (raw fetched HTML, reproduction script, and the
before/after JSON report) is attached as a release asset:
https://github.com/alexkost819/openstates-scrapers/releases/download/ok-vote-fix-verify-4ff4c0df6/ok-vote-fix-verification.zip

Note: a full end-to-end `os-update ok bills --scrape` run is currently
blocked by an unrelated, pre-existing site issue -- oklegislature.gov's
bill-search listing returns bill-detail links as `http://` URLs, and the
site now 404s on plain HTTP for that host/path (confirmed via direct
curl: `http://` -> 404, `https://` -> 200 for the same path). Verification
above instead exercises the exact same parsing code path against real
vote-page HTML fetched directly over HTTPS.

## Test plan

- [x] `pytest scrapers/ok/tests/test_vote_name_parsing.py` passes (6/6)
- [x] `flake8` / `black --check` clean on changed files
- [x] Parsing logic verified against 29 real vote blocks from live
      2025-2026 session data (see release asset above)

Done with Claude Code