### PR TITLE
TX: fix garbled voter names and duplicate vote events

### DIFF
--- a/scrapers/tx/votes.py
+++ b/scrapers/tx/votes.py
@@ -95,8 +95,15 @@ def names(el):
     text = (el.text or "") + (el.tail or "")
     split_name_list = text.split(";")
     if len(split_name_list) < 7:
-        # probably failed to properly split on semi-colons; try commas:
-        split_name_list = text.split(",")
+        # probably failed to properly split on semi-colons; try commas.
+        # But TX names legitimately use a comma to disambiguate shared
+        # surnames, e.g. "Davis, A." or "Lopez, J." -- don't split those
+        # apart. Only skip a comma when it's immediately followed by a
+        # lone initial that ends the name (semicolon or end of string);
+        # if a capitalized word follows the initial instead (senate lists
+        # disambiguate with a *leading* initial, e.g. "Hancock, A.
+        # Hinojosa, J. Hinojosa, Huffman"), the comma is a real separator.
+        split_name_list = re.split(r",(?!\s*[A-Z]\.(?:;|$))", text)
 
     names = []
     for name in split_name_list:
@@ -112,7 +119,11 @@ def names(el):
             for n in names_still_with_semicolon:
                 n = n.strip().replace(".", "")
                 if " — " in n:
-                    n = n.split()[-1]
+                    # Take everything after the label (e.g. "Absent —"),
+                    # not just the last whitespace token -- a comma-initial
+                    # name like "Jones, V" has a space in it and would
+                    # otherwise get shredded down to just "V".
+                    n = n.split(" — ")[-1]
                 names.append(n)
         else:
             names.append(name)
@@ -120,8 +131,11 @@ def names(el):
     if names:
         # First item in the list will have stuff to ignore before an mdash
         names[0] = clean_starting_name(names[0]).strip()
-        # Get rid of trailing '.'
-        names[-1] = names[-1][0:-1]
+        # Get rid of trailing '.', if there is one -- don't blindly chop
+        # the last character, or a real trailing character (e.g. the "l"
+        # in "Virdell") gets truncated.
+        if names[-1].endswith("."):
+            names[-1] = names[-1][:-1]
 
     return names
 
@@ -142,14 +156,28 @@ def clean_starting_name(name):
     return re.split(r"[\u2014:]", name)[-1]
 
 
+def paragraph_key(el):
+    """A stable identity for a journal paragraph, used to make sure the
+    four vote scanners below (whose trigger conditions aren't mutually
+    exclusive -- e.g. a paragraph can contain both "yeas"-style text and
+    a trailing "(N - N - N)" tally) don't each turn the same paragraph
+    into its own VoteEvent."""
+    return " ".join(el.text_content().split())
+
+
 def votes(root, session, chamber):
-    for vote in record_votes_with_yeas(root, session, chamber):
+    # Shared across all four scanners so a paragraph already claimed by
+    # an earlier one is skipped by the rest.
+    claimed_paragraphs = set()
+    for vote in record_votes_with_yeas(root, session, chamber, claimed_paragraphs):
         yield vote
-    for vote in viva_voce_votes(root, session, chamber):
+    for vote in viva_voce_votes(root, session, chamber, claimed_paragraphs):
         yield vote
-    for vote in record_votes_with_short_count_notation(root, session, chamber):
+    for vote in record_votes_with_short_count_notation(
+        root, session, chamber, claimed_paragraphs
+    ):
         yield vote
-    for vote in local_calendar_votes(root, session, chamber):
+    for vote in local_calendar_votes(root, session, chamber, claimed_paragraphs):
         yield vote
 
 
@@ -473,7 +501,7 @@ short_count_notation_regex = re.compile(
 )
 
 
-def record_votes_with_short_count_notation(root, session, chamber):
+def record_votes_with_short_count_notation(root, session, chamber, claimed_paragraphs):
     # votes with short vote count notation may look like:
     # SB 422 (Cook, Patterson, and Thimesch - no) (135 - 3 - 1)
     # or
@@ -495,6 +523,10 @@ def record_votes_with_short_count_notation(root, session, chamber):
         if not mv.is_valid:
             continue
 
+        key = paragraph_key(mv.el)
+        if key in claimed_paragraphs:
+            continue
+
         if mv.passed:
             motion_text = "passage"
         else:
@@ -510,6 +542,7 @@ def record_votes_with_short_count_notation(root, session, chamber):
             bill=mv.bill_id,
             bill_chamber=mv.chamber,
         )
+        claimed_paragraphs.add(key)
 
         v.set_count("yes", mv.counts["yeas"] or 0)
         v.set_count("no", mv.counts["nays"] or 0)
@@ -523,7 +556,7 @@ def record_votes_with_short_count_notation(root, session, chamber):
         yield v
 
 
-def local_calendar_votes(root, session, chamber):
+def local_calendar_votes(root, session, chamber, claimed_paragraphs):
     # The senate's Local & Uncontested Calendar lists each bill with a
     # terse per-bill vote entry in the journal, e.g.:
     #   SB 2474 (Hinojosa)
@@ -534,6 +567,10 @@ def local_calendar_votes(root, session, chamber):
     for el in root.xpath('//div[@class = "textpara"]'):
         text = " ".join(el.text_content().split())
         if not LOCAL_CALENDAR_VOTE_REGEX.match(text):
+            continue
+
+        key = paragraph_key(el)
+        if key in claimed_paragraphs:
             continue
 
         # The bill is the "SB 2474 (Author)" line a couple of elements
@@ -555,6 +592,7 @@ def local_calendar_votes(root, session, chamber):
         if bill_id is None:
             continue
         bill_chamber = {"H": "lower", "S": "upper"}.get(bill_id[0])
+        claimed_paragraphs.add(key)
 
         count_groups = LOCAL_CALENDAR_COUNTS_REGEX.findall(text)
         for i, (yeas, nays, trailing) in enumerate(count_groups):
@@ -589,7 +627,7 @@ def local_calendar_votes(root, session, chamber):
             yield v
 
 
-def record_votes_with_yeas(root, session, chamber):
+def record_votes_with_yeas(root, session, chamber, claimed_paragraphs):
     # votes with "yeas" may look like:
     # SB 186 was passed by (Record 2040): 122 Yeas, 17 Nays, 1 Present, not voting.
     # or
@@ -606,6 +644,10 @@ def record_votes_with_yeas(root, session, chamber):
 
     for mv in maybe_votes:
         if not mv.is_valid:
+            continue
+
+        key = paragraph_key(mv.el)
+        if key in claimed_paragraphs:
             continue
 
         if mv.motion_text:
@@ -625,6 +667,7 @@ def record_votes_with_yeas(root, session, chamber):
             bill=mv.bill_id,
             bill_chamber=mv.chamber,
         )
+        claimed_paragraphs.add(key)
 
         v.set_count("yes", mv.yeas or 0)
         v.set_count("no", mv.nays or 0)
@@ -653,12 +696,16 @@ def clean_vote_name(name):
     return name
 
 
-def viva_voce_votes(root, session, chamber):
+def viva_voce_votes(root, session, chamber, claimed_paragraphs):
     vote_elements = root.xpath('//div[starts-with(., "All Members are deemed")]')
     maybe_votes = [MaybeViva(el) for el in vote_elements]
 
     for mv in maybe_votes:
         if not mv.is_valid:
+            continue
+
+        key = paragraph_key(mv.el)
+        if key in claimed_paragraphs:
             continue
 
         if mv.motion_text:
@@ -678,6 +725,7 @@ def viva_voce_votes(root, session, chamber):
             bill=mv.bill_id,
             bill_chamber=mv.chamber,
         )
+        claimed_paragraphs.add(key)
 
         v.set_count("yes", 0)
         v.set_count("no", 0)
@@ -888,3 +936,82 @@ class TXVoteScraper(Scraper):
             return None
 
         return session_instance["start_date"]
+
+
+def _self_check():
+    """Small assert-based smoke test for the two bugs fixed here:
+    - names() shredding a "Surname, Initial." token via the comma-fallback
+      split, and blindly chopping the last character of the last name.
+    - overlapping vote-paragraph scanners yielding the same paragraph's
+      vote twice.
+    Run directly: `python scrapers/tx/votes.py`
+    """
+
+    class FakeEl:
+        def __init__(self, text):
+            self.text = text
+            self.tail = None
+
+        def text_content(self):
+            return self.text
+
+    # Bug A: "Davis, A." must survive intact, and "Simmons" must not be
+    # truncated even though the comma-fallback used to fire (only 4
+    # semicolon-separated parts here, well under the len(...) < 7 trigger).
+    assert names(FakeEl("Absent — Bowers; Davis, A.; Dean; Simmons.")) == [
+        "Bowers",
+        "Davis, A",
+        "Dean",
+        "Simmons",
+    ]
+    # A name with no trailing period must not lose its last character.
+    assert names(FakeEl("Present, not voting — Mr. Speaker; Virdell.")) == [
+        "Present",
+        "Mr Speaker",
+        "Virdell",
+    ]
+
+    # A comma-disambiguated name buried right after an em-dash label must
+    # not get shredded down to its bare initial by the "take the last
+    # word after the em-dash" heuristic.
+    assert names(FakeEl("Absent — Jones, V.; Lambert; Smithee.")) == [
+        "Jones, V",
+        "Lambert",
+        "Smithee",
+    ]
+
+    # Senate lists disambiguate with a *leading* initial and separate
+    # names with commas (no semicolons at all) -- these commas are real
+    # separators and must still be split on.
+    assert names(FakeEl("Hancock, A. Hinojosa, J. Hinojosa, Huffman.")) == [
+        "Hancock",
+        "A. Hinojosa",
+        "J. Hinojosa",
+        "Huffman",
+    ]
+
+    # Bug B: a paragraph satisfying both the "yeas" scanner's trigger and
+    # the short-count-notation scanner's trigger must only be claimed once.
+    html = (
+        "<html><body>"
+        '<div class="textpara">Filler paragraph.</div>'
+        '<div class="textpara">HOUSE BILL 1 ON THIRD READING</div>'
+        '<div class="textpara">HB 1 was passed by (Record 1): '
+        "100 Yeas, 0 Nays, 0 Present, not voting. (100 - 0 - 0)</div>"
+        '<div class="textpara">Trailing filler paragraph.</div>'
+        "</body></html>"
+    )
+    root = lxml.html.fromstring(html)
+    claimed = set()
+    yeas_votes = list(record_votes_with_yeas(root, "89R", "lower", claimed))
+    short_count_votes = list(
+        record_votes_with_short_count_notation(root, "89R", "lower", claimed)
+    )
+    assert len(yeas_votes) == 1
+    assert len(short_count_votes) == 0, "second scanner should skip claimed paragraph"
+
+    print("tx/votes.py self-check OK")
+
+
+if __name__ == "__main__":
+    _self_check()


### PR DESCRIPTION
## Summary

- `names()` shredded TX's `"Surname, Initial."` names on short voter lists (`"Morales, C."` -> `"Morales"` + `"C"`), via a naive `text.split(",")` fallback and an `"Absent — "` label strip that grabbed the last whitespace token.
- `names()` also chopped the last character off the last name in every list, whether or not it was a trailing period: `"Paul"` -> `"Pau"`, `"Schofield"` -> `"Schofiel"`, `"Vasut(C)"` -> `"Vasut(C"`. All 213 vote events on 89R House day 65 had at least one garbled name.
- The four vote-paragraph scanners chained in `votes()` have non-mutually-exclusive triggers and can turn one paragraph into several `VoteEvent`s; they now share a set of claimed paragraphs, keyed by document position (journal boilerplate text repeats verbatim across bills, so text is not a usable key).

Fixes #5795. Fixes #5797.

## Bug example

SB 2052, 89R, passage (2025-05-15), House day 65 journal:

```json
{
  "counts": [
    { "option": "yes", "value": 139 },
    { "option": "no", "value": 2 },
    { "option": "not voting", "value": 2 }
  ],
  "votes": [
    { "option": "no", "voter_name": "Morales" },
    { "option": "no", "voter_name": "C" },
    { "option": "not voting", "voter_name": "Speaker" },
    { "option": "not voting", "voter_name": "Vasut(C" },
    { "option": "absent", "voter_name": "Pau" },
    { "option": "absent", "voter_name": "Coo" }
  ]
}
```

## Resolution example

Same vote in the after scrape:

```json
{
  "counts": [
    { "option": "yes", "value": 139 },
    { "option": "no", "value": 2 },
    { "option": "not voting", "value": 2 }
  ],
  "votes": [
    { "option": "no", "voter_name": "Morales, C" },
    { "option": "not voting", "voter_name": "Mr Speaker" },
    { "option": "not voting", "voter_name": "Vasut(C)" },
    { "option": "absent", "voter_name": "Paul" },
    { "option": "absent", "voter_name": "Cook" }
  ]
}
```

## Scrapes

Before and after: https://github.com/alexkost819/openstates-scrapers/releases/tag/scrape-tx-after (`tx-before.zip` / `tx-after.zip`), both from `89RDAY65FINAL.HTM` (House, `chamber=lower url_match=89RDAY65FINAL`) and `89RSJ05-15-F.HTM` (Senate, `chamber=upper url_match=05-15`), 89R.

Diff over the matched vote events:
- House: 213 vote events before and after, all 213 with voter-row changes -- 801 voter rows removed, 731 added.
- Recurring repairs: `Speaker` -> `Mr Speaker` (164), `Schofiel` -> `Schofield` (99), `Vasut(C` -> `Vasut(C)` (83), `Pau` -> `Paul` (79), `Harris(C` -> `Harris(C)` (61), `Virdel` -> `Virdell` (23), plus the comma-initial names (`Davis, A`, `Jones, V`, `Lopez, R`, `Morales, C`) that were split in two.
- Senate: 62 vote events before and after, no rows changed. No vote events added or removed in either chamber -- the paragraph-claiming change is a latent-correctness guard.
