### PR TITLE
MN: re-enable Senate vote extraction in bills.py

### DIFF
--- a/scrapers/mn/bills.py
+++ b/scrapers/mn/bills.py
@@ -590,15 +590,24 @@ class MNBillScraper(Scraper, LXMLMixin):
             elif len(page_links) > 0:
                 pages.append(page_links[0])
 
-            # TODO: add votes back in once not broken
             # Try to extract vote
             # senate vote only, house votes are scraped by the vote_event.py scraper
-            # if current_chamber == "upper":
-            #     vote = self.extract_vote_from_action(
-            #         bill, bill_action, current_chamber, row, pages
-            #     )
-            #     if vote:
-            #         votes.append(vote)
+            if current_chamber == "upper":
+                try:
+                    vote = self.extract_vote_from_action(
+                        bill, bill_action, current_chamber, row, pages
+                    )
+                except Exception as e:
+                    # Senate journal vote links/pages are occasionally malformed
+                    # or point at content that doesn't parse as expected. Don't let
+                    # one bad vote link take down the whole bill scrape for it.
+                    self.warning(
+                        f"{bill.identifier}: failed to extract Senate vote from "
+                        f"action {bill_action['action_text']!r}: {e}"
+                    )
+                    vote = None
+                if vote:
+                    votes.append(vote)
 
         return bill_actions, votes
 
@@ -820,7 +829,7 @@ class MNBillScraper(Scraper, LXMLMixin):
                         f"No vote url in the page. trying to use the previous vote url: {vote_url}"
                     )
                     if not vote_url:
-                        return [None] * 2
+                        return None
                 else:
                     vote_url = vote_element.xpath(".//a[@href]/@href")[0]
 


### PR DESCRIPTION
## Summary

MN Senate floor votes haven't been scraped since Feb 2024 (PR #4838 / commit b991c3595 disabled the only call site of `extract_vote_from_action` in `scrapers/mn/bills.py` after "bad vote links" were crashing the whole bill scrape, with a `# TODO: add votes back in once not broken` left in place). `scrapers/mn/vote_events.py` only ever covered the House, so the Senate side has produced zero `VoteEvent`s the entire time.

I re-tested `extract_vote_from_action` directly against the live revisor.mn.gov/senate.mn site for several enacted 2025-2026 bills (SF202, SF856, SF1075, SF1251) and the parsing logic itself works correctly against the current site markup — the "bad vote links" failure mode from 2024 no longer reproduces with today's page structure. So the fix here is:

- Re-enable the Senate-only call to `extract_vote_from_action` in `process_actions_table`.
- Wrap that call in `try/except`, logging a warning and skipping just that one vote on failure, so a single malformed/unexpected vote link can never again take down the whole bill scrape (this is the actual root-cause fix for the original failure mode, not just "uncomment and hope").
- Fix a latent bug in the no-page-link fallback path: it returned `[None] * 2` instead of `None` when no page URL could be resolved, which the caller's `if vote:` check would have treated as a truthy (bogus) vote object.

## Why this fix, not a rewrite

`extract_vote_from_action` already does the hard part correctly (resolves the Senate journal page via `senate.mn`'s API, downloads and parses the journal PDF with PyMuPDF, extracts yes/no roll calls) — I verified it end-to-end against six real votes this session including a failed 19-45 floor motion with a missing page link (the `pages[-1]` fallback path). Nothing here needed a rewrite; the dedicated House scraper (`vote_events.py`) is untouched and there's no overlap risk since it's chamber-gated to the House only.

## Verification

Ran the real `MNBillScraper.scrape()` for Senate bills (2025-2026 session, bill numbers 1-300) with the fix applied. Confirmed multiple real `VoteEvent`s now come through with correct chamber/date/counts/roll-call data, no exceptions, and no overlap with House votes (produced by a completely separate, chamber-gated scraper).

Full scrape output and additional per-bill verification: https://github.com/alexkost819/openstates-scrapers/releases/download/mn-vote-fix-verify-6d38286c6/mn-vote-fix-verification.zip

Fixes #5801

Done with Claude Code
