### PR TITLE
TX Events scraper fix for ScrapeValueError

### DIFF
--- a/scrapers/tx/events.py
+++ b/scrapers/tx/events.py
@@ -136,7 +136,12 @@ class TXEventScraper(Scraper, LXMLMixin):
             for span in p_element.xpath(xpath):
                 text = " ".join("".join(span.itertext()).split())
                 if text and text not in results:
-                    agenda_text = text.rstrip(" :")
+                    results.append(text)
+                    agenda_text = text.rstrip(" :-").strip()
+                    # Skip empty agenda descriptions, which fail schema
+                    # validation (agenda description requires minLength 1)
+                    if not agenda_text:
+                        continue
                     agenda = event.add_agenda_item(agenda_text)
 
                     siblings = [p_element] + p_element.xpath("following-sibling::p")


### PR DESCRIPTION
**Summary:** TX events scraper fails validation on empty agenda item descriptions
**Description:**
The TX events scraper was raising ScrapeValueError: '' is too short when an agenda item's text consisted only of punctuation (e.g. ":", "-"). After rstrip(" :"), these became empty strings, which fail the openstates schema's minLength: 1 requirement on agenda[].description and abort the whole scrape.
**Fix:** Skip agenda items whose description is empty after stripping trailing punctuation/whitespace, and fix the dedup check so repeated agenda text is properly filtered.
**Output -** 
[tx_Sept02.zip](https://github.com/user-attachments/files/31766793/tx_Sept02.zip)

